### PR TITLE
chore: Always use LTS NodeJS for Docker builds

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:18-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:22-bullseye
 
 RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Node dependencies stage
-FROM public.ecr.aws/docker/library/node:18-alpine AS frontend-dependencies
+FROM public.ecr.aws/docker/library/node:lts-alpine AS frontend-dependencies
 WORKDIR /app
 
 # Install pnpm globally (caching layer)
@@ -10,7 +10,7 @@ COPY frontend/package.json frontend/pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --shamefully-hoist
 
 # Build Nuxt (frontend) stage
-FROM public.ecr.aws/docker/library/node:18-alpine AS frontend-builder
+FROM public.ecr.aws/docker/library/node:lts-alpine AS frontend-builder
 WORKDIR /app
 
 # Install pnpm globally again (it can reuse the cache if not changed)

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -1,5 +1,5 @@
 # Node dependencies stage
-FROM public.ecr.aws/docker/library/node:18-alpine AS frontend-dependencies
+FROM public.ecr.aws/docker/library/node:lts-alpine AS frontend-dependencies
 WORKDIR /app
 
 # Install pnpm globally (caching layer)
@@ -10,7 +10,7 @@ COPY frontend/package.json frontend/pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --shamefully-hoist
 
 # Build Nuxt (frontend) stage
-FROM public.ecr.aws/docker/library/node:18-alpine AS frontend-builder
+FROM public.ecr.aws/docker/library/node:lts-alpine AS frontend-builder
 WORKDIR /app
 
 # Install pnpm globally again (it can reuse the cache if not changed)


### PR DESCRIPTION
Use LTS NodeJS for Docker builds and deployments instead of potentially out of date version we will forget to update at some point (as we would have if not for this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated container build configurations to use the latest stable Node.js runtime (`lts-alpine`) in various Dockerfiles, ensuring enhanced stability and long-term support during deployments.
  - Upgraded TypeScript and Node.js development environment in the `.devcontainer/Dockerfile` to a newer version (`22-bullseye`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->