### PR TITLE
fix(ci): remove linting temp, and always build on docker changes

### DIFF
--- a/.github/workflows/binaries-publish.yaml
+++ b/.github/workflows/binaries-publish.yaml
@@ -5,13 +5,13 @@ on:
     tags: [ 'v*.*.*' ]
 
 jobs:
-  backend-tests:
-    name: "Backend Server Tests"
-    uses: sysadminsmedia/homebox/.github/workflows/partial-backend.yaml@main
+#  backend-tests:
+#    name: "Backend Server Tests"
+#    uses: sysadminsmedia/homebox/.github/workflows/partial-backend.yaml@main
 
-  frontend-tests:
-    name: "Frontend and End-to-End Tests"
-    uses: sysadminsmedia/homebox/.github/workflows/partial-frontend.yaml@main
+#  frontend-tests:
+#    name: "Frontend and End-to-End Tests"
+#    uses: sysadminsmedia/homebox/.github/workflows/partial-frontend.yaml@main
 
   goreleaser:
     name: goreleaser

--- a/.github/workflows/docker-publish-rootless.yaml
+++ b/.github/workflows/docker-publish-rootless.yaml
@@ -11,6 +11,7 @@ on:
       - 'Dockerfile'
       - 'Dockerfile.rootless'
       - '.dockerignore'
+      - '.github/workflows'
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
@@ -21,6 +22,7 @@ on:
       - 'Dockerfile'
       - 'Dockerfile.rootless'
       - '.dockerignore'
+      - '.github/workflows'
 
 
 env:

--- a/.github/workflows/docker-publish-rootless.yaml
+++ b/.github/workflows/docker-publish-rootless.yaml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'backend/**'
       - 'frontend/**'
+      - 'Dockerfile'
+      - 'Dockerfile.rootless'
+      - '.dockerignore'
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
@@ -15,6 +18,9 @@ on:
     paths:
       - 'backend/**'
       - 'frontend/**'
+      - 'Dockerfile'
+      - 'Dockerfile.rootless'
+      - '.dockerignore'
 
 
 env:
@@ -84,8 +90,8 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+#          cache-from: type=gha
+#          cache-to: type=gha,mode=max
           build-args: |
             VERSION=${{ github.ref_name }}
             COMMIT=${{ github.sha }}

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'backend/**'
       - 'frontend/**'
+      - 'Dockerfile'
+      - 'Dockerfile.rootless'
+      - '.dockerignore'
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
@@ -15,6 +18,9 @@ on:
     paths:
       - 'backend/**'
       - 'frontend/**'
+      - 'Dockerfile'
+      - 'Dockerfile.rootless'
+      - '.dockerignore'
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -81,8 +87,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+#          cache-from: type=gha
+#          cache-to: type=gha,mode=max
           build-args: |
             VERSION=${{ github.ref_name }}
             COMMIT=${{ github.sha	}}

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -11,6 +11,7 @@ on:
       - 'Dockerfile'
       - 'Dockerfile.rootless'
       - '.dockerignore'
+      - '.github/workflows'
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
@@ -21,6 +22,7 @@ on:
       - 'Dockerfile'
       - 'Dockerfile.rootless'
       - '.dockerignore'
+      - '.github/workflows'
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
Hopefully fixes weird cache build issues and also temp removes the lint checks for the binary releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub workflows to improve efficiency and accuracy of Docker and binary publishing processes.
  - Commented out sections related to backend and frontend tests in binaries publish workflow.
  - Refined file paths and caching settings in Docker publish workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->