### PR TITLE
Add URL column to CSV export for items

### DIFF
--- a/backend/app/api/handlers/v1/controller.go
+++ b/backend/app/api/handlers/v1/controller.go
@@ -57,6 +57,12 @@ func WithSecureCookies(secure bool) func(*V1Controller) {
 	}
 }
 
+func WithURL(url string) func(*V1Controller) {
+	return func(ctrl *V1Controller) {
+		ctrl.url = url
+	}
+}
+
 type V1Controller struct {
 	cookieSecure      bool
 	repo              *repo.AllRepos
@@ -65,6 +71,7 @@ type V1Controller struct {
 	isDemo            bool
 	allowRegistration bool
 	bus               *eventbus.EventBus
+	url               string
 }
 
 type (

--- a/backend/app/api/handlers/v1/v1_ctrl_items.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_items.go
@@ -334,7 +334,7 @@ func (ctrl *V1Controller) HandleItemsExport() errchain.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		ctx := services.NewContext(r.Context())
 
-		csvData, err := ctrl.svc.Items.ExportCSV(r.Context(), ctx.GID, stripPathFromURL(r.Header.Get("Referer")))
+		csvData, err := ctrl.svc.Items.ExportCSV(r.Context(), ctx.GID, getHBURL(r.Header.Get("Referer"), ctrl.url))
 		if err != nil {
 			log.Err(err).Msg("failed to export items")
 			return validate.NewRequestError(err, http.StatusInternalServerError)
@@ -347,6 +347,15 @@ func (ctrl *V1Controller) HandleItemsExport() errchain.HandlerFunc {
 		writer.Comma = ','
 		return writer.WriteAll(csvData)
 	}
+}
+
+func getHBURL(refererHeader, fallback string) (hbURL string) {
+	hbURL = refererHeader
+	if hbURL == "" {
+		hbURL = fallback
+	}
+
+	return stripPathFromURL(hbURL)
 }
 
 // stripPathFromURL removes the path from a URL.

--- a/backend/app/api/routes.go
+++ b/backend/app/api/routes.go
@@ -3,6 +3,7 @@ package main
 import (
 	"embed"
 	"errors"
+	"fmt"
 	"io"
 	"mime"
 	"net/http"
@@ -54,6 +55,7 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 		v1.WithMaxUploadSize(a.conf.Web.MaxUploadSize),
 		v1.WithRegistration(a.conf.Options.AllowRegistration),
 		v1.WithDemoStatus(a.conf.Demo), // Disable Password Change in Demo Mode
+		v1.WithURL(fmt.Sprintf("%s:%s", a.conf.Web.Host, a.conf.Web.Port)),
 	)
 
 	r.Route(prefix+"/v1", func(r chi.Router) {

--- a/backend/internal/core/services/reporting/io_row.go
+++ b/backend/internal/core/services/reporting/io_row.go
@@ -18,6 +18,7 @@ type ExportCSVRow struct {
 	LabelStr  LabelString    `csv:"HB.labels"`
 	AssetID   repo.AssetID   `csv:"HB.asset_id"`
 	Archived  bool           `csv:"HB.archived"`
+	URL       string         `csv:"HB.url"`
 
 	Name        string `csv:"HB.name"`
 	Quantity    int    `csv:"HB.quantity"`

--- a/backend/internal/core/services/reporting/io_sheet.go
+++ b/backend/internal/core/services/reporting/io_sheet.go
@@ -153,7 +153,7 @@ func (s *IOSheet) Read(data io.Reader) error {
 }
 
 // ReadItems writes the sheet to a writer.
-func (s *IOSheet) ReadItems(ctx context.Context, items []repo.ItemOut, GID uuid.UUID, repos *repo.AllRepos) error {
+func (s *IOSheet) ReadItems(ctx context.Context, items []repo.ItemOut, GID uuid.UUID, repos *repo.AllRepos, hbURL string) error {
 	s.Rows = make([]ExportCSVRow, len(items))
 
 	extraHeaders := map[string]struct{}{}
@@ -178,6 +178,8 @@ func (s *IOSheet) ReadItems(ctx context.Context, items []repo.ItemOut, GID uuid.
 			labelString[i] = l.Name
 		}
 
+		url := generateItemURL(item, hbURL)
+
 		customFields := make([]ExportItemFields, len(item.Fields))
 
 		for i, f := range item.Fields {
@@ -201,6 +203,7 @@ func (s *IOSheet) ReadItems(ctx context.Context, items []repo.ItemOut, GID uuid.
 			Description: item.Description,
 			Insured:     item.Insured,
 			Archived:    item.Archived,
+			URL:         url,
 
 			PurchasePrice: item.PurchasePrice,
 			PurchaseFrom:  item.PurchaseFrom,
@@ -250,6 +253,14 @@ func (s *IOSheet) ReadItems(ctx context.Context, items []repo.ItemOut, GID uuid.
 	}
 
 	return nil
+}
+
+func generateItemURL(item repo.ItemOut, d string) string {
+	url := ""
+	if item.ID != uuid.Nil {
+		url = fmt.Sprintf("%s/item/%s", d, item.ID.String())
+	}
+	return url
 }
 
 // CSV writes the current sheet to a 2d array, for compatibility with TSV/CSV files.

--- a/backend/internal/core/services/service_items.go
+++ b/backend/internal/core/services/service_items.go
@@ -329,7 +329,7 @@ func (svc *ItemService) CsvImport(ctx context.Context, GID uuid.UUID, data io.Re
 	return finished, nil
 }
 
-func (svc *ItemService) ExportCSV(ctx context.Context, GID uuid.UUID) ([][]string, error) {
+func (svc *ItemService) ExportCSV(ctx context.Context, GID uuid.UUID, hbURL string) ([][]string, error) {
 	items, err := svc.repo.Items.GetAll(ctx, GID)
 	if err != nil {
 		return nil, err
@@ -337,7 +337,7 @@ func (svc *ItemService) ExportCSV(ctx context.Context, GID uuid.UUID) ([][]strin
 
 	sheet := reporting.IOSheet{}
 
-	err = sheet.ReadItems(ctx, items, GID, svc.repo)
+	err = sheet.ReadItems(ctx, items, GID, svc.repo, hbURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Enhanced the CSV export functionality to include a URL field for each item. This change required updating the export logic to generate and include item URLs based on the request's referrer header.

## What type of PR is this?
- feature

## What this PR does / why we need it:

This PR adds the export of a URL column.

<img width="1402" alt="image" src="https://github.com/user-attachments/assets/61475c98-a1c7-4cfb-a57b-f322497a05a5">


## Which issue(s) this PR fixes:

Fixes #126 

## Special notes for your reviewer:

I did not include the field in the import docs, because it will only be in the export. 

I am open to using a different solution to getting the host/port for the service. We have it in the config, but didn't want to expand the API of the routes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced URL handling improvements for CSV exports, allowing cleaner data representation.
  - Added a new utility function for URL management.

- **Enhancements**
  - Expanded CSV row structures to include associated URLs for more comprehensive reporting.
  - Updated methods to support additional parameters for improved data handling and context.
  - Enhanced routing configuration to dynamically set the base URL for the API.

- **Bug Fixes**
  - Improved handling of the "Referer" header for better URL processing during export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->