### PR TITLE
fix: redirect back to locations list after deleting location

### DIFF
--- a/frontend/pages/location/[id].vue
+++ b/frontend/pages/location/[id].vue
@@ -47,7 +47,7 @@
     }
 
     toast.success("Location deleted");
-    navigateTo("/home");
+    navigateTo("/locations");
   }
 
   const updateModal = ref(false);


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug
- feature

## What this PR does / why we need it:

Currently you're redirected back to `/home` after deleting a location. This PR changes the redirect to take the user to `/locations`, which is more convenient if you're managing multiple locations in one go (e.g deleting a bunch of locations).

## Which issue(s) this PR fixes:

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated navigation behavior to redirect users to the "/locations" page after successfully deleting a location, enhancing user experience by providing immediate access to the locations list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->