### PR TITLE
Change the width of the items quantity badge to not be fixed

### DIFF
--- a/frontend/components/Item/Card.vue
+++ b/frontend/components/Item/Card.vue
@@ -30,7 +30,7 @@
         </div>
         <div class="grow"></div>
         <div class="tooltip" data-tip="Quantity">
-          <span class="badge badge-primary badge-sm size-5 text-xs">
+          <span class="badge badge-primary badge-sm h-5 text-xs">
             {{ item.quantity }}
           </span>
         </div>


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- bug

## What this PR does / why we need it:

Changes the width of the badge that shows the items quantity to not be fixed, the height was maintained the same size.

![Captura de tela de 2025-02-14 15-40-30](https://github.com/user-attachments/assets/51167037-1711-459f-af9f-60645fefb521)
Original look

![Captura de tela de 2025-02-14 15-41-19](https://github.com/user-attachments/assets/a174d3f4-88e8-4f17-aac5-c7be4e2bdee1)
Fixed look

## Which issue(s) this PR fixes:

Fixes #518

## Special notes for your reviewer:

The CSS class that defined the badge size was changed from size-5 (that defines width and height at the same time) to h-5 (the height was maintained the same size and the width will autosize). The badge will not be a perfect circle anymore and the width will autosize accordingly with the content. 

## Testing

Just create some items and change its quantity to bigger numbers like 100 and 1000.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the visual presentation of item quantity displays on cards for a refined look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->