### PR TITLE
Splitting dependencies into separate docker layers (better caching)

### DIFF
--- a/.github/workflows/docker-publish-rootless.yaml
+++ b/.github/workflows/docker-publish-rootless.yaml
@@ -92,8 +92,8 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-#          cache-from: type=gha
-#          cache-to: type=gha,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             VERSION=${{ github.ref_name }}
             COMMIT=${{ github.sha }}

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -89,8 +89,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-#          cache-from: type=gha
-#          cache-to: type=gha,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             VERSION=${{ github.ref_name }}
             COMMIT=${{ github.sha	}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM node:18-alpine AS frontend-builder
 WORKDIR  /app
 RUN npm install -g pnpm
 COPY frontend .
-COPY --from=frontend-dependencies /app/node_modules
+COPY --from=frontend-dependencies /app/node_modules .
 RUN pnpm build
 
 # Build API

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ COPY frontend .
 COPY --from=frontend-dependencies /app/node_modules ./node_modules
 RUN pnpm build
 
+FROM golang:alpine AS builder-dependencies
+WORKDIR /go/src/app
+COPY ./backend .
+RUN go mod download
+
 # Build API
 FROM golang:alpine AS builder
 ARG BUILD_TIME
@@ -24,14 +29,11 @@ RUN apk update && \
 
 WORKDIR /go/src/app
 COPY ./backend .
-RUN go get -d -v ./...
 RUN rm -rf ./app/api/public
 COPY --from=frontend-builder /app/.output/public ./app/api/static/public
-# For some reason this can't be a seperate layer?
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    go mod download
-RUN CGO_ENABLED=0 GOOS=linux go build \
+COPY --from=builder-dependencies /go/pkg/mod /go/pkg/mod
+RUN --mount=type=cache,target=/root/.cache/go-build  \
+    CGO_ENABLED=0 GOOS=linux go build \
     -ldflags "-s -w -X main.commit=$COMMIT -X main.buildTime=$BUILD_TIME -X main.version=$VERSION"  \
     -o /go/bin/api \
     -v ./app/api/*.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM node:18-alpine AS frontend-builder
 WORKDIR  /app
 RUN npm install -g pnpm
 COPY frontend .
-COPY --from=frontend-dependencies /app/node_modules .
+COPY --from=frontend-dependencies /app/node_modules ./node_modules
 RUN pnpm build
 
 # Build API

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ COPY ./backend .
 RUN go get -d -v ./...
 RUN rm -rf ./app/api/public
 COPY --from=frontend-builder /app/.output/public ./app/api/static/public
+# For some reason this can't be a seperate layer?
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
 RUN CGO_ENABLED=0 GOOS=linux go build \
     -ldflags "-s -w -X main.commit=$COMMIT -X main.buildTime=$BUILD_TIME -X main.version=$VERSION"  \
     -o /go/bin/api \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
+# Node dependencies
+FROM node:18-alpine AS frontend-dependencies
+WORKDIR /app
+RUN npm install -g pnpm
+COPY frontend/package.json frontend/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile --shamefully-hoist
 
 # Build Nuxt
 FROM node:18-alpine AS frontend-builder
 WORKDIR  /app
 RUN npm install -g pnpm
-COPY frontend/package.json frontend/pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile --shamefully-hoist
 COPY frontend .
+COPY --from=frontend-dependencies /app/node_modules
 RUN pnpm build
 
 # Build API

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -10,7 +10,7 @@ FROM node:18-alpine AS frontend-builder
 WORKDIR  /app
 RUN npm install -g pnpm
 COPY frontend .
-COPY --from=frontend-dependencies /app/node_modules
+COPY --from=frontend-dependencies /app/node_modules .
 RUN pnpm build
 
 # Build API

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -13,32 +13,30 @@ COPY frontend .
 COPY --from=frontend-dependencies /app/node_modules ./node_modules
 RUN pnpm build
 
+FROM golang:alpine AS builder-dependencies
+WORKDIR /go/src/app
+COPY ./backend .
+RUN go mod download
+
 # Build API
 FROM golang:alpine AS builder
 ARG BUILD_TIME
 ARG COMMIT
 ARG VERSION
-ARG BUSYBOX_VERSION=1.36.1-r31
 RUN apk update && \
     apk upgrade && \
     apk add --update git build-base gcc g++
 
 WORKDIR /go/src/app
 COPY ./backend .
-RUN go get -d -v ./...
 RUN rm -rf ./app/api/public
 COPY --from=frontend-builder /app/.output/public ./app/api/static/public
-# For some reason this can't be a seperate layer
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    go mod download
-RUN CGO_ENABLED=0 GOOS=linux go build \
+COPY --from=builder-dependencies /go/pkg/mod /go/pkg/mod
+RUN --mount=type=cache,target=/root/.cache/go-build  \
+    CGO_ENABLED=0 GOOS=linux go build \
     -ldflags "-s -w -X main.commit=$COMMIT -X main.buildTime=$BUILD_TIME -X main.version=$VERSION"  \
     -o /go/bin/api \
-    -v ./app/api/*.go && \
-    chmod +x /go/bin/api && \
-    # create a directory so that we can copy it in the next stage
-    mkdir /data
+    -v ./app/api/*.go
 
 FROM gcr.io/distroless/java:latest
 

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -10,7 +10,7 @@ FROM node:18-alpine AS frontend-builder
 WORKDIR  /app
 RUN npm install -g pnpm
 COPY frontend .
-COPY --from=frontend-dependencies /app/node_modules .
+COPY --from=frontend-dependencies /app/node_modules ./node_modules
 RUN pnpm build
 
 # Build API

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -28,6 +28,10 @@ COPY ./backend .
 RUN go get -d -v ./...
 RUN rm -rf ./app/api/public
 COPY --from=frontend-builder /app/.output/public ./app/api/static/public
+# For some reason this can't be a seperate layer
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
 RUN CGO_ENABLED=0 GOOS=linux go build \
     -ldflags "-s -w -X main.commit=$COMMIT -X main.buildTime=$BUILD_TIME -X main.version=$VERSION"  \
     -o /go/bin/api \

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -1,11 +1,16 @@
+# Node dependencies
+FROM node:18-alpine AS frontend-dependencies
+WORKDIR /app
+RUN npm install -g pnpm
+COPY frontend/package.json frontend/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile --shamefully-hoist
 
 # Build Nuxt
 FROM node:18-alpine AS frontend-builder
 WORKDIR  /app
 RUN npm install -g pnpm
-COPY frontend/package.json frontend/pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile --shamefully-hoist
 COPY frontend .
+COPY --from=frontend-dependencies /app/node_modules
 RUN pnpm build
 
 # Build API


### PR DESCRIPTION
Resolves issue where every build has to pull new dependencies. In theory by making the dependencies a separate layer, we should be able to speed up the build process by a lot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved build efficiency for the Node.js application by introducing a multi-stage Docker build process for dependency management.
	- Added dedicated stages for managing Node.js and Go dependencies, reducing build times and enhancing overall performance.
	- Enhanced caching mechanism in GitHub Actions for Docker builds, improving build performance by reusing cached layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->