### PR TITLE
compare SearchFilter values on a unique field instead of by reference for finding unselected

### DIFF
--- a/frontend/components/Search/Filter.vue
+++ b/frontend/components/Search/Filter.vue
@@ -45,6 +45,7 @@
     options: any[];
     display?: string;
     modelValue: any[];
+    uniqueField: string;
   };
 
   const btn = ref<HTMLButtonElement>();
@@ -75,6 +76,7 @@
     label: "",
     display: "name",
     modelValue: () => [],
+    uniqueField: "id",
   });
 
   const len = computed(() => {
@@ -95,9 +97,9 @@
   const unselected = computed(() => {
     return props.options.filter(o => {
       if (searchFold.value.length > 0) {
-        return o[props.display].toLowerCase().includes(searchFold.value) && !selected.value.includes(o);
+        return o[props.display].toLowerCase().includes(searchFold.value) && selected.value.every(s => s[props.uniqueField] !== o[props.uniqueField]);
       }
-      return !selected.value.includes(o);
+      return selected.value.every(s => s[props.uniqueField] !== o[props.uniqueField]);
     });
   });
 </script>


### PR DESCRIPTION
What type of PR is this?
fix

What this PR does / why we need it:
For the SearchFilter instead of finding unselected values by objects that do not have the same reference in the selected, instead use a unique field.

Which issue(s) this PR fixes:
Fixes #186  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `uniqueField` property in the Filter component for enhanced filtering flexibility.
	- Improved filtering logic to support various data structures by utilizing the `uniqueField`.

- **Bug Fixes**
	- Adjusted filtering conditions to ensure accurate selection of unselected items based on the specified unique identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->