### PR TITLE
fix(ci): broken CI/CD

### DIFF
--- a/.github/workflows/docker-publish-rootless.yaml
+++ b/.github/workflows/docker-publish-rootless.yaml
@@ -88,7 +88,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             VERSION=${{ github.ref_name }}
-            COMMIT=${{ github.sha	}}
+            COMMIT=${{ github.sha }}
 
       - name: Attest
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/docker-publish-rootless.yaml
+++ b/.github/workflows/docker-publish-rootless.yaml
@@ -88,8 +88,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             VERSION=${{ github.ref_name }}
-            COMMIT=$(git rev-parse HEAD)
-            BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            COMMIT=${{ github.sha	}}
 
       - name: Attest
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -85,8 +85,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             VERSION=${{ github.ref_name }}
-            COMMIT=$(git rev-parse HEAD)
-            BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            COMMIT=${{ github.sha	}}
         
       - name: Attest
         uses: actions/attest-build-provenance@v1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflow to use `${{ github.sha }}` for `BUILD_TIME` and `COMMIT` variables.
  - Removed the `BUILD_TIME` variable from the Docker publish workflow.
  - Minor formatting improvements in the workflow files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->