### PR TITLE
fix: move version info to sidebar, tweak sign out button

### DIFF
--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -12,15 +12,15 @@
     <AppToast />
     <div class="drawer drawer-mobile">
       <input id="my-drawer-2" v-model="drawerToggle" type="checkbox" class="drawer-toggle" />
-      <div class="drawer-content justify-center bg-base-300 pt-20 lg:pt-0">
+      <div class="drawer-content bg-base-300 justify-center pt-20 lg:pt-0">
         <AppHeaderDecor v-if="preferences.displayHeaderDecor" class="-mt-10 hidden lg:block" />
         <!-- Button -->
-        <div class="navbar drawer-button fixed top-0 z-[99] bg-primary shadow-md lg:hidden">
+        <div class="navbar drawer-button bg-primary fixed top-0 z-[99] shadow-md lg:hidden">
           <label for="my-drawer-2" class="btn btn-square btn-ghost drawer-button text-base-100 lg:hidden">
             <MdiMenu class="size-6" />
           </label>
           <NuxtLink to="/home">
-            <h2 class="flex text-3xl font-bold tracking-tight text-base-100">
+            <h2 class="text-base-100 flex text-3xl font-bold tracking-tight">
               HomeB
               <AppLogo class="-mb-3 w-8" />
               x
@@ -29,12 +29,6 @@
         </div>
 
         <slot></slot>
-        <footer v-if="status" class="bottom-0 w-full bg-base-300 pb-4 text-center text-secondary-content">
-          <p class="text-center text-sm">
-            {{ $t("global.version", { version: status.build.version }) }} ~
-            {{ $t("global.build", { build: status.build.commit }) }}
-          </p>
-        </footer>
       </div>
 
       <!-- Sidebar -->
@@ -42,17 +36,17 @@
         <label for="my-drawer-2" class="drawer-overlay"></label>
 
         <!-- Top Section -->
-        <div class="flex w-60 flex-col bg-base-200 py-5 md:py-10">
+        <div class="bg-base-200 flex w-60 flex-col pb-4 pt-5 md:pt-10">
           <div class="space-y-8">
             <div class="flex flex-col items-center gap-4">
               <p>{{ $t("global.welcome", { username: username }) }}</p>
               <NuxtLink class="avatar placeholder" to="/home">
-                <div class="w-24 rounded-full bg-base-300 p-4 text-neutral-content">
+                <div class="bg-base-300 text-neutral-content w-24 rounded-full p-4">
                   <AppLogo />
                 </div>
               </NuxtLink>
             </div>
-            <div class="flex flex-col bg-base-200">
+            <div class="bg-base-200 flex flex-col">
               <div class="mx-auto mb-6 w-40">
                 <div class="dropdown visible w-40">
                   <label tabindex="0" class="text-no-transform btn btn-primary btn-block text-lg">
@@ -61,7 +55,7 @@
                     </span>
                     {{ $t("global.create") }}
                   </label>
-                  <ul tabindex="0" class="dropdown-content menu rounded-box w-40 bg-base-100 p-2 shadow">
+                  <ul tabindex="0" class="dropdown-content menu rounded-box bg-base-100 w-40 p-2 shadow">
                     <li v-for="btn in dropdown" :key="btn.name">
                       <button @click="btn.action">
                         {{ btn.name }}
@@ -89,9 +83,16 @@
           </div>
 
           <!-- Bottom -->
-          <button class="rounded-btn mx-2 mt-auto p-3 hover:bg-base-300" @click="logout">
+          <button class="rounded-btn hover:bg-base-300 mx-4 mt-auto p-3 text-sm" @click="logout">
             {{ $t("global.sign_out") }}
           </button>
+
+          <footer v-if="status" class="text-secondary-content mt-4">
+            <p class="text-center text-xs">
+              {{ $t("global.version", { version: status.build.version }) }} ~
+              {{ $t("global.build", { build: status.build.commit }) }}
+            </p>
+          </footer>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- feature

## What this PR does / why we need it:

Moves the current footer displaying version info to the sidebar, and slightly tweaks the sign-out button to be a bit smaller.

This change is an easy way to prevent the footer from, in some pages, being in the center of the page due to the small vertical dimensions of the page content.

The footer content in those cases could be confused as being part of the individual page's useful content, and overall impacted readability.

<img width="460" alt="image" src="https://github.com/user-attachments/assets/66c57b19-1b96-4b93-b5ce-6a0ea089eba7">

## Which issue(s) this PR fixes:

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted layout and structure of HTML elements for improved visual presentation.
	- Rearranged class orders for `drawer-content`, `navbar`, and dropdown menu.
	- Updated footer position and styling for better accessibility.
	- Modified padding and margin for various elements, including the sidebar and logout button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->