### PR TITLE
Add nmprc to automatically hoist dependencies

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=true


### PR DESCRIPTION
This project currently uses a command line call in the dockerfile for pnpm containing the `--shamefully-hoist` option. I've found that we can also enable that using an `.npmrc`. I think this is in general the better approach as its the standard way of setting pnpm option that should be enabled project wide. This then enables people trying to build this project to know where to look for options, and use the standard pnpm commands without having to look in the dockerfile incantations.

This also relieves us from having to use the `--shamefully-hoist` option ourselves, which I didn't yet do because I was unsure if its okay to just change the dockerfile, but I will add that if someone gives their OK.

## What type of PR is this?


- cleanup

## What this PR does / why we need it:


We currently explicitly call pnpm in the dockerfile with the `--shamefully-hoist` option this makes that unnecessary using the intended way of configuring pnpm.

## Testing

build the package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated npm configuration to optimize dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->