### PR TITLE
fix: prevent submit modal when trying to create location with no name

### DIFF
--- a/frontend/components/Form/TextField.vue
+++ b/frontend/components/Form/TextField.vue
@@ -3,7 +3,14 @@
     <label class="label">
       <span class="label-text">{{ label }}</span>
     </label>
-    <input ref="input" v-model="value" :placeholder="placeholder" :type="type" class="input input-bordered w-full" />
+    <input
+      ref="input"
+      v-model="value"
+      :placeholder="placeholder"
+      :type="type"
+      :required="required"
+      class="input input-bordered w-full"
+    />
   </div>
   <div v-else class="sm:grid sm:grid-cols-4 sm:items-start sm:gap-4">
     <label class="label">
@@ -21,6 +28,10 @@
     },
     modelValue: {
       type: [String, Number],
+      default: null,
+    },
+    required: {
+      type: [Boolean],
       default: null,
     },
     type: {

--- a/frontend/components/Location/CreateModal.vue
+++ b/frontend/components/Location/CreateModal.vue
@@ -7,6 +7,7 @@
         v-model="form.name"
         :trigger-focus="focused"
         :autofocus="true"
+        :required="true"
         label="Location Name"
       />
       <FormTextArea v-model="form.description" label="Location Description" />
@@ -18,7 +19,7 @@
             <label tabindex="0" class="btn rounded-l-none rounded-r-xl">
               <MdiChevronDown class="size-5" />
             </label>
-            <ul tabindex="0" class="dropdown-content menu rounded-box right-0 w-64 bg-base-100 p-2 shadow">
+            <ul tabindex="0" class="dropdown-content menu rounded-box bg-base-100 right-0 w-64 p-2 shadow">
               <li>
                 <button type="button" @click="create(false)">{{ $t("global.create_and_add") }}</button>
               </li>


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug

## What this PR does / why we need it:

- Prevents the Create Location modal from submitting without a location name input.
- Adds a `required` attribute to `FormTextField`

<img width="614" alt="image" src="https://github.com/user-attachments/assets/d6d428a0-621d-4781-99bb-cf1512333277">


## Which issue(s) this PR fixes:

Fixes #233
