### PR TITLE
Fix flash of wrong theme on initial UI load

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -20,6 +20,12 @@ export default defineNuxtConfig({
     },
   },
 
+  app: {
+    head: {
+      script: [{ src: "/set-theme.js" }],
+    },
+  },
+
   css: ["@/assets/css/main.css"],
 
   pwa: {

--- a/frontend/public/set-theme.js
+++ b/frontend/public/set-theme.js
@@ -1,4 +1,9 @@
 try {
-    const theme = JSON.parse(localStorage.getItem("homebox/preferences/location")).theme
-    if (theme) document.documentElement.setAttribute("data-theme", theme)
-} catch(e) {/* */}
+  console.log('Setting theme');
+  const theme = JSON.parse(
+    localStorage.getItem('homebox/preferences/location')
+  ).theme;
+  if (theme) document.documentElement.setAttribute('data-theme', theme);
+} catch (e) {
+  console.error('Failed to set theme', e);
+}

--- a/frontend/public/set-theme.js
+++ b/frontend/public/set-theme.js
@@ -1,0 +1,4 @@
+try {
+    const theme = JSON.parse(localStorage.getItem("homebox/preferences/location")).theme
+    if (theme) document.documentElement.setAttribute("data-theme", theme)
+} catch(e) {/* */}


### PR DESCRIPTION

## What type of PR is this?

- bug

## What this PR does / why we need it:

On load of UI the `data-theme` attribute is not yet set, causing the wrong UI theme to "flash" before the correct theme is loaded from local storage and applied.

This effect can be observed on for example the demo instance, by paying attention to a primary button which, when reloading the page, appears purple for the fraction of a second before turning green.

This PR fixes this common problem by adding a small inline script `set-theme.js` to the `head` of the page that sets the theme.

- add `set-theme.js` script that tries to read the theme from local storage and apply it as `data-theme` to the `html` tag
- add script inline to document `head` for it to run before the entire nuxt behemoth sets the theme seconds after the initial load

## Which issue(s) this PR fixes:

None.

## Testing

Tested locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added theme persistence mechanism that allows users to save and restore their preferred theme between sessions.
	- Implemented client-side theme preference loading from local storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->