### PR TITLE
Fix labelmaker wrong defaults in docs

### DIFF
--- a/docs/en/configure-homebox.md
+++ b/docs/en/configure-homebox.md
@@ -28,8 +28,8 @@
 | HBOX_OPTIONS_CHECK_GITHUB_RELEASE    | true                                       | check for new github releases                                                          |
 | HBOX_LABEL_MAKER_WIDTH               | 526                                        | width for generated labels in pixels                                                   |
 | HBOX_LABEL_MAKER_HEIGHT              | 200                                        | height for generated labels in pixels                                                  |
-| HBOX_LABEL_MAKER_PADDING             | 8                                          | space between elements on label                                                        |
-| HBOX_LABEL_MAKER_MARGIN              | 8                                          | space between the label content and edges of the label                                 |
+| HBOX_LABEL_MAKER_PADDING             | 32                                         | space between elements on label                                                        |
+| HBOX_LABEL_MAKER_MARGIN              | 32                                         | space between the label content and edges of the label                                 |
 | HBOX_LABEL_MAKER_FONT_SIZE           | 32.0                                       | the size of the labels font                                                            |
 | HBOX_LABEL_MAKER_PRINT_COMMAND       |                                            | the command to use for printing labels. if empty, label printing is disabled. `{{.FileName}}` in the command will be replaced with the png filename of the label |
 
@@ -64,8 +64,8 @@ OPTIONS
 --options-check-github-release/$HBOX_OPTIONS_CHECK_GITHUB_RELEASE        <bool>    (default: true)
 --label-maker-width/$HBOX_LABEL_MAKER_WIDTH                              <int>     (default: 526)
 --label-maker-height/$HBOX_LABEL_MAKER_HEIGHT                            <int>     (default: 200)
---label-maker-padding/$HBOX_LABEL_MAKER_PADDING                          <int>     (default: 8)
---label-maker-margin/$HBOX_LABEL_MAKER_MARGIN                            <int>       (default: 8)
+--label-maker-padding/$HBOX_LABEL_MAKER_PADDING                          <int>     (default: 32)
+--label-maker-margin/$HBOX_LABEL_MAKER_MARGIN                            <int>       (default: 32)
 --label-maker-font-size/$HBOX_LABEL_MAKER_FONT_SIZE                      <float>   (default: 32.0)
 --label-maker-print-command/$HBOX_LABEL_MAKER_PRINT_COMMAND              <string>
 --help/-h    display this help message


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

`LabelMakerConf` has different defaults hardcoded. This fixes the docs.

## Which issue(s) this PR fixes:

Followup to https://github.com/sysadminsmedia/homebox/pull/498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
	- Updated the Homebox configuration documentation to reflect enhanced default label spacing, offering increased padding and margin for a more balanced and visually appealing label layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->