### PR TITLE
In maintenance view, change link to aim maintenance page of item

### DIFF
--- a/frontend/components/Maintenance/ListView.vue
+++ b/frontend/components/Maintenance/ListView.vue
@@ -131,7 +131,7 @@
         <BaseSectionHeader class="border-b border-b-gray-300 p-6">
           <span class="text-base-content">
             <span v-if="!props.currentItemId">
-              <NuxtLink class="hover:underline" :to="`/item/${(e as MaintenanceEntryWithDetails).itemID}`">
+              <NuxtLink class="hover:underline" :to="`/item/${(e as MaintenanceEntryWithDetails).itemID}/maintenance`">
                 {{ (e as MaintenanceEntryWithDetails).itemName }}
               </NuxtLink>
               -


### PR DESCRIPTION
## What type of PR is this?
- feature (or bug ?)

## What this PR does / why we need it:
![maintenance_view](https://github.com/user-attachments/assets/02245fec-a8cc-495f-b70f-ceaeb240e2aa)
In the global maintenance view, clicking on an item will now open the maintenance view of the item.
From my point of view, this (minor) change do improve the user experience but feedback from other is always welcome :)

## Testing

Tested within the provided devcontainer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated URL structure for item navigation to include `/maintenance`, enhancing clarity in routing.
  
- **Bug Fixes**
	- Improved navigation behavior when `props.currentItemId` is not defined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->