### PR TITLE
When a location is requested by ID, sort its children location by name

### DIFF
--- a/backend/internal/data/repo/repo_locations.go
+++ b/backend/internal/data/repo/repo_locations.go
@@ -164,7 +164,9 @@ func (r *LocationRepository) getOne(ctx context.Context, where ...predicate.Loca
 		Where(where...).
 		WithGroup().
 		WithParent().
-		WithChildren().
+		WithChildren(func(lq *ent.LocationQuery) {
+			lq.Order(location.ByName())
+		}).
 		Only(ctx))
 }
 


### PR DESCRIPTION
## What type of PR is this?

- bug
- feature

## What this PR does / why we need it:

It sorts the results of requests of locations by ID, it sorts the child location. This way it appears sorted by name in the user interface as almost everything is sorted by name. It helps to find and navigate through locations making the order predictable. 

## Which issue(s) this PR fixes:

Fixes #412

## Testing

Access a location and add children locations to it, no matter the order the locations are inserted it needs to appear sorted by name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated location retrieval method to order child locations by name

- **Bug Fixes**
	- Improved method signature to provide more consistent error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->