### PR TITLE
fix(ci): add version info to docker builds

### DIFF
--- a/.github/workflows/docker-publish-rootless.yaml
+++ b/.github/workflows/docker-publish-rootless.yaml
@@ -86,6 +86,10 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=$(git rev-parse HEAD)
+            BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
       - name: Attest
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -83,6 +83,10 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=$(git rev-parse HEAD)
+            BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
         
       - name: Attest
         uses: actions/attest-build-provenance@v1


### PR DESCRIPTION
Resolve #45 by setting the version information when building the docker images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Docker publish workflows to include build arguments for `VERSION`, `COMMIT`, and `BUILD_TIME`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->