### PR TITLE
Fix multiple primary attachments on a single item

### DIFF
--- a/backend/internal/data/repo/repo_item_attachments_test.go
+++ b/backend/internal/data/repo/repo_item_attachments_test.go
@@ -133,3 +133,25 @@ func TestAttachmentRepo_Delete(t *testing.T) {
 	_, err = tRepos.Attachments.Get(context.Background(), entity.ID)
 	require.Error(t, err)
 }
+
+func TestAttachmentRepo_EnsureSinglePrimaryAttachment(t *testing.T) {
+	ctx := context.Background()
+	attachments := useAttachments(t, 2)
+
+	setAndVerifyPrimary := func(primaryAttachmentID, nonPrimaryAttachmentID uuid.UUID) {
+		primaryAttachment, err := tRepos.Attachments.Update(ctx, primaryAttachmentID, &ItemAttachmentUpdate{
+			Type:    attachment.TypePhoto.String(),
+			Primary: true,
+		})
+		require.NoError(t, err)
+
+		nonPrimaryAttachment, err := tRepos.Attachments.Get(ctx, nonPrimaryAttachmentID)
+		require.NoError(t, err)
+
+		assert.True(t, primaryAttachment.Primary)
+		assert.False(t, nonPrimaryAttachment.Primary)
+	}
+
+	setAndVerifyPrimary(attachments[0].ID, attachments[1].ID)
+	setAndVerifyPrimary(attachments[1].ID, attachments[0].ID)
+}


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

- Prevents multiple primary attachments on a single item

## Which issue(s) this PR fixes:

Fixes #283 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated attachment management to ensure only one primary attachment can be designated per item.

- **Bug Fixes**
	- Improved logic for identifying and updating attachments based on their type and primary status.

- **Tests**
	- Introduced a new test to validate the primary attachment functionality, ensuring correct behavior when multiple attachments exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->