### PR TITLE
Improve filter for maintenances

### DIFF
--- a/backend/internal/data/repo/repo_maintenance_entry.go
+++ b/backend/internal/data/repo/repo_maintenance_entry.go
@@ -134,13 +134,15 @@ func (r *MaintenanceEntryRepository) GetMaintenanceByItemID(ctx context.Context,
 		query = query.Where(maintenanceentry.Or(
 			maintenanceentry.DateIsNil(),
 			maintenanceentry.DateEQ(time.Time{}),
+			maintenanceentry.DateGT(time.Now()),
 		))
 	} else if filters.Status == MaintenanceFilterStatusCompleted {
 		query = query.Where(
 			maintenanceentry.Not(maintenanceentry.Or(
 				maintenanceentry.DateIsNil(),
-				maintenanceentry.DateEQ(time.Time{})),
-			))
+				maintenanceentry.DateEQ(time.Time{}),
+				maintenanceentry.DateGT(time.Now()),
+			)))
 	}
 	entries, err := query.WithItem().Order(maintenanceentry.ByScheduledDate()).All(ctx)
 

--- a/backend/internal/data/repo/repo_maintenance_entry_test.go
+++ b/backend/internal/data/repo/repo_maintenance_entry_test.go
@@ -32,8 +32,8 @@ func getPrevMonth(now time.Time) time.Time {
 func TestMaintenanceEntryRepository_GetLog(t *testing.T) {
 	item := useItems(t, 1)[0]
 
-	// Create 10 maintenance entries for the item
-	created := make([]MaintenanceEntryCreate, 10)
+	// Create 11 maintenance entries for the item
+	created := make([]MaintenanceEntryCreate, 11)
 
 	thisMonth := time.Now()
 	lastMonth := getPrevMonth(thisMonth)
@@ -50,6 +50,14 @@ func TestMaintenanceEntryRepository_GetLog(t *testing.T) {
 			Description:   "Maintenance description",
 			Cost:          10,
 		}
+	}
+
+	// Add an entry completed in the future
+	created[10] = MaintenanceEntryCreate{
+		CompletedDate: types.DateFromTime(time.Now().AddDate(0, 0, 1)),
+		Name:          "Maintenance",
+		Description:   "Maintenance description",
+		Cost:          10,
 	}
 
 	for _, entry := range created {


### PR DESCRIPTION
Maintenances with completed date in the future should be in the scheduled tab

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- feature

## What this PR does / why we need it:

Maintenances which complete in the future should be in the scheduled tab instead of completed.

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

Fixes: #280 
<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->

## Special notes for your reviewer:


<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

_(fill-in or delete this section)_

<!--
  Describe how you tested this change.
-->

I've added a test case in TestMaintenanceEntryRepository_GetLog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced filtering logic for retrieving maintenance entries based on their scheduled and completed statuses.

- **Bug Fixes**
  - Adjusted the filtering criteria to ensure accurate retrieval of maintenance entries, including those with future scheduled dates.

- **Tests**
  - Updated test cases to include an additional future maintenance entry while maintaining existing assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->