### PR TITLE
show add photo button on mobile

### DIFF
--- a/frontend/components/Base/Modal.vue
+++ b/frontend/components/Base/Modal.vue
@@ -2,7 +2,7 @@
   <div class="z-[999]">
     <input :id="modalId" v-model="modal" type="checkbox" class="modal-toggle" />
     <div class="modal modal-bottom overflow-visible sm:modal-middle">
-      <div class="modal-box relative overflow-visible">
+      <div class="modal-box relative overflow-auto">
         <button :for="modalId" class="btn btn-circle btn-sm absolute right-2 top-2" @click="close">✕</button>
 
         <h3 class="text-lg font-bold">

--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -7,12 +7,13 @@
       <FormTextArea v-model="form.description" label="Item Description" />
       <FormMultiselect v-model="form.labels" label="Labels" :items="labels ?? []" />
 
-      <div class="modal-action">
-        <div class="flex justify-center">
-          <div>
-            <label for="photo" class="btn">{{ $t("components.item.create_modal.photo_button") }}</label>
-            <input id="photo" type="file" accept="image/*" style="visibility: hidden" @change="previewImage" />
-          </div>
+      <div class="modal-action mb-6">
+        <div>
+          <label for="photo" class="btn">{{ $t("components.item.create_modal.photo_button") }}</label>
+          <input id="photo" class="hidden" type="file" accept="image/*" @change="previewImage" />
+        </div>
+        <div class="grow"></div>
+        <div>
           <BaseButton class="rounded-r-none" :loading="loading" type="submit">
             <template #icon>
               <MdiPackageVariant class="swap-off size-5" />


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

![image](https://github.com/user-attachments/assets/4bb8015b-2324-4381-bcfc-602706895f3a)

- Improves the add image button within the create item modal on mobile.

## Which issue(s) this PR fixes:

_(REQUIRED)_

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->

Fixes https://github.com/sysadminsmedia/homebox/discussions/213
Fixes #226 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved layout and styling of the modal's action section for a better user experience.
	- Enhanced usability of the modal with updated overflow behavior, allowing for scrollbars when content exceeds the modal's dimensions.

- **Bug Fixes**
	- Enhanced maintainability of the file selection input by utilizing Tailwind CSS classes for styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->