### PR TITLE
Exclude items that have a solddate from total price calculation

### DIFF
--- a/backend/app/api/handlers/v1/v1_ctrl_items.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_items.go
@@ -88,6 +88,9 @@ func (ctrl *V1Controller) HandleItemsGetAll() errchain.HandlerFunc {
 		items, err := ctrl.repo.Items.QueryByGroup(ctx, ctx.GID, extractQuery(r))
 		totalPrice := new(big.Int)
 		for _, item := range items.Items {
+			if !item.SoldTime.IsZero() { // Skip items with a non-null SoldDate
+				continue
+			}
 			totalPrice.Add(totalPrice, big.NewInt(int64(item.PurchasePrice*100)))
 		}
 

--- a/backend/app/api/handlers/v1/v1_ctrl_locations.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_locations.go
@@ -99,6 +99,11 @@ func (ctrl *V1Controller) GetLocationWithPrice(auth context.Context, gid uuid.UU
 	}
 
 	for _, item := range items.Items {
+		// Skip items with a non-zero SoldTime
+		if !item.SoldTime.IsZero() {
+			continue
+		}
+
 		// Convert item.Quantity to float64 for multiplication
 		quantity := float64(item.Quantity)
 		itemTotal := big.NewInt(int64(item.PurchasePrice * quantity * 100))

--- a/backend/internal/data/repo/repo_items.go
+++ b/backend/internal/data/repo/repo_items.go
@@ -134,9 +134,7 @@ type (
 		Labels   []LabelSummary   `json:"labels"`
 
 		ImageID *uuid.UUID `json:"imageId,omitempty"`
-
-		// Sale details
-		SoldTime time.Time `json:"updatedAt"`
+		
 	}
 
 	ItemOut struct {

--- a/backend/internal/data/repo/repo_items.go
+++ b/backend/internal/data/repo/repo_items.go
@@ -134,7 +134,9 @@ type (
 		Labels   []LabelSummary   `json:"labels"`
 
 		ImageID *uuid.UUID `json:"imageId,omitempty"`
-		
+
+		// Sale details
+		SoldTime time.Time `json:"soldTime"`
 	}
 
 	ItemOut struct {

--- a/backend/internal/data/repo/repo_items.go
+++ b/backend/internal/data/repo/repo_items.go
@@ -134,6 +134,9 @@ type (
 		Labels   []LabelSummary   `json:"labels"`
 
 		ImageID *uuid.UUID `json:"imageId,omitempty"`
+
+		// Sale details
+		SoldTime time.Time `json:"updatedAt"`
 	}
 
 	ItemOut struct {

--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -72,7 +72,7 @@
 </template>
 
 <script setup lang="ts">
-  import type { ItemCreate, LabelOut, LocationOut, PhotoPreview } from "~~/lib/api/types/data-contracts";
+  import type { ItemCreate, LabelOut, LocationOut } from "~~/lib/api/types/data-contracts"; 
   import { useLabelStore } from "~~/stores/labels";
   import { useLocationStore } from "~~/stores/locations";
   import MdiPackageVariant from "~icons/mdi/package-variant";

--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -72,7 +72,7 @@
 </template>
 
 <script setup lang="ts">
-  import type { ItemCreate, LabelOut, LocationOut } from "~~/lib/api/types/data-contracts"; 
+  import type { ItemCreate, LabelOut, LocationOut, PhotoPreview } from "~~/lib/api/types/data-contracts";
   import { useLabelStore } from "~~/stores/labels";
   import { useLocationStore } from "~~/stores/locations";
   import MdiPackageVariant from "~icons/mdi/package-variant";


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Fixes #64 to exclude items that have a sold date from the total price calculations. 

## Which issue(s) this PR fixes:

#64 

## Special notes for your reviewer:

I might have cocked up the exclusion logic, so please pay careful attention to reviewing this.
Further, there might be a neater way of doing this, but this is just an MVP whilst I work out a better way of handling the mess that is items. 

## Testing

To assist me with testing this:
- Please create a new item and set the price to 1000
- Create a new item at 100 
- Confirm total price is 1100
- Add a sold Date to item of a price of 100. 
- Confirm that the total price is updated to 1000.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced conditional checks to exclude sold items from total price calculations, enhancing accuracy in pricing.
- **Bug Fixes**
  - Updated pricing calculations so that sold items are now automatically excluded from total price aggregations, ensuring more accurate totals.
- **Enhancements**
  - Added a new field to track the time an item was sold, improving the representation of sale details.
- **Chores**
  - Minor formatting adjustments made for improved code readability.
- **Refactor**
  - Removed unused type `PhotoPreview` from the import statements in the CreateModal component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->