### PR TITLE
Fix command typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ start command `task go:run`
 
 ### Frontend Development Notes
 
-start command `task: ui:dev`
+start command `task ui:dev`
 
 1. The frontend is a Vue 3 app with Nuxt.js that uses Tailwind and DaisyUI for styling.
 2. We're using Vitest for our automated testing. You can run these with `task ui:watch`.


### PR DESCRIPTION
Minor inconvenience that bothered me

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- documentation

## What this PR does / why we need it:

- Fix a typo in the comand in `CONTRIBUTING.md` that allows to start the Frontend.
- I've noticed it when following the instructions to build the project for development, and it bothered me because it doesn't work :)
- The new line at the end was added by Github editor, and it's a good practice so left it.


## Which issue(s) this PR fixes:

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated command syntax for starting the UI development server for improved clarity.
	- Added a newline at the end of the `CONTRIBUTING.md` file for better formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->