### PR TITLE
fix: Use subrouter for API and correctly handle 404 errors

### DIFF
--- a/backend/app/api/handlers/v1/controller.go
+++ b/backend/app/api/handlers/v1/controller.go
@@ -87,12 +87,6 @@ type (
 	}
 )
 
-func BaseURLFunc(prefix string) func(s string) string {
-	return func(s string) string {
-		return prefix + "/v1" + s
-	}
-}
-
 func NewControllerV1(svc *services.AllServices, repos *repo.AllRepos, bus *eventbus.EventBus, options ...func(*V1Controller)) *V1Controller {
 	ctrl := &V1Controller{
 		repo:              repos,


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Currently, the implementation for API v1 routes has the main drawback that any unknown path gets the fallback `notFoundHandler`, trying to access filesystem paths.

However, for API routes specifically, we can have a subrouter, and a default NotFound handler that returns 404.

## Testing

With this change, requests to `api/v1/<unknown>` now correctly returns status code 404 instead of 200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new endpoint: `/reporting/bill-of-materials`.

- **Improvements**
	- Restructured API routes under `/v1` for better organization.
	- Enhanced endpoint handling for users, groups, actions, locations, labels, items, assets, notifiers, and maintenance.
	- Introduced middleware for certain asset-related endpoints.
	- Added a default `NotFound` handler for undefined routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->