### PR TITLE
Allow AVIF and WebP for primary photo when creating an item

### DIFF
--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -18,7 +18,13 @@
       <div class="modal-action mb-6">
         <div>
           <label for="photo" class="btn">{{ $t("components.item.create_modal.photo_button") }}</label>
-          <input id="photo" class="hidden" type="file" accept="image/png,image/jpeg,image/gif" @change="previewImage" />
+          <input
+            id="photo"
+            class="hidden"
+            type="file"
+            accept="image/png,image/jpeg,image/gif,image/avif,image/webp"
+            @change="previewImage"
+          />
         </div>
         <div class="grow"></div>
         <div>
@@ -33,7 +39,7 @@
             <label tabindex="0" class="btn rounded-l-none rounded-r-xl">
               <MdiChevronDown class="size-5" name="mdi-chevron-down" />
             </label>
-            <ul tabindex="0" class="dropdown-content menu rounded-box right-0 w-64 bg-base-100 p-2 shadow">
+            <ul tabindex="0" class="dropdown-content menu rounded-box bg-base-100 right-0 w-64 p-2 shadow">
               <li>
                 <button type="button" @click="create(false)">{{ $t("global.create_and_add") }}</button>
               </li>


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

This PR adds avif and webp as allowed mime types for picture upload during item creation.
Those formats are widely supported by web browers (source: https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types)

## Special notes for your reviewer:

Ideally, testing on an apple device is a must-have as mime type list was initially introduced to fix an issue regarding apple devices (#165, #227)

## Testing

Tested in the provided devcontainer + included in my "beta" branch (`ghcr.io/mcarbonne/homebox:beta`)
(only on linux and android devices)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced file upload functionality to support additional image formats: `image/avif` and `image/webp`.
  
- **Bug Fixes**
	- Improved the dropdown menu by removing a redundant class for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->