### PR TITLE
Fix the parent location being undefined when set while the locationStore is empty

### DIFF
--- a/frontend/pages/location/[id].vue
+++ b/frontend/pages/location/[id].vue
@@ -27,6 +27,10 @@
       parent.value = locations.value.find(l => l.id === data.parent.id);
     }
 
+    if (parent.value === undefined) {
+      parent.value = data.parent;
+    }
+
     return data;
   });
 


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Fixes the parent location being empty in the Update Location modal dialog. It happens mostly when the URL of the location is open directly (a label being scanned outside the system, as theres now a feature to scan labels from the system) or opening a new tab and the code tries to query the locationStore while it is still being loaded. This will only happen with databases with a lot of data and cannot be replicated in the demo.

## Which issue(s) this PR fixes:

Fixes #488

## Special notes for your reviewer:

With the new scanner feature this bug will be less noticed, but will still happen. Instead of stay waiting for the locationStore to initialize, as the code already query the database to get the current location using its id and then the parent locations id using that response, and the locationStore is needed to fill the options to select in the update modal dialog, Im just testing if the parent value is still undefined (meaning the locationStore was accessed when still empty) and set the parent with the parent returned by the previous query. That means that the locationStore is needed but it is not needed to access it inside the function that sets the parent because the response is already there, and in the time the user opens the update modal dialog the locationStore will already be loaded.

## Testing

The error only happens in databases with a lot of data, I was not able to replicate in the demo that has only a few items and locations. In a reasonably big database, keep loading a location URL in a new browser tab before and after the patch. Without the patch it will randomly fail to show the parent location in the update modal dialog, with this patch this will not happen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the location details page to always display accurate parent location information. This update ensures that even if the primary data retrieval for the parent fails, a fallback value is used, providing a more reliable and consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->