### PR TITLE
Update currencies to include more currencies

### DIFF
--- a/backend/internal/core/currencies/currencies.json
+++ b/backend/internal/core/currencies/currencies.json
@@ -18,6 +18,18 @@
     "name": "Afghan Afghani"
   },
   {
+    "code": "XCD",
+    "local": "Eastern Carribean",
+    "symbol": "$",
+    "name": "Eastern Carribean Dollar"
+  },
+  {
+    "code": "XOF",
+    "local": "CFA Franc",
+    "symbol": "CFA",
+    "name": "CFA Franc"
+  },
+  {
     "code": "ALL",
     "local": "Albania",
     "symbol": "L",
@@ -168,10 +180,22 @@
     "name": "Congolese Franc"
   },
   {
+    "code": "XAF",
+    "local": "CFA",
+    "symbol": "FCFA",
+    "name": "CFA Franc BEAC"
+  },  
+  {
     "code": "CHF",
     "local": "Switzerland",
     "symbol": "CHF",
     "name": "Swiss Franc"
+  },
+  {
+    "code": "NZD",
+    "local": "New Zealand",
+    "symbol": "NZ$",
+    "name": "New Zealand Dollar"
   },
   {
     "code": "CLP",


### PR DESCRIPTION
## What type of PR is this?
- feature

## What this PR does / why we need it:

Update the list of available currencies to include more, such as the New Zealand Dollar.
Begin refactor to allow for easier updating going forwards.

## Which issue(s) this PR fixes:
#1 #79 

## Release Notes


```
Begins refactor of currencies to allow for easier syncing and management. 
Adds extended support for additional currencies. 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new currency entries for Eastern Carribean Dollar (XCD) and CFA Franc (XOF).
  - Included New Zealand Dollar (NZD) in the currency list.

- **Updates**
  - Updated the existing entry for CFA Franc BEAC (XAF) with more detailed information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->