### PR TITLE
chore(docs): update doc links

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,6 +20,7 @@ export default defineConfig({
     // https://vitepress.dev/reference/default-theme-config
     nav: [
       { text: 'Home', link: '/' },
+      { text: 'API', link: 'https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/sysadminsmedia/homebox/main/docs/docs/api/openapi-2.0.json' }
     ],
 
     sidebar: [
@@ -40,7 +41,9 @@ export default defineConfig({
     ],
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/sysadminsmedia/homebox' }
+      { icon: 'discord', link: 'https://discord.gg/aY4DCkpNA9' },
+      { icon: 'github', link: 'https://github.com/sysadminsmedia/homebox' },
+      { icon: 'mastodon', link: 'https://noc.social/@sysadminszone' },
     ]
   }
 })


### PR DESCRIPTION
Updates the documentation links to include Mastodon and Discord, as well as API documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new link for 'API' in the navigation.
  - Updated social links to include Discord and Mastodon alongside GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->