### PR TITLE
Fix overflow caused by long URL tooltips

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -6,6 +6,10 @@
     text-transform: none !important;
 }
 
+.tooltip {
+  overflow-wrap: break-word;
+}
+
 /* transparent subtle scrollbar */
 ::-webkit-scrollbar {
   width: 0.2em;

--- a/frontend/components/global/DetailsSection/DetailsSection.vue
+++ b/frontend/components/global/DetailsSection/DetailsSection.vue
@@ -14,7 +14,7 @@
             />
             <Currency v-else-if="detail.type == 'currency'" :amount="detail.text" />
             <template v-else-if="detail.type === 'link'">
-              <div class="tooltip tooltip-primary tooltip-right" :data-tip="detail.href">
+              <div class="tooltip tooltip-primary tooltip-top" :data-tip="detail.href">
                 <a class="btn btn-primary btn-xs" :href="detail.href" target="_blank">
                   <MdiOpenInNew class="mr-2 swap-on" />
                   {{ detail.text }}

--- a/frontend/components/global/DetailsSection/DetailsSection.vue
+++ b/frontend/components/global/DetailsSection/DetailsSection.vue
@@ -14,7 +14,7 @@
             />
             <Currency v-else-if="detail.type == 'currency'" :amount="detail.text" />
             <template v-else-if="detail.type === 'link'">
-              <div class="tooltip tooltip-primary tooltip-top" :data-tip="detail.href">
+              <div class="tooltip tooltip-primary tooltip-right" :data-tip="detail.href">
                 <a class="btn btn-primary btn-xs" :href="detail.href" target="_blank">
                   <MdiOpenInNew class="mr-2 swap-on" />
                   {{ detail.text }}


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Fix overflow in item field links caused by the tooltip by wrapping the text into several lines.

Before/after:

![overflow_before](https://github.com/sysadminsmedia/homebox/assets/103900164/7feed55a-06a4-4d51-8ccd-9819a3491469)

![overflow_after](https://github.com/sysadminsmedia/homebox/assets/103900164/d58e6e04-3c79-4455-9e29-aa804129baeb)

## Which issue(s) this PR fixes:

Fixes #72 

## Release Notes

```release-note
Move URL tooltips to the top to fix overflow with long links
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Changed tooltip position to appear on the top instead of the right in the Details Section for improved visibility.
  - Improved tooltip text handling with word wrapping to ensure better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->