### PR TITLE
refresh search on include archived change

### DIFF
--- a/frontend/pages/items.vue
+++ b/frontend/pages/items.vue
@@ -158,6 +158,12 @@
     return data;
   });
 
+  watch(includeArchived, (newV, oldV) => {
+    if (newV !== oldV) {
+      search();
+    }
+  });
+
   watch(fieldSelector, (newV, oldV) => {
     if (newV === false && oldV === true) {
       fieldTuples.value = [];


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:

- like other filter toggles causes the search to refresh when include archived is toggled



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented a new watcher for the `includeArchived` property, enhancing search functionality to provide immediate updates based on user selections regarding archived items.
  
- **Improvements**
	- Enhanced component reactivity for a better user experience by linking the state of `includeArchived` directly to search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->