### PR TITLE
Try to choose a media device that have the word "back" in it, if it doesn't find falls back to the first

### DIFF
--- a/frontend/pages/scanner.vue
+++ b/frontend/pages/scanner.vue
@@ -34,7 +34,14 @@
       sources.value = devices;
 
       if (devices.length > 0) {
-        selectedSource.value = devices[0].deviceId;
+        for (let i = 0; i < devices.length; i++) {
+          if (devices[i].label.toLowerCase().includes("back")) {
+            selectedSource.value = devices[i].deviceId;
+          }
+        }
+        if (!selectedSource.value) {
+          selectedSource.value = devices[0].deviceId;
+        }
       } else {
         errorMessage.value = t("scanner.no_sources");
       }


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

The scanner feature always select the first media device, in some mobile devices this is the front camera and it keeps pointing to the users face until changed.

## Which issue(s) this PR fixes:

Fixes #572

## Special notes for your reviewer:

Im testing the labels of the current media devices and choosing the first that have a "back" word in it, meaning its a "back camera", if it doesn't find any it falls back to choosing the first device again.

## Testing

Using the scanner feature several times, the first time it chooses correctly the back camera even in the mobile devices that this bug happens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the video source selection to prioritize back-facing cameras for improved device handling during scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->