### PR TITLE
fix: #413 text not wrapping in location names when in location page

### DIFF
--- a/frontend/pages/location/[id].vue
+++ b/frontend/pages/location/[id].vue
@@ -142,10 +142,10 @@
             <div>
               <div v-if="location?.parent" class="breadcrumbs py-0 text-sm">
                 <ul class="text-base-content/70">
-                  <li>
+                  <li class="text-wrap">
                     <NuxtLink :to="`/location/${location.parent.id}`"> {{ location.parent.name }}</NuxtLink>
                   </li>
-                  <li>{{ location.name }}</li>
+                  <li class="text-wrap">{{ location.name }}</li>
                 </ul>
               </div>
               <h1 class="flex items-center gap-3 pb-1 text-2xl">


### PR DESCRIPTION
Just added some text-wrap classes in the user interface that was forgotten inside the location page, the items page is already fixed.

## What type of PR is this?

- bug

## What this PR does / why we need it:

Fixes the UI in small screen devices like mobile devices when navigating through locations.

## Which issue(s) this PR fixes:

Fixes #413

## Testing

Conduct test like described in #413. The location page should wrap the location names like the items screen does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated breadcrumbs to improve text wrapping for location names
	- Added `text-wrap` class to location breadcrumb elements for better text rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->