### PR TITLE
Fix cannot delete photo in create item modal form

### DIFF
--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -55,19 +55,21 @@
 
       <!-- photo preview area is AFTER the create button, to avoid pushing the button below the screen on small displays -->
       <div class="border-t border-gray-300 px-4 pb-4">
-        <div v-for="(photo, index) in form.photos" :key="index" class="pt-4">
-          <div class="flex justify-end py-1">
-            <button type="button" class="btn btn-circle btn-primary btn-sm sm:btn-md" @click="deleteImage(index)">
-              <MdiDelete class="size-5" />
-            </button>
-          </div>
+        <div v-for="(photo, index) in form.photos" :key="index">
+          <div class="indicator mt-8 w-auto">
+            <div class="indicator-item right-2 top-2">
+              <button type="button" class="btn btn-circle btn-primary btn-md" @click="deleteImage(index)">
+                <MdiDelete class="size-5" />
+              </button>
+            </div>
 
-          <img
-            :src="photo.fileBase64"
-            class="w-full rounded-t border-gray-300 object-fill shadow-sm"
-            alt="Uploaded Photo"
-          />
-          <p class="mt-1" style="overflow-wrap: anywhere">File name: {{ photo.photoName }}</p>
+            <img
+              :src="photo.fileBase64"
+              class="w-full rounded-t border-gray-300 object-fill shadow-sm"
+              alt="Uploaded Photo"
+            />
+          </div>
+          <p class="mt-1 text-sm" style="overflow-wrap: anywhere">File name: {{ photo.photoName }}</p>
         </div>
       </div>
     </form>

--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -44,7 +44,7 @@
             <label tabindex="0" class="btn rounded-l-none rounded-r-xl">
               <MdiChevronDown class="size-5" name="mdi-chevron-down" />
             </label>
-            <ul tabindex="0" class="dropdown-content menu rounded-box bg-base-100 right-0 w-64 p-2 shadow">
+            <ul tabindex="0" class="dropdown-content menu rounded-box right-0 w-64 bg-base-100 p-2 shadow">
               <li>
                 <button type="button" @click="create(false)">{{ $t("global.create_and_add") }}</button>
               </li>

--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -44,7 +44,7 @@
             <label tabindex="0" class="btn rounded-l-none rounded-r-xl">
               <MdiChevronDown class="size-5" name="mdi-chevron-down" />
             </label>
-            <ul tabindex="0" class="dropdown-content menu rounded-box right-0 w-64 bg-base-100 p-2 shadow">
+            <ul tabindex="0" class="dropdown-content menu rounded-box bg-base-100 right-0 w-64 p-2 shadow">
               <li>
                 <button type="button" @click="create(false)">{{ $t("global.create_and_add") }}</button>
               </li>
@@ -54,14 +54,20 @@
       </div>
 
       <!-- photo preview area is AFTER the create button, to avoid pushing the button below the screen on small displays -->
-      <div class="border-t border-gray-300 p-4">
-        <div v-for="(photo, index) in form.photos" :key="index">
-          <p class="mb-0" style="overflow-wrap: anywhere">File name: {{ photo.photoName }}</p>
+      <div class="border-t border-gray-300 px-4 pb-4">
+        <div v-for="(photo, index) in form.photos" :key="index" class="pt-4">
+          <div class="flex justify-end py-1">
+            <button type="button" class="btn btn-circle btn-primary btn-sm sm:btn-md" @click="deleteImage(index)">
+              <MdiDelete class="size-5" />
+            </button>
+          </div>
+
           <img
             :src="photo.fileBase64"
             class="w-full rounded-t border-gray-300 object-fill shadow-sm"
             alt="Uploaded Photo"
           />
+          <p class="mt-2" style="overflow-wrap: anywhere">File name: {{ photo.photoName }}</p>
         </div>
       </div>
     </form>
@@ -78,6 +84,7 @@
   import MdiPackageVariant from "~icons/mdi/package-variant";
   import MdiPackageVariantClosed from "~icons/mdi/package-variant-closed";
   import MdiChevronDown from "~icons/mdi/chevron-down";
+  import MdiDelete from "~icons/mdi/delete";
   import { AttachmentTypes } from "~~/lib/api/types/non-generated";
 
   const props = defineProps({
@@ -127,6 +134,10 @@
   });
 
   const { shift } = useMagicKeys();
+
+  function deleteImage(index: number) {
+    form.photos.splice(index, 1);
+  }
 
   function previewImage(event: Event) {
     const input = event.target as HTMLInputElement;

--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -67,7 +67,7 @@
             class="w-full rounded-t border-gray-300 object-fill shadow-sm"
             alt="Uploaded Photo"
           />
-          <p class="mt-2" style="overflow-wrap: anywhere">File name: {{ photo.photoName }}</p>
+          <p class="mt-1" style="overflow-wrap: anywhere">File name: {{ photo.photoName }}</p>
         </div>
       </div>
     </form>

--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -80,7 +80,7 @@
 </template>
 
 <script setup lang="ts">
-  import type { ItemCreate, LabelOut, LocationOut, PhotoPreview } from "~~/lib/api/types/data-contracts";
+  import type { ItemCreate, LabelOut, LocationOut } from "~~/lib/api/types/data-contracts";
   import { useLabelStore } from "~~/stores/labels";
   import { useLocationStore } from "~~/stores/locations";
   import MdiPackageVariant from "~icons/mdi/package-variant";
@@ -88,6 +88,12 @@
   import MdiChevronDown from "~icons/mdi/chevron-down";
   import MdiDelete from "~icons/mdi/delete";
   import { AttachmentTypes } from "~~/lib/api/types/non-generated";
+
+  interface PhotoPreview {
+    photoName: string;
+    file: File;
+    fileBase64: string;
+  }
 
   const props = defineProps({
     modelValue: {


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

It adds a delete button to every photo taken and added to the create item modal dialog box to allow a specific photo to be deleted if it is not as expected.

## Which issue(s) this PR fixes:

Fixes #612

## Special notes for your reviewer:

This is what it will look like:
![Captura de tela de 2025-04-01 16-40-50](https://github.com/user-attachments/assets/6bd48555-7fc6-4c53-a10e-61ead91bb62e)

I moved the filename to the bottom of the image as a subtitle and added a delete button aligned to the top right corner of the photo.
  
## Testing

Just add some photos and delete some of them creating the item and seeing if it will be created with the correct photos that remained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a delete button in the image preview area, empowering users to remove photos seamlessly.
- **Style**
	- Enhanced the layout with improved spacing and repositioned file name displays for a clearer preview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->