### PR TITLE
fix(backend): assetID incorrectly made 32 bit

### DIFF
--- a/backend/app/api/handlers/v1/v1_ctrl_assets.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_assets.go
@@ -30,7 +30,7 @@ func (ctrl *V1Controller) HandleAssetGet() errchain.HandlerFunc {
 		assetIDParam := chi.URLParam(r, "id")
 		assetIDParam = strings.ReplaceAll(assetIDParam, "-", "") // Remove dashes
 		// Convert the asset ID to an int64
-		assetID, err := strconv.ParseInt(assetIDParam, 10, 32)
+		assetID, err := strconv.ParseInt(assetIDParam, 10, 64)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Fixes the incorrect change made that caused assetIDs to be parsed as 32 bit, instead of the 64 bit allowed.

## Which issue(s) this PR fixes:

Fixes #60 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of large asset IDs by modifying the data type to support larger values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->