### PR TITLE
feat: display item labels in the details page

### DIFF
--- a/frontend/pages/item/[id]/index.vue
+++ b/frontend/pages/item/[id]/index.vue
@@ -480,6 +480,9 @@
               <h1 class="text-wrap pb-1 text-2xl">
                 {{ item ? item.name : "" }}
               </h1>
+              <div class="flex flex-wrap gap-2 pb-1">
+                <LabelChip v-for="label in item?.labels || []" :key="label.id" :label="label" size="sm" />
+              </div>
               <div class="flex flex-wrap gap-1 text-wrap text-xs">
                 <div>
                   Created


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

This PR adds the asset labels to the item details page, so they can be viewed without having to enter the edition tab.

![homebox_item_labels](https://github.com/user-attachments/assets/cdb9adb7-eb9a-4e4a-bf83-d777d394b85b)

## Which issue(s) this PR fixes:

No issues.

## Special notes for your reviewer:

-

## Testing

1. Create an item with labels
2. Observe that the labels are updated below the item description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new section to display item labels using a `LabelChip` component.
  
- **Bug Fixes**
	- No significant changes to existing logic or functionality; error handling and data fetching mechanisms remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->