### PR TITLE
feat: add button to copy the item URL

### DIFF
--- a/frontend/pages/item/[id]/index.vue
+++ b/frontend/pages/item/[id]/index.vue
@@ -386,6 +386,10 @@
     closeDialog();
   });
 
+  const currentUrl = computed(() => {
+    return window.location.href;
+  });
+
   const currentPath = computed(() => {
     return route.path;
   });
@@ -525,7 +529,10 @@
                 <input v-model="preferences.showEmpty" type="checkbox" class="toggle toggle-primary" />
                 <span class="label-text ml-4"> Show Empty </span>
               </label>
-              <PageQRCode />
+              <div class="space-x-1">
+                <CopyText :text="currentUrl" :icon-size="16" class="btn btn-circle btn-ghost btn-xs" />
+                <PageQRCode />
+              </div>
             </div>
           </template>
           <DetailsSection :details="itemDetails">


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

It can be useful to be able to copy an item's URL (especially from the PWA on mobile devices, where the URL bar is not visible).

## Which issue(s) this PR fixes:

No issues.

## Special notes for your reviewer:

\-

## Testing

Enter the item page for an asset and click the copy button next to the QR code generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a button to copy the current URL, enhancing user interaction.
  - Added a QR code component alongside the copy URL button for easy sharing.

- **Style**
  - Styled the new button as a circular ghost button to indicate its secondary action nature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->