### PR TITLE
Fix problem of broken navigation text in Chinese and set the correct value of html lang

### DIFF
--- a/frontend/app.vue
+++ b/frontend/app.vue
@@ -1,6 +1,6 @@
 <template>
   <NuxtLayout>
-    <Html lang="en" :data-theme="theme || 'homebox'" />
+    <Html :lang="locale" :data-theme="theme || 'homebox'" />
     <Link rel="icon" type="image/svg" href="/favicon.svg"></Link>
     <Link rel="apple-touch-icon" href="/apple-touch-icon.png" size="180x180" />
     <Link rel="mask-icon" href="/mask-icon.svg" color="#5b7f67" />
@@ -11,5 +11,9 @@
 </template>
 
 <script lang="ts" setup>
+  import { useI18n } from "vue-i18n";
+
   const { theme } = useTheme();
+
+  const { locale } = useI18n();
 </script>

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -79,6 +79,7 @@
                     :to="n.to"
                     :class="{
                       'bg-secondary text-secondary-content': n.active?.value,
+                      'text-nowrap': typeof locale === 'string' && locale.startsWith('zh-'),
                     }"
                   >
                     <component :is="n.icon" class="mr-4 size-6" />
@@ -114,7 +115,7 @@
   import MdiMenu from "~icons/mdi/menu";
   import MdiPlus from "~icons/mdi/plus";
 
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const username = computed(() => authCtx.user?.name || "User");
 
   const preferences = useViewPreferences();


### PR DESCRIPTION
## What type of PR is this?
- bug
- feature

## What this PR does / why we need it:

1. When language is set to Chinese, text of sidebar navigation will be broken and displayed on a new line. This is caused by browser's CJK typesetting. Therefore, when locale is Chinese, add `text-nowrap` to sidebar text to avoid text being broken and make it display normally.
  Original
![localhost_3000_home](https://github.com/user-attachments/assets/9b022530-1279-4d62-89fb-222882250e5d)
  After this fixed
![localhost_3000_home (1)](https://github.com/user-attachments/assets/4ab98d0d-feed-496f-bc5a-d9ba7c65090c)

2. set `lang` value of `html` to current vue-i18n's locale value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced internationalization support by dynamically setting the HTML language attribute based on the current locale.
  - Added locale-based conditional styling for navigation elements.

- **Refactor**
  - Updated internationalization hook to include locale information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->