### PR TITLE
Add LocationID for API Item Patch Command, to change fast the Location ID 

### DIFF
--- a/backend/internal/data/repo/repo_items.go
+++ b/backend/internal/data/repo/repo_items.go
@@ -110,6 +110,7 @@ type (
 	ItemPatch struct {
 		ID        uuid.UUID `json:"id"`
 		Quantity  *int      `json:"quantity,omitempty" extensions:"x-nullable,x-omitempty"`
+		LocationID uuid.UUID   `json:"locationId"`
 		ImportRef *string   `json:"-,omitempty"        extensions:"x-nullable,x-omitempty"`
 	}
 
@@ -764,6 +765,10 @@ func (e *ItemsRepository) Patch(ctx context.Context, gid, id uuid.UUID, data Ite
 
 	if data.Quantity != nil {
 		q.SetQuantity(*data.Quantity)
+	}
+
+	if data.locationId != nil {
+		q.SetLocationID(*data.LocationID)
 	}
 
 	e.publishMutationEvent(gid)

--- a/backend/internal/data/repo/repo_items.go
+++ b/backend/internal/data/repo/repo_items.go
@@ -110,7 +110,7 @@ type (
 	ItemPatch struct {
 		ID        uuid.UUID `json:"id"`
 		Quantity  *int      `json:"quantity,omitempty" extensions:"x-nullable,x-omitempty"`
-		LocationID uuid.UUID   `json:"locationId"`
+		LocationID *uuid.UUID   `json:"locationId"`
 		ImportRef *string   `json:"-,omitempty"        extensions:"x-nullable,x-omitempty"`
 	}
 
@@ -767,7 +767,7 @@ func (e *ItemsRepository) Patch(ctx context.Context, gid, id uuid.UUID, data Ite
 		q.SetQuantity(*data.Quantity)
 	}
 
-	if data.locationId != nil {
+	if data.LocationID != nil {
 		q.SetLocationID(*data.LocationID)
 	}
 


### PR DESCRIPTION


## What type of PR is this?

- feature

## What this PR does / why we need it:

With this code you can "Patch" a item by knowing ItemID and new LocationID

Patch is now usable for quantity und locationID