### PR TITLE
changed companyname and url to sysadminsmedia.com

### DIFF
--- a/backend/pkgs/mailer/templates.go
+++ b/backend/pkgs/mailer/templates.go
@@ -29,9 +29,9 @@ func (tp *TemplateProps) Set(key, value string) {
 func DefaultTemplateData() TemplateProps {
 	return TemplateProps{
 		Defaults: TemplateDefaults{
-			CompanyName:        "Haybytes.com",
+			CompanyName:        "sysadminsmedia.com",
 			CompanyAddress:     "123 Main St, Anytown, CA 12345",
-			CompanyURL:         "https://haybytes.com",
+			CompanyURL:         "https://sysadminsmedia.com",
 			ActivateAccountURL: "https://google.com",
 			UnsubscribeURL:     "https://google.com",
 		},


### PR DESCRIPTION
## What type of PR is this?

<!--
  Delete any of the following that do not apply:
 -->

- cleanup
- documentation

## What this PR does / why we need it:

changed templates.go to sysadminmedia.com

removal of some hybytes text, this has been in this file since the init from hay-kot, as far as i know there is no affiliation it would be "neat" to remove them from here and change it to sysadminmedia.com

## Which issue(s) this PR fixes:

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated company information in email templates to reflect the new branding for Sysadmins Media, including changes to the company name and URL.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->