### PR TITLE
make ItemViewTable headers customisable

### DIFF
--- a/frontend/components/Base/Card.vue
+++ b/frontend/components/Base/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="card bg-base-100 shadow-xl sm:rounded-lg">
+  <div class="card bg-base-100 shadow-xl rounded-lg">
     <div v-if="$slots.title" class="px-4 py-5 sm:px-6">
       <component :is="collapsable ? 'button' : 'div'" v-on="collapsable ? { click: toggle } : {}">
         <h3 class="flex items-center text-lg font-medium leading-6">

--- a/frontend/components/Item/View/Table.types.ts
+++ b/frontend/components/Item/View/Table.types.ts
@@ -5,6 +5,8 @@ export type TableHeader = {
   value: keyof ItemSummary;
   sortable?: boolean;
   align?: "left" | "center" | "right";
+  enabled: boolean;
+  type?: "price" | "boolean" | "name" | "location" | "date";
 };
 
 export type TableData = Record<string, any>;

--- a/frontend/composables/use-preferences.ts
+++ b/frontend/composables/use-preferences.ts
@@ -1,4 +1,5 @@
 import type { Ref } from "vue";
+import type { TableHeader } from "components/Item/View/Table.types";
 import type { DaisyTheme } from "~~/lib/data/themes";
 
 export type ViewType = "table" | "card" | "tree";
@@ -10,6 +11,7 @@ export type LocationViewPreferences = {
   itemDisplayView: ViewType;
   theme: DaisyTheme;
   itemsPerTablePage: number;
+  tableHeaders?: TableHeader[];
   displayHeaderDecor: boolean;
   language?: string;
 };

--- a/frontend/pages/home/index.vue
+++ b/frontend/pages/home/index.vue
@@ -38,7 +38,7 @@
         <Subtitle> Recently Added </Subtitle>
 
         <BaseCard v-if="breakpoints.lg">
-          <ItemViewTable :items="itemTable.items" />
+          <ItemViewTable :items="itemTable.items" disable-controls />
         </BaseCard>
         <div v-else class="grid grid-cols-1 gap-4 md:grid-cols-2">
           <ItemCard v-for="item in itemTable.items" :key="item.id" :item="item" />


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- feature

## What this PR does / why we need it:

This makes it so you can customise both what headers/columns are shown and the order they are shown for the ItemViewTable.

This makes homebox more customisable, some users for example may not use the insured field or may not find it generally useful so they could disable it and show other information such as serial number.

## Which issue(s) this PR fixes:

Fixes #209 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic header management in the table component, allowing users to conditionally display and reorder table columns.
	- Added a dropdown control for managing header visibility and order.
	- Enhanced table header properties for improved data representation (e.g., type and enabled state).
  
- **Bug Fixes**
	- Improved styling and layout of the table for better visual presentation.

- **Documentation**
	- Updated preferences to include an optional property for table headers, enhancing user customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->