### PR TITLE
Update WGET from Busybox to APK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ FROM golang:alpine AS builder
 ARG BUILD_TIME
 ARG COMMIT
 ARG VERSION
-ARG BUSYBOX_VERSION=1.36.1-r31
 RUN apk update && \
     apk upgrade && \
     apk add --update git build-base gcc g++
@@ -28,13 +27,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
     -o /go/bin/api \
     -v ./app/api/*.go
 
-# Downloading Wget
-ADD https://busybox.net/downloads/binaries/$BUSYBOX_VERSION/busybox_WGET /wget
-RUN chmod a+x /wget
-
 FROM gcr.io/distroless/java:latest
-
-COPY --from=builder /wget /usr/bin/wget
 
 # Production Stage
 FROM alpine:latest
@@ -46,9 +39,9 @@ ENV HBOX_STORAGE_SQLITE_URL=/data/homebox.db?_pragma=busy_timeout=2000&_pragma=j
 RUN apk --no-cache add ca-certificates
 RUN mkdir /app
 COPY --from=builder /go/bin/api /app
-COPY --from=builder /wget /usr/bin/wget
 
 RUN chmod +x /app/api
+RUN apk add --no-cache wget
 
 LABEL Name=homebox Version=0.0.1
 LABEL org.opencontainers.image.source="https://github.com/sysadminsmedia/homebox"

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -31,13 +31,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
     # create a directory so that we can copy it in the next stage
     mkdir /data
 
-# Downloading Wget
-ADD https://busybox.net/downloads/binaries/$BUSYBOX_VERSION/busybox_WGET /wget
-RUN chmod a+x /wget
-
 FROM gcr.io/distroless/java:latest
-
-COPY --from=builder /wget /usr/bin/wget
 
 # Production Stage
 FROM gcr.io/distroless/static:latest
@@ -50,7 +44,8 @@ ENV HBOX_STORAGE_SQLITE_URL=/data/homebox.db?_fk=1
 # change the ownership to the low-privileged user
 COPY --from=builder --chown=nonroot /go/bin/api /app
 COPY --from=builder --chown=nonroot /data /data
-COPY --from=builder --chown=nonroot /wget /usr/bin/wget
+
+RUN apk add --no-cache wget
 
 LABEL Name=homebox Version=0.0.1
 LABEL org.opencontainers.image.source="https://github.com/sysadminsmedia/homebox"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved Dockerfile and Dockerfile.rootless by simplifying the installation process of `wget` using `apk add --no-cache wget`. This change enhances efficiency and reduces build complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->