### PR TITLE
Move the link tooltip to the top to prevent overflows

### DIFF
--- a/frontend/components/global/DetailsSection/DetailsSection.vue
+++ b/frontend/components/global/DetailsSection/DetailsSection.vue
@@ -14,7 +14,7 @@
             />
             <Currency v-else-if="detail.type == 'currency'" :amount="detail.text" />
             <template v-else-if="detail.type === 'link'">
-              <div class="tooltip tooltip-primary tooltip-right" :data-tip="detail.href">
+              <div class="tooltip tooltip-primary tooltip-top" :data-tip="detail.href">
                 <a class="btn btn-primary btn-xs" :href="detail.href" target="_blank">
                   <MdiOpenInNew class="mr-2 swap-on" />
                   {{ detail.text }}


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Seems like https://github.com/sysadminsmedia/homebox/pull/73 didn't solve the issue for some links (I could test this on mobile devices). Moving the tooltip to the top helps in this cases.

## Which issue(s) this PR fixes:

Fixes #72

```release-note
Move the item field link tooltips to the top
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Changed the tooltip position for links in the Details Section from right to top for improved user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->