### PR TITLE
fix: CSV has wrong file extension

### DIFF
--- a/backend/app/api/handlers/v1/v1_ctrl_reporting.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_reporting.go
@@ -24,7 +24,7 @@ func (ctrl *V1Controller) HandleBillOfMaterialsExport() errchain.HandlerFunc {
 			return err
 		}
 
-		w.Header().Set("Content-Type", "text/tsv")
+		w.Header().Set("Content-Type", "text/csv")
 		w.Header().Set("Content-Disposition", "attachment; filename=bill-of-materials.csv")
 		_, err = w.Write(csv)
 		return err

--- a/backend/app/api/handlers/v1/v1_ctrl_reporting.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_reporting.go
@@ -3,8 +3,8 @@ package v1
 import (
 	"net/http"
 
-	"github.com/hay-kot/homebox/backend/internal/core/services"
-	"github.com/hay-kot/httpkit/errchain"
+	"github.com/sysadminsmedia/homebox/backend/internal/core/services"
+	"github.com/sysadminsmedia/httpkit/errchain"
 )
 
 // HandleBillOfMaterialsExport godoc
@@ -25,7 +25,7 @@ func (ctrl *V1Controller) HandleBillOfMaterialsExport() errchain.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "text/tsv")
-		w.Header().Set("Content-Disposition", "attachment; filename=bill-of-materials.tsv")
+		w.Header().Set("Content-Disposition", "attachment; filename=bill-of-materials.csv")
 		_, err = w.Write(csv)
 		return err
 	}


### PR DESCRIPTION
Amend BOM export to CSV

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?
- bug

## What this PR does / why we need it:

Fixes https://github.com/sysadminsmedia/homebox/issues/3
WIP to remediate TSV issue, and to format as CSV instead

## Which issue(s) this PR fixes:
Fixes #3 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated export filename from `bill-of-materials.tsv` to `bill-of-materials.csv` to ensure correct file type for downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->