### PR TITLE
Remove Logo size

### DIFF
--- a/frontend/components/App/Logo.vue
+++ b/frontend/components/App/Logo.vue
@@ -1,7 +1,5 @@
 <template>
   <svg
-    height="76px"
-    width="48px"
     viewBox="0 0 10817 9730"
     xmlns="http://www.w3.org/2000/svg"
     xml:space="preserve"


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Due to misplaced logo components, reverting change to add sizing whilst further investigation is conducted.

## Which issue(s) this PR fixes:

Revert fix for Safari logo not showing due to placement issues of the logo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced scalability of the logo by removing fixed height and width attributes from the SVG.
  
- **Bug Fixes**
	- Ensured the logo maintains its design and functionality while allowing for better responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->