### PR TITLE
Fix labelmaker font size mixed up

### DIFF
--- a/backend/pkgs/labelmaker/labelmaker.go
+++ b/backend/pkgs/labelmaker/labelmaker.go
@@ -167,11 +167,11 @@ func GenerateLabel(w io.Writer, params *GenerateParameters) error {
 	}
 
 	regularFace := truetype.NewFace(regularFont, &truetype.Options{
-		Size: params.TitleFontSize,
+		Size: params.DescriptionFontSize,
 		DPI:  params.Dpi,
 	})
 	boldFace := truetype.NewFace(boldFont, &truetype.Options{
-		Size: params.DescriptionFontSize,
+		Size: params.TitleFontSize,
 		DPI:  params.Dpi,
 	})
 


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Some change in #498 scrambled up the font sizes. I dont know how it was ment in the end, but the font sizes are used inconsistently. @jake-walker you may remember. This bug hinders expanding the text within its frame.

I am not sure if this is the correct fix for this issue or if `NewFace` was correct and everything else has to change.

Without Fix:
![label-000-005(33)](https://github.com/user-attachments/assets/7ae74342-4bc3-456a-8aa6-6b11821a2d59)

With this Fix:
![label-000-005(32)](https://github.com/user-attachments/assets/6ec5ad54-728e-4b57-85c7-01b8eea284e8)

## Which issue(s) this PR fixes:

Followup to https://github.com/sysadminsmedia/homebox/pull/498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the label display by swapping the font sizes for title and description text. This change refines text hierarchy and improves overall readability on generated labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->