### PR TITLE
Fix file upload size env in installation.md

### DIFF
--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -48,7 +48,7 @@ services:
     environment:
     - HBOX_LOG_LEVEL=info
     - HBOX_LOG_FORMAT=text
-    - HBOX_WEB_MAX_UPLOAD_SIZE=10
+    - HBOX_WEB_MAX_FILE_UPLOAD=10
     volumes:
       - homebox-data:/data/
     ports:


### PR DESCRIPTION
## What type of PR is this?

- documentation
- 
## What this PR does / why we need it:

I just set up the docker container with the docker-compose and noticed the old way of setting the max file upload size which was changed in #420 

## Which issue(s) this PR fixes:

Missed change from #420 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised the installation guide to use updated environment variable terminology for clarity.
  - Improved text file formatting by ensuring a standard trailing newline for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->