### PR TITLE
Store times using a more standard format

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
                 "HBOX_LOG_LEVEL": "debug",
                 "HBOX_DEBUG_ENABLED": "true",
                 "HBOX_STORAGE_DATA": "${workspaceRoot}/backend/.data",
-                "HBOX_STORAGE_SQLITE_URL": "${workspaceRoot}/backend/.data/homebox.db?_fk=1"
+                "HBOX_STORAGE_SQLITE_URL": "${workspaceRoot}/backend/.data/homebox.db?_fk=1&_time_format=sqlite"
             },
             "console": "integratedTerminal",
         },

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 FROM --platform=$TARGETPLATFORM alpine:latest
 ENV HBOX_MODE=production
 ENV HBOX_STORAGE_DATA=/data/
-ENV HBOX_STORAGE_SQLITE_URL=/data/homebox.db?_pragma=busy_timeout=2000&_pragma=journal_mode=WAL&_fk=1
+ENV HBOX_STORAGE_SQLITE_URL=/data/homebox.db?_pragma=busy_timeout=2000&_pragma=journal_mode=WAL&_fk=1&_time_format=sqlite
 
 # Install necessary runtime dependencies
 RUN apk --no-cache add ca-certificates wget

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -43,7 +43,7 @@ FROM gcr.io/distroless/static:latest
 
 ENV HBOX_MODE=production
 ENV HBOX_STORAGE_DATA=/data/
-ENV HBOX_STORAGE_SQLITE_URL=/data/homebox.db?_fk=1
+ENV HBOX_STORAGE_SQLITE_URL=/data/homebox.db?_fk=1&_time_format=sqlite
 
 # Copy the binary and data directory, change ownership
 COPY --from=builder --chown=nonroot /go/bin/api /app

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,7 +2,7 @@ version: "3"
 
 env:
   HBOX_LOG_LEVEL: debug
-  HBOX_STORAGE_SQLITE_URL: .data/homebox.db?_pragma=busy_timeout=1000&_pragma=journal_mode=WAL&_fk=1
+  HBOX_STORAGE_SQLITE_URL: .data/homebox.db?_pragma=busy_timeout=1000&_pragma=journal_mode=WAL&_fk=1&_time_format=sqlite
   HBOX_OPTIONS_ALLOW_REGISTRATION: true
   UNSAFE_DISABLE_PASSWORD_PROJECTION: "yes_i_am_sure"
 tasks:

--- a/backend/app/tools/migrations/main.go
+++ b/backend/app/tools/migrations/main.go
@@ -36,7 +36,7 @@ func main() {
 	}
 
 	// Generate migrations using Atlas support for MySQL (note the Ent dialect option passed above).
-	err = migrate.NamedDiff(ctx, "sqlite://.data/homebox.migration.db?_fk=1", os.Args[1], opts...)
+	err = migrate.NamedDiff(ctx, "sqlite://.data/homebox.migration.db?_fk=1&_time_format=sqlite", os.Args[1], opts...)
 	if err != nil {
 		log.Fatalf("failed generating migration file: %v", err)
 	}

--- a/backend/internal/core/services/main_test.go
+++ b/backend/internal/core/services/main_test.go
@@ -50,7 +50,7 @@ func bootstrap() {
 }
 
 func MainNoExit(m *testing.M) int {
-	client, err := ent.Open("sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	client, err := ent.Open("sqlite3", "file:ent?mode=memory&cache=shared&_fk=1&_time_format=sqlite")
 	if err != nil {
 		log.Fatalf("failed opening connection to sqlite: %v", err)
 	}

--- a/backend/internal/data/repo/main_test.go
+++ b/backend/internal/data/repo/main_test.go
@@ -40,7 +40,7 @@ func bootstrap() {
 }
 
 func MainNoExit(m *testing.M) int {
-	client, err := ent.Open("sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	client, err := ent.Open("sqlite3", "file:ent?mode=memory&cache=shared&_fk=1&_time_format=sqlite")
 	if err != nil {
 		log.Fatalf("failed opening connection to sqlite: %v", err)
 	}

--- a/backend/internal/sys/config/conf_database.go
+++ b/backend/internal/sys/config/conf_database.go
@@ -7,5 +7,5 @@ const (
 type Storage struct {
 	// Data is the path to the root directory
 	Data      string `yaml:"data"       conf:"default:./.data"`
-	SqliteURL string `yaml:"sqlite-url" conf:"default:./.data/homebox.db?_pragma=busy_timeout=999&_pragma=journal_mode=WAL&_fk=1"`
+	SqliteURL string `yaml:"sqlite-url" conf:"default:./.data/homebox.db?_pragma=busy_timeout=999&_pragma=journal_mode=WAL&_fk=1&_time_format=sqlite"`
 }

--- a/docs/en/configure-homebox.md
+++ b/docs/en/configure-homebox.md
@@ -2,29 +2,30 @@
 
 ## Env Variables & Configuration
 
-| Variable                             | Default                | Description                                                                        |
-| ------------------------------------ | ---------------------- | ---------------------------------------------------------------------------------- |
-| HBOX_MODE                            | `production`           | application mode used for runtime behavior  can be one of: `development`, `production` |
-| HBOX_WEB_PORT                        | 7745                   | port to run the web server on, if you're using docker do not change this           |
-| HBOX_WEB_HOST                        |                        | host to run the web server on, if you're using docker do not change this           |
-| HBOX_OPTIONS_ALLOW_REGISTRATION      | true                   | allow users to register themselves                                                 |
-| HBOX_OPTIONS_AUTO_INCREMENT_ASSET_ID | true                   | auto-increments the asset_id field for new items                                   |
-| HBOX_OPTIONS_CURRENCY_CONFIG         |                        | json configuration file containing additional currencie                            |
-| HBOX_WEB_MAX_FILE_UPLOAD             | 10                     | maximum file upload size supported in MB                                           |
-| HBOX_WEB_READ_TIMEOUT                | 10s                    | Read timeout of HTTP sever                                                         |
-| HBOX_WEB_WRITE_TIMEOUT               | 10s                    | Write timeout of HTTP server                                                       |
-| HBOX_WEB_IDLE_TIMEOUT                | 30s                    | Idle timeout of HTTP server                                                        |
-| HBOX_STORAGE_DATA                    | /data/                 | path to the data directory, do not change this if you're using docker              |
-| HBOX_STORAGE_SQLITE_URL              | /data/homebox.db?_fk=1 | sqlite database url, if you're using docker do not change this                     |
-| HBOX_LOG_LEVEL                       | `info`                 | log level to use, can be one of `trace`, `debug`, `info`, `warn`, `error`, `critical`         |
-| HBOX_LOG_FORMAT                      | `text`                 | log format to use, can be one of: `text`, `json`                                       |
-| HBOX_MAILER_HOST                     |                        | email host to use, if not set no email provider will be used                       |
-| HBOX_MAILER_PORT                     | 587                    | email port to use                                                                  |
-| HBOX_MAILER_USERNAME                 |                        | email user to use                                                                  |
-| HBOX_MAILER_PASSWORD                 |                        | email password to use                                                              |
-| HBOX_MAILER_FROM                     |                        | email from address to use                                                          |
-| HBOX_SWAGGER_HOST                    | 7745                   | swagger host to use, if not set swagger will be disabled                           |
-| HBOX_SWAGGER_SCHEMA                  | `http`                 | swagger schema to use, can be one of: `http`, `https`                                  |
+| Variable                             | Default                                    | Description                                                                            |
+|--------------------------------------|--------------------------------------------|----------------------------------------------------------------------------------------|
+| HBOX_MODE                            | `production`                               | application mode used for runtime behavior  can be one of: `development`, `production` |
+| HBOX_WEB_PORT                        | 7745                                       | port to run the web server on, if you're using docker do not change this               |
+| HBOX_WEB_HOST                        |                                            | host to run the web server on, if you're using docker do not change this               |
+| HBOX_OPTIONS_ALLOW_REGISTRATION      | true                                       | allow users to register themselves                                                     |
+| HBOX_OPTIONS_AUTO_INCREMENT_ASSET_ID | true                                       | auto-increments the asset_id field for new items                                       |
+| HBOX_OPTIONS_CURRENCY_CONFIG         |                                            | json configuration file containing additional currencie                                |
+| HBOX_WEB_MAX_FILE_UPLOAD             | 10                                         | maximum file upload size supported in MB                                               |
+| HBOX_WEB_READ_TIMEOUT                | 10s                                        | Read timeout of HTTP sever                                                             |
+| HBOX_WEB_WRITE_TIMEOUT               | 10s                                        | Write timeout of HTTP server                                                           |
+| HBOX_WEB_IDLE_TIMEOUT                | 30s                                        | Idle timeout of HTTP server                                                            |
+| HBOX_STORAGE_DATA                    | /data/                                     | path to the data directory, do not change this if you're using docker                  |
+| HBOX_STORAGE_SQLITE_URL              | /data/homebox.db?_fk=1&_time_format=sqlite | sqlite database url, if you're using docker do not change this                         |
+| HBOX_LOG_LEVEL                       | `info`                                     | log level to use, can be one of `trace`, `debug`, `info`, `warn`, `error`, `critical`  |
+| HBOX_LOG_FORMAT                      | `text`                                     | log format to use, can be one of: `text`, `json`                                       |
+| HBOX_MAILER_HOST                     |                                            | email host to use, if not set no email provider will be used                           |
+| HBOX_MAILER_PORT                     | 587                                        | email port to use                                                                      |
+| HBOX_MAILER_USERNAME                 |                                            | email user to use                                                                      |
+| HBOX_MAILER_PASSWORD                 |                                            | email password to use                                                                  |
+| HBOX_MAILER_FROM                     |                                            | email from address to use                                                              |
+| HBOX_SWAGGER_HOST                    | 7745                                       | swagger host to use, if not set swagger will be disabled                               |
+| HBOX_SWAGGER_SCHEMA                  | `http`                                     | swagger schema to use, can be one of: `http`, `https`                                  |
+
 
 ::: tip "CLI Arguments"
 If you're deploying without docker you can use command line arguments to configure the application. Run `homebox --help` for more information.
@@ -38,7 +39,7 @@ OPTIONS
 --web-host/$HBOX_WEB_HOST                                                <string>
 --web-max-file-upload/$HBOX_WEB_MAX_FILE_UPLOAD                          <int>     (default: 10)
 --storage-data/$HBOX_STORAGE_DATA                                        <string>  (default: ./.data)
---storage-sqlite-url/$HBOX_STORAGE_SQLITE_URL                            <string>  (default: ./.data/homebox.db?_fk=1)
+--storage-sqlite-url/$HBOX_STORAGE_SQLITE_URL                            <string>  (default: ./.data/homebox.db?_fk=1&_time_format=sqlite)
 --log-level/$HBOX_LOG_LEVEL                                              <string>  (default: info)
 --log-format/$HBOX_LOG_FORMAT                                            <string>  (default: text)
 --mailer-host/$HBOX_MAILER_HOST                                          <string>


### PR DESCRIPTION
this results in times being stored more sensibly (i.e. a format supported by the sqlite date and time functions). See https://pkg.go.dev/modernc.org/sqlite#Driver.OpenA

Think `2024-06-10 10:31:25.491169542+10:00` opposed to `2023-10-04 20:27:15.365730552 +1100 AEDT m=+245.850218253`

It doesn't update existing values and everything works fine with the old format and new format (those two times are pulled from an actual item in my database) 

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- bug
- cleanup

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->
Semantically, storing times as something the database system functions recognise as times is beneficial. 
It is also better for database compatibility (I personally interface with the homebox sqlite database via a postgres fdw)

If anyone really uses or needs the monotonic duration i'll eat my hat. 

## Which issue(s) this PR fixes:

_(REQUIRED)_

None. This is just a bugbear of mine. 

## Special notes for your reviewer:

I've considered adding some sort of process to update existing values, however given both formats can exist in harmony and it's something the user never sees, I've decided against it. 


## Testing

_(fill-in or delete this section)_

I've been running this config setting on my private fork for 6+ months without any issues. 

<!--
  Describe how you tested this change.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration Updates**
    - Added `_time_format=sqlite` parameter to SQLite database connection strings across multiple configuration files
    - Updated environment variable `HBOX_STORAGE_SQLITE_URL` in Dockerfile, Dockerfile.rootless, and Taskfile.yml
    - Modified documentation to reflect new SQLite URL configuration

- **Documentation**
    - Updated configuration guide to include new time formatting parameter
<!-- end of auto-generated comment: release notes by coderabbit.ai -->