### PR TITLE
Fix lazy loading of item images not working

### DIFF
--- a/frontend/components/Item/Card.vue
+++ b/frontend/components/Item/Card.vue
@@ -4,6 +4,7 @@
       <img
         v-if="imageUrl"
         class="h-[200px] w-full rounded-t border-gray-300 object-cover shadow-sm"
+        loading="lazy"
         :src="imageUrl"
         alt=""
       />
@@ -12,7 +13,6 @@
           v-if="item.location"
           class="badge rounded-md text-sm shadow-md hover:link"
           :to="`/location/${item.location.id}`"
-          loading="lazy"
         >
           {{ locationString }}
         </NuxtLink>


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

This PR fixes the lazy loading of item images using the loading attribute of the image tag, so, using the HTML language instead of Javascript.

## Which issue(s) this PR fixes:

Fixes #482

## Special notes for your reviewer:

The loading="lazy" attribute already existed in the interface but was added to the badge (an \<a> tag), but it is an attribute of the \<image> tag. So it was moved to the correct tag.

It was tested in Chrome 132.0.6834.83 64 bits for Linux and in Firefox 127.0.2 64 bits for Linux. For it to work in Firefox the "loading" attribute needs to be define before the "src" attribute. Chrome have a different behavior loading in advance images that are placed a little further outside the view pane, but with lazy loading it still doesn't load all images from the page, still saving resources. Anyway, if any browser or version doesn't implement the loading attribute it will simply not lazy load the images. How it was before, it was defined but not working at all.

## Testing

See issue #482. It is suggested to create a lot of items with images and test it on the search page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
	- Added lazy loading for images to improve page load efficiency
	- Optimized image rendering by deferring off-screen image loading

<!-- end of auto-generated comment: release notes by coderabbit.ai -->