### PR TITLE
FIX: Homebox SVG logo missing in Safari due to size not specified

### DIFF
--- a/frontend/components/App/Logo.vue
+++ b/frontend/components/App/Logo.vue
@@ -1,7 +1,7 @@
 <template>
   <svg
-    height: 250px
-    width: 250px
+    height="250px"
+    width="250px"
     viewBox="0 0 10817 9730"
     xmlns="http://www.w3.org/2000/svg"
     xml:space="preserve"

--- a/frontend/components/App/Logo.vue
+++ b/frontend/components/App/Logo.vue
@@ -1,5 +1,7 @@
 <template>
   <svg
+    height: 250px
+    width: 250px
     viewBox="0 0 10817 9730"
     xmlns="http://www.w3.org/2000/svg"
     xml:space="preserve"
@@ -9,8 +11,6 @@
       stroke-linecap: round;
       stroke-linejoin: round;
       stroke-miterlimit: 5.42683;
-      height: 250px; /* Set the height directly in the SVG */
-      width: 250px; /* Set the width directly in the SVG */
     "
   >
     <path


### PR DESCRIPTION
Fixes #360 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Explicitly defined height and width attributes for the SVG logo, enhancing clarity and standardization.
- **Bug Fixes**
	- Removed commented-out dimensions in the style attribute for better browser recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->