### PR TITLE
Improve swagger generation

### DIFF
--- a/.github/workflows/partial-backend.yaml
+++ b/.github/workflows/partial-backend.yaml
@@ -34,3 +34,8 @@ jobs:
 
       - name: Test
         run: task go:coverage
+
+      - name: Validate OpenAPI definition
+        uses: swaggerexpert/swagger-editor-validate@v1
+        with:
+          definition-file: backend/app/api/static/docs/swagger.json

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -28,7 +28,6 @@ tasks:
       - "./backend/internal/data/**"
       - "./backend/internal/core/services/**/*"
       - "./backend/app/tools/typegen/main.go"
-
   typescript-types:
     desc: Generates typescript types from swagger definition
     cmds:

--- a/backend/app/api/handlers/v1/v1_ctrl_auth.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_auth.go
@@ -28,8 +28,8 @@ type (
 	}
 
 	LoginForm struct {
-		Username     string `json:"username"`
-		Password     string `json:"password"`
+		Username     string `json:"username" example:"admin@admin.com"`
+		Password     string `json:"password" example:"admin"`
 		StayLoggedIn bool   `json:"stayLoggedIn"`
 	}
 )
@@ -83,8 +83,6 @@ type AuthProvider interface {
 //	@Tags    Authentication
 //	@Accept  x-www-form-urlencoded
 //	@Accept  application/json
-//	@Param   username formData string false "string" example(admin@admin.com)
-//	@Param   password formData string false "string" example(admin)
 //	@Param   payload body     LoginForm true "Login Data"
 //	@Param   provider    query    string   false "auth provider"
 //	@Produce json

--- a/backend/app/api/handlers/v1/v1_ctrl_items.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_items.go
@@ -298,6 +298,7 @@ func (ctrl *V1Controller) HandleGetAllCustomFieldValues() errchain.HandlerFunc {
 //	@Success  204
 //	@Param    csv formData file true "Image to upload"
 //	@Router   /v1/items/import [Post]
+//	@Consumes multipart/form-data
 //	@Security Bearer
 func (ctrl *V1Controller) HandleItemsImport() errchain.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) error {
@@ -341,8 +342,8 @@ func (ctrl *V1Controller) HandleItemsExport() errchain.HandlerFunc {
 			log.Err(err).Msg("failed to export items")
 			return validate.NewRequestError(err, http.StatusInternalServerError)
 		}
-		
-		timestamp := time.Now().Format("2006-01-02_15-04-05") // YYYY-MM-DD_HH-MM-SS format
+
+		timestamp := time.Now().Format("2006-01-02_15-04-05")      // YYYY-MM-DD_HH-MM-SS format
 		filename := fmt.Sprintf("homebox-items_%s.csv", timestamp) // add timestamp to filename
 
 		w.Header().Set("Content-Type", "text/csv")

--- a/backend/app/api/handlers/v1/v1_ctrl_items.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_items.go
@@ -294,11 +294,11 @@ func (ctrl *V1Controller) HandleGetAllCustomFieldValues() errchain.HandlerFunc {
 //
 //	@Summary  Import Items
 //	@Tags     Items
+//	@Accept   multipart/form-data
 //	@Produce  json
 //	@Success  204
 //	@Param    csv formData file true "Image to upload"
 //	@Router   /v1/items/import [Post]
-//	@Consumes multipart/form-data
 //	@Security Bearer
 func (ctrl *V1Controller) HandleItemsImport() errchain.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) error {

--- a/backend/app/api/handlers/v1/v1_ctrl_items_attachments.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_items_attachments.go
@@ -25,7 +25,7 @@ type (
 //
 //	@Summary  Create Item Attachment
 //	@Tags     Items Attachments
-//	@Accept multipart/form-data
+//	@Accept   multipart/form-data
 //	@Produce  json
 //	@Param    id   path     string true "Item ID"
 //	@Param    file formData file   true "File attachment"

--- a/backend/app/api/handlers/v1/v1_ctrl_items_attachments.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_items_attachments.go
@@ -25,6 +25,7 @@ type (
 //
 //	@Summary  Create Item Attachment
 //	@Tags     Items Attachments
+//	@Accept multipart/form-data
 //	@Produce  json
 //	@Param    id   path     string true "Item ID"
 //	@Param    file formData file   true "File attachment"
@@ -33,7 +34,6 @@ type (
 //	@Success  200  {object} repo.ItemOut
 //	@Failure  422  {object} validate.ErrorResponse
 //	@Router   /v1/items/{id}/attachments [POST]
-//	@Consumes multipart/form-data
 //	@Security Bearer
 func (ctrl *V1Controller) HandleItemAttachmentCreate() errchain.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) error {

--- a/backend/app/api/handlers/v1/v1_ctrl_items_attachments.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_items_attachments.go
@@ -33,6 +33,7 @@ type (
 //	@Success  200  {object} repo.ItemOut
 //	@Failure  422  {object} validate.ErrorResponse
 //	@Router   /v1/items/{id}/attachments [POST]
+//	@Consumes multipart/form-data
 //	@Security Bearer
 func (ctrl *V1Controller) HandleItemAttachmentCreate() errchain.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) error {

--- a/backend/app/api/handlers/v1/v1_ctrl_maint_entry.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_maint_entry.go
@@ -15,6 +15,7 @@ import (
 //	@Summary  Get Maintenance Log
 //	@Tags     Item Maintenance
 //	@Produce  json
+//	@Param    id  path     string true "Item ID"
 //	@Param    filters query    repo.MaintenanceFilters     false "which maintenance to retrieve"
 //	@Success  200       {array} repo.MaintenanceEntryWithDetails[]
 //	@Router   /v1/items/{id}/maintenance [GET]
@@ -33,6 +34,7 @@ func (ctrl *V1Controller) HandleMaintenanceLogGet() errchain.HandlerFunc {
 //	@Summary  Create Maintenance Entry
 //	@Tags     Item Maintenance
 //	@Produce  json
+//	@Param    id  path     string true "Item ID"
 //	@Param    payload body     repo.MaintenanceEntryCreate true "Entry Data"
 //	@Success  201     {object} repo.MaintenanceEntry
 //	@Router   /v1/items/{id}/maintenance [POST]

--- a/backend/app/api/handlers/v1/v1_ctrl_maintenance.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_maintenance.go
@@ -33,6 +33,7 @@ func (ctrl *V1Controller) HandleMaintenanceGetAll() errchain.HandlerFunc {
 //	@Summary  Update Maintenance Entry
 //	@Tags     Maintenance
 //	@Produce  json
+//	@Param    id  path     string true "Maintenance ID"
 //	@Param    payload body     repo.MaintenanceEntryUpdate true "Entry Data"
 //	@Success  200     {object} repo.MaintenanceEntry
 //	@Router   /v1/maintenance/{id} [PUT]

--- a/backend/app/api/handlers/v1/v1_ctrl_maintenance.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_maintenance.go
@@ -52,6 +52,7 @@ func (ctrl *V1Controller) HandleMaintenanceEntryUpdate() errchain.HandlerFunc {
 //	@Summary  Delete Maintenance Entry
 //	@Tags     Maintenance
 //	@Produce  json
+//	@Param    id  path     string true "Maintenance ID"
 //	@Success  204
 //	@Router   /v1/maintenance/{id} [DELETE]
 //	@Security Bearer

--- a/backend/app/api/handlers/v1/v1_ctrl_notifiers.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_notifiers.go
@@ -86,7 +86,6 @@ func (ctrl *V1Controller) HandleUpdateNotifier() errchain.HandlerFunc {
 //	@Summary  Test Notifier
 //	@Tags     Notifiers
 //	@Produce  json
-//	@Param    id path string true "Notifier ID"
 //	@Param url query string true "URL"
 //	@Success  204
 //	@Router   /v1/notifiers/test [POST]


### PR DESCRIPTION
## What type of PR is this?

- bug
- documentation

## What this PR does / why we need it:

_(REQUIRED)_

The generated swagger has some differences from the expected routes. These show up as validation errors in Swagger, and cause ogen-api to fail conversion after converting them to OpenAPI 3.0.

Additionally, this adds a github workflow to validate the generated swagger to prevent regressions.

## Which issue(s) this PR fixes:

_(REQUIRED)_

- [x] Semantic error at paths./v1/items/{id}/attachments.post -- Operations with parameters of "type: file" must include -- "multipart/form-data" in their "consumes" property. Jump to line 1137
- [x] Semantic error at paths./v1/items/{id}/maintenance -- Declared path parameter "id" needs to be defined as a path parameter at either the path or operation level -- Jump to line 1248
- [x] Semantic error at paths./v1/items/import.post -- Operations with parameters of "type: file" must include "multipart/form-data" in their "consumes" property -- Jump to line 1363
- [x] Semantic error at paths./v1/maintenance/{id} -- Declared path parameter "id" needs to be defined as a path parameter at either the path or operation level -- Jump to line 1624
- [x] Semantic error at paths./v1/notifiers/test.post.parameters.0.name -- Path parameter "id" must have the corresponding {id} segment in the "/v1/notifiers/test" path -- Jump to line 1736
- [x] Structural error at paths./v1/users/login.post.parameters.0 -- should NOT have additional properties additionalProperty: example -- Jump to line 1822
- [x] Semantic error at paths./v1/users/login.post.parameters -- Parameters cannot have both a "in: body" and "in: formData", as "formData" _will_ be the body -- Jump to line 1822
- [x] Structural error at paths./v1/users/login.post.parameters.1 -- should NOT have additional properties additionalProperty:example -- Jump to line 1827

## Special notes for your reviewer:

1. Does the Github Workflow automatically generate the swagger files? If not, does that mean I should check it in with this PR?
2. I haven't been able to validate the Github Workflow change. I think github blocks non-members from modify the workflow file to prevent malicious activity.

## Testing

In addition to adding the Github Workflow that validates the schema, I generated the schema using `task -f swag` and copied it to https://editor.swagger.io .  There are no validation errors now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added validation for OpenAPI definition in the build/test workflow.
	- Enhanced item handling API to support file uploads.
	- Updated documentation for maintenance and notifier endpoints to clarify required parameters.

- **Bug Fixes**
	- Improved error handling for file uploads in item import functionality.

- **Documentation**
	- Added example values for `Username` and `Password` fields in the login form.
	- Clarified API documentation regarding required parameters for various endpoints. 

- **Chores**
	- Reorganized and clarified task dependencies and commands in the Taskfile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->