### PR TITLE
FIX: Set SVG logo size to fix logo not showing on Safari

### DIFF
--- a/frontend/components/App/Logo.vue
+++ b/frontend/components/App/Logo.vue
@@ -9,8 +9,8 @@
       stroke-linecap: round;
       stroke-linejoin: round;
       stroke-miterlimit: 5.42683;
-      height: 250px;   /* Set the height directly in the SVG */
-      width: 250px;    /* Set the width directly in the SVG */
+      height: 250px; /* Set the height directly in the SVG */
+      width: 250px; /* Set the width directly in the SVG */
     "
   >
     <path

--- a/frontend/components/App/Logo.vue
+++ b/frontend/components/App/Logo.vue
@@ -3,14 +3,14 @@
     viewBox="0 0 10817 9730"
     xmlns="http://www.w3.org/2000/svg"
     xml:space="preserve"
-    height="250"
-    width="250"
     style="
       fill-rule: evenodd;
       clip-rule: evenodd;
       stroke-linecap: round;
       stroke-linejoin: round;
       stroke-miterlimit: 5.42683;
+      height: 250px;   /* Set the height directly in the SVG */
+      width: 250px;    /* Set the width directly in the SVG */
     "
   >
     <path

--- a/frontend/lib/datelib/datelib.test.ts
+++ b/frontend/lib/datelib/datelib.test.ts
@@ -25,13 +25,19 @@ describe("zeroTime", () => {
 describe("factorRange", () => {
   test("should return a range of dates", () => {
     const [start, end] = factorRange(10);
+
     // Start should be today
     expect(start).toBeInstanceOf(Date);
     expect(start.getFullYear()).toBe(new Date().getFullYear());
 
     // End should be 10 days from now
     expect(end).toBeInstanceOf(Date);
-    expect(end.getFullYear()).toBe(new Date().getFullYear());
+
+    // Set the future date so it works even in late December when the year changes
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 10); // Adds 10 days to the current date
+
+    expect(end.getFullYear()).toBe(futureDate.getFullYear());
   });
 });
 

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -8,13 +8,7 @@ export default defineNuxtConfig({
     transpile: ["vue-i18n"],
   },
 
-  modules: [
-    "@nuxtjs/tailwindcss",
-    "@pinia/nuxt",
-    "@vueuse/nuxt",
-    "@vite-pwa/nuxt",
-    "unplugin-icons/nuxt",
-  ],
+  modules: ["@nuxtjs/tailwindcss", "@pinia/nuxt", "@vueuse/nuxt", "@vite-pwa/nuxt", "unplugin-icons/nuxt"],
 
   nitro: {
     devProxy: {


### PR DESCRIPTION
I hate Safari with a passion. That is all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated the SVG element's dimensions to use CSS pixel values instead of numeric attributes.
- **Tests**
	- Enhanced the test suite for the `factorRange` function to accurately handle year-end transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->