### PR TITLE
Update Docs to rectify invalid environment variable for max file upload

### DIFF
--- a/docs/en/configure-homebox.md
+++ b/docs/en/configure-homebox.md
@@ -4,27 +4,27 @@
 
 | Variable                             | Default                | Description                                                                        |
 | ------------------------------------ | ---------------------- | ---------------------------------------------------------------------------------- |
-| HBOX_MODE                            | `production`             | application mode used for runtime behavior  can be one of: `development`, `production` |
+| HBOX_MODE                            | `production`           | application mode used for runtime behavior  can be one of: `development`, `production` |
 | HBOX_WEB_PORT                        | 7745                   | port to run the web server on, if you're using docker do not change this           |
 | HBOX_WEB_HOST                        |                        | host to run the web server on, if you're using docker do not change this           |
 | HBOX_OPTIONS_ALLOW_REGISTRATION      | true                   | allow users to register themselves                                                 |
 | HBOX_OPTIONS_AUTO_INCREMENT_ASSET_ID | true                   | auto-increments the asset_id field for new items                                   |
 | HBOX_OPTIONS_CURRENCY_CONFIG         |                        | json configuration file containing additional currencie                            |
-| HBOX_WEB_MAX_UPLOAD_SIZE             | 10                     | maximum file upload size supported in MB                                           |
+| HBOX_WEB_MAX_FILE_UPLOAD             | 10                     | maximum file upload size supported in MB                                           |
 | HBOX_WEB_READ_TIMEOUT                | 10s                    | Read timeout of HTTP sever                                                         |
 | HBOX_WEB_WRITE_TIMEOUT               | 10s                    | Write timeout of HTTP server                                                       |
 | HBOX_WEB_IDLE_TIMEOUT                | 30s                    | Idle timeout of HTTP server                                                        |
 | HBOX_STORAGE_DATA                    | /data/                 | path to the data directory, do not change this if you're using docker              |
 | HBOX_STORAGE_SQLITE_URL              | /data/homebox.db?_fk=1 | sqlite database url, if you're using docker do not change this                     |
-| HBOX_LOG_LEVEL                       | `info`                   | log level to use, can be one of `trace`, `debug`, `info`, `warn`, `error`, `critical`         |
-| HBOX_LOG_FORMAT                      | `text`                   | log format to use, can be one of: `text`, `json`                                       |
+| HBOX_LOG_LEVEL                       | `info`                 | log level to use, can be one of `trace`, `debug`, `info`, `warn`, `error`, `critical`         |
+| HBOX_LOG_FORMAT                      | `text`                 | log format to use, can be one of: `text`, `json`                                       |
 | HBOX_MAILER_HOST                     |                        | email host to use, if not set no email provider will be used                       |
 | HBOX_MAILER_PORT                     | 587                    | email port to use                                                                  |
 | HBOX_MAILER_USERNAME                 |                        | email user to use                                                                  |
 | HBOX_MAILER_PASSWORD                 |                        | email password to use                                                              |
 | HBOX_MAILER_FROM                     |                        | email from address to use                                                          |
 | HBOX_SWAGGER_HOST                    | 7745                   | swagger host to use, if not set swagger will be disabled                           |
-| HBOX_SWAGGER_SCHEMA                  | `http`                   | swagger schema to use, can be one of: `http`, `https`                                  |
+| HBOX_SWAGGER_SCHEMA                  | `http`                 | swagger schema to use, can be one of: `http`, `https`                                  |
 
 ::: tip "CLI Arguments"
 If you're deploying without docker you can use command line arguments to configure the application. Run `homebox --help` for more information.
@@ -36,7 +36,7 @@ OPTIONS
 --mode/$HBOX_MODE                                                        <string>  (default: development)
 --web-port/$HBOX_WEB_PORT                                                <string>  (default: 7745)
 --web-host/$HBOX_WEB_HOST                                                <string>
---web-max-upload-size/$HBOX_WEB_MAX_UPLOAD_SIZE                          <int>     (default: 10)
+--web-max-upload-size/$HBOX_WEB_MAX_FILE_UPLOAD                          <int>     (default: 10)
 --storage-data/$HBOX_STORAGE_DATA                                        <string>  (default: ./.data)
 --storage-sqlite-url/$HBOX_STORAGE_SQLITE_URL                            <string>  (default: ./.data/homebox.db?_fk=1)
 --log-level/$HBOX_LOG_LEVEL                                              <string>  (default: info)


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Update Docs to rectify invalid environment variable for max file upload

## Which issue(s) this PR fixes:

Fixes #419 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated configuration documentation for Homebox
	- Renamed environment variable `HBOX_WEB_MAX_UPLOAD_SIZE` to `HBOX_WEB_MAX_FILE_UPLOAD`
	- Updated corresponding command line argument to match new environment variable name
	- Improved formatting consistency for default values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->