### PR TITLE
fix: sorting for completed and scheduled maintenance entries

### DIFF
--- a/backend/internal/data/repo/repo_maintenance_entry.go
+++ b/backend/internal/data/repo/repo_maintenance_entry.go
@@ -131,7 +131,8 @@ func (r *MaintenanceEntryRepository) GetMaintenanceByItemID(ctx context.Context,
 			item.HasGroupWith(group.IDEQ(groupID)),
 		),
 	)
-	if filters.Status == MaintenanceFilterStatusScheduled {
+	switch filters.Status {
+	case MaintenanceFilterStatusScheduled:
 		query = query.Where(maintenanceentry.Or(
 			maintenanceentry.DateIsNil(),
 			maintenanceentry.DateEQ(time.Time{}),
@@ -141,7 +142,7 @@ func (r *MaintenanceEntryRepository) GetMaintenanceByItemID(ctx context.Context,
 		query = query.Order(
 			maintenanceentry.ByScheduledDate(sql.OrderAsc()),
 		)
-	} else if filters.Status == MaintenanceFilterStatusCompleted {
+	case MaintenanceFilterStatusCompleted:
 		query = query.Where(
 			maintenanceentry.Not(maintenanceentry.Or(
 				maintenanceentry.DateIsNil(),
@@ -152,7 +153,7 @@ func (r *MaintenanceEntryRepository) GetMaintenanceByItemID(ctx context.Context,
 		query = query.Order(
 			maintenanceentry.ByDate(sql.OrderDesc()),
 		)
-	} else {
+	default:
 		// Sort entries by default by scheduled and maintenance date in descending order
 		query = query.Order(
 			maintenanceentry.ByScheduledDate(sql.OrderDesc()),


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Maintenance entries are expected to sorted from closest to the current date to furthest away in time. That means, for scheduled entries the user would expect to see the next entry that will be scheduled first, and for completed entries the user would expect to see the last completed entry first in the list.

## Which issue(s) this PR fixes:

No tracking issue.

## Special notes for your reviewer:

* Completed entries are sorted by descending completion date
* Scheduled entries are sorted by ascending scheduling date
* Selecting both entries shall sort them by scheduling and then completion date in descending order

## Testing

1. Create scheduled and completed maintenance entries on different dates
2. Verify that the sorting matches the expected behavior as specified in the PR description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced sorting capabilities for maintenance entries based on their status in the maintenance management system.
	- Entries can now be sorted by scheduled and completion dates depending on their status. 
	- Improved query logic for retrieving maintenance entries based on filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->