### PR TITLE
Fixes the document record being abandoned inside the database after an attachment is deleted

### DIFF
--- a/backend/internal/core/services/service_items_attachments.go
+++ b/backend/internal/core/services/service_items_attachments.go
@@ -2,14 +2,12 @@ package services
 
 import (
 	"context"
-	"io"
-	"os"
-
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/attachment"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/repo"
+	"io"
 )
 
 func (svc *ItemService) AttachmentPath(ctx context.Context, attachmentID uuid.UUID) (*ent.Document, error) {
@@ -77,14 +75,19 @@ func (svc *ItemService) AttachmentDelete(ctx context.Context, gid, itemID, attac
 		return err
 	}
 
+	documentID := attachment.Edges.Document.GetID()
+
 	// Delete the attachment
 	err = svc.repo.Attachments.Delete(ctx, attachmentID)
 	if err != nil {
 		return err
 	}
 
-	// Remove File
-	err = os.Remove(attachment.Edges.Document.Path)
+	// Delete the document, this function also removes the file
+	err = svc.repo.Docs.Delete(ctx, documentID)
+	if err != nil {
+		return err
+	}
 
 	return err
 }


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

It deletes the document record in the database that is abandoned as described in issue #578

## Which issue(s) this PR fixes:

Fixes #578

## Special notes for your reviewer:

In service_items_attachments.go where is the function that deletes the attachments I just changed the code to get the document ID and delete it too, the function that deletes the document record already deletes the file too, this can be seen in repo_documents.go

This PR will only fix what happens after it is applied, the abandoned documents records from previous attachment exclusion will still be in the database and if someone wants to delete it will need to look at the documents records and delete those that points to files that doesn't exist anymore. There will be no errors if this is not done anyway, it will just occupy space in the database.

## Testing

The testing procedure should be the same described in issue #578, but with this fix the records in the attachments and documents database should be deleted as the file in the storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This update refines the removal process for attachments, delivering improved efficiency and system stability.

- **Refactor**
  - Streamlined attachment deletion by consolidating cleanup operations to ensure associated items are removed seamlessly. These enhancements contribute to a smoother, more reliable experience.

- **Chore**
  - Eliminated outdated file handling procedures to simplify internal workflows and support maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->