### PR TITLE
fix(docker): fixes the health check wget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ HEALTHCHECK --interval=30s \
             --timeout=5s \
             --start-period=5s \
             --retries=3 \
-            CMD [ "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:7745/api/v1/status" ]
+            CMD [ "/usr/bin/wget", "--no-verbose", "--tries=1", "-O -", "http://localhost:7745/api/v1/status" ]
 VOLUME [ "/data" ]
 
 ENTRYPOINT [ "/app/api" ]

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -54,7 +54,7 @@ HEALTHCHECK --interval=30s \
             --timeout=5s \
             --start-period=5s \
             --retries=3 \
-            CMD [ "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:7745/api/v1/status" ]
+            CMD [ "/usr/bin/wget", "--no-verbose", "--tries=1", "-O -", "http://localhost:7745/api/v1/status" ]
 VOLUME [ "/data" ]
 
 # Drop root and run as low-privileged user


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Fixes the docker health check, we can't use `wget --spider` because the API does not accept the correct HTTP `HEAD` method

## Which issue(s) this PR fixes:

Fixes #103 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated health check commands in Dockerfiles to use `wget` with the `-O -` option for improved service status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->