### PR TITLE
fix(frontend): stat card title

### DIFF
--- a/frontend/components/global/StatCard/StatCard.vue
+++ b/frontend/components/global/StatCard/StatCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="stats bg-neutral shadow rounded-md">
     <div class="stat text-neutral-content text-center space-y-1 p-3">
-      <div class="homebox-stat-title">{{ title }}</div>
+      <div class="stat-title">{{ title }}</div>
       <div class="stat-value text-2xl">
         <Currency v-if="type === 'currency'" :amount="value" />
         <template v-if="type === 'number'">{{ value }}</template>
@@ -26,3 +26,9 @@
     subtitle: undefined,
   });
 </script>
+
+<style>
+  [data-theme="homebox"] .stat-title {
+    color: hsl(0 0% 90/0.6);
+  }
+</style>

--- a/frontend/components/global/StatCard/StatCard.vue
+++ b/frontend/components/global/StatCard/StatCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="stats bg-neutral shadow rounded-md">
     <div class="stat text-neutral-content text-center space-y-1 p-3">
-      <div class="stat-title">{{ title }}</div>
+      <div class="homebox-stat-title">{{ title }}</div>
       <div class="stat-value text-2xl">
         <Currency v-if="type === 'currency'" :amount="value" />
         <template v-if="type === 'number'">{{ value }}</template>


### PR DESCRIPTION
daisyUI stat-title css is broken when colors are just wrong.

Adding a little bit of CSS to the offending component for the offending themes solves the issue

## What type of PR is this?

- bug

## What this PR does / why we need it:

Fixes #34 bug where the title for the stat cards breaks on some themes.

## Testing

Manually validated each theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated CSS class name for the title element in StatCard component for better clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->