### PR TITLE
Fix french maintenance translation (inverted entries)

### DIFF
--- a/frontend/locales/fr.json
+++ b/frontend/locales/fr.json
@@ -199,8 +199,8 @@
         },
         "monthly_average": "Moyenne mensuelle",
         "toast": {
-            "failed_to_create": "Échec de suppression de l'entrée",
-            "failed_to_delete": "Échec de création de l'entrée",
+            "failed_to_create": "Échec de création de l'entrée",
+            "failed_to_delete": "Échec de suppression de l'entrée",
             "failed_to_update": "Échec de mise à jour de l'entrée"
         },
         "total_cost": "Coût total",


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Fixed inverted translation entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated French localization for error messages related to maintenance operations.
	- Improved clarity in user feedback with corrected messages for creation and deletion errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->