### PR TITLE
Improve Media Stream API error message for clarity

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -350,7 +350,7 @@
         "invalid_url": "Invalid barcode URL",
         "no_sources": "No video sources available",
         "select_video_source": "Pick a video source",
-        "unsupported": "Media Stream API is not supported"
+        "unsupported": "Media Stream API is not supported without HTTPS"
     },
     "tools": {
         "actions": "Inventory Actions",


### PR DESCRIPTION
## What type of PR is this?

- bug / documentation

## What this PR does / why we need it:

This PR improves the error message for the Media Stream API to clearly indicate that HTTPS is required. The previous message was vague, leading to confusion about why the API was not supported. The updated message explicitly states:  

> "Media Stream API is not supported without HTTPS. Please use a secure connection."  

This change is based on [discussion #587](https://github.com/sysadminsmedia/homebox/discussions/587), where it was confirmed that the scanner won't work when the site tries to access the API without HTTPS.  

## Which issue(s) this PR fixes:

Fixes #587 

## Special notes for your reviewer:

No functional changes were made—just an improvement to the error message for better clarity.

## Testing:
- Ensured that I don't change any behavior/functionality aside from the message update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the scanner’s notification message to clarify that the Media Stream API is only supported when using HTTPS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->