### PR TITLE
add timestamp to the export filename

### DIFF
--- a/backend/app/api/handlers/v1/v1_ctrl_items.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_items.go
@@ -4,10 +4,12 @@ import (
 	"database/sql"
 	"encoding/csv"
 	"errors"
+	"fmt"
 	"math/big"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/hay-kot/httpkit/errchain"
@@ -339,9 +341,12 @@ func (ctrl *V1Controller) HandleItemsExport() errchain.HandlerFunc {
 			log.Err(err).Msg("failed to export items")
 			return validate.NewRequestError(err, http.StatusInternalServerError)
 		}
+		
+		timestamp := time.Now().Format("2006-01-02_15-04-05") // YYYY-MM-DD_HH-MM-SS format
+		filename := fmt.Sprintf("homebox-items_%s.csv", timestamp) // add timestamp to filename
 
 		w.Header().Set("Content-Type", "text/csv")
-		w.Header().Set("Content-Disposition", "attachment;filename=homebox-items.csv")
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment;filename=%s", filename))
 
 		writer := csv.NewWriter(w)
 		writer.Comma = ','


### PR DESCRIPTION

## What type of PR is this?

- feature

## What this PR does / why we need it:

This PR introduces the ability to include a timestamp in the filenames of exported CSVs in the items export feature. Previously, filenames were static, making it difficult to distinguish between multiple exports. Adding a timestamp ensures that each export is uniquely identifiable and reflects the time of export.

Changes:

* Modified the `HandleItemsExport` method to dynamically generate a timestamp using Go’s time formatting.
* Updated the `Content-Disposition` header to include the dynamically generated filename.

## Special notes for your reviewer:

I am new to contributing to any software and new to the Go language. If I made any mistakes, I would love to be informed and guided. I thought this change was necessary, so I got the timestamp code from StackOverflow and made it work.

## Testing

I manually exported files after several minutes and confirmed that the timestamp in the filenames was accurate. I didn’t perform any other tests. Please advise on additional testing methods if necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced item export functionality with dynamically generated filenames that include timestamps.
- **Bug Fixes**
	- Improved error handling for item import processes to ensure better logging of issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->