### PR TITLE
Remove shamefully hoist

### DIFF
--- a/.github/workflows/binaries-publish.yaml
+++ b/.github/workflows/binaries-publish.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Build Frontend and Copy to Backend
         working-directory: frontend
         run: |
-          pnpm install --shamefully-hoist
+          pnpm install
           pnpm run build
           cp -r ./.output/public ../backend/app/api/static/
 

--- a/.github/workflows/partial-frontend.yaml
+++ b/.github/workflows/partial-frontend.yaml
@@ -18,7 +18,7 @@ jobs:
           version: 9.12.2
 
       - name: Install dependencies
-        run: pnpm install --shamefully-hoist
+        run: pnpm install
         working-directory: frontend
 
       - name: Run Lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,6 @@ If you're using `taskfile` you can run `task --list-all` for a list of all comma
 
 If you're using the taskfile, you can use the `task setup` command to run the required setup commands. Otherwise, you can review the commands required in the `Taskfile.yml` file.
 
-Note that when installing dependencies with pnpm you must use the `--shamefully-hoist` flag. If you don't use this flag, you will get an error when running the frontend server.
-
 ### API Development Notes
 
 start command `task go:run`

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN npm install -g pnpm
 
 # Copy package.json and lockfile to leverage caching
 COPY frontend/package.json frontend/pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile --shamefully-hoist
+RUN pnpm install --frozen-lockfile
 
 # Build Nuxt (frontend) stage
 FROM public.ecr.aws/docker/library/node:lts-alpine AS frontend-builder

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -7,7 +7,7 @@ RUN npm install -g pnpm
 
 # Copy package.json and lockfile to leverage caching
 COPY frontend/package.json frontend/pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile --shamefully-hoist
+RUN pnpm install --frozen-lockfile
 
 # Build Nuxt (frontend) stage
 FROM public.ecr.aws/docker/library/node:lts-alpine AS frontend-builder

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,7 +12,7 @@ tasks:
     cmds:
       - go install github.com/swaggo/swag/cmd/swag@latest
       - cd backend && go mod tidy
-      - cd frontend && pnpm install --shamefully-hoist
+      - cd frontend && pnpm install
 
   swag:
     desc: Generate swagger docs

--- a/docs/en/contribute/get-started.md
+++ b/docs/en/contribute/get-started.md
@@ -19,8 +19,6 @@ If you're using `taskfile` you can run `task --list-all` for a list of all comma
 
 If you're using the taskfile, you can use the `task setup` command to run the required setup commands. Otherwise, you can review the commands required in the `Taskfile.yml` file.
 
-Note that when installing dependencies with pnpm, you must use the `--shamefully-hoist` flag. If you don't use this flag, you will get an error when running the frontend server.
-
 ### API Development Notes
 start command `task go:run`
 

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,1 +1,0 @@
-shamefully-hoist=true


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- cleanup

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

Stops pnpm from shamefully hoisting deps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Removed the requirement to use the `--shamefully-hoist` flag with `pnpm install` in all setup scripts, workflows, and Dockerfiles for frontend dependency installation.

- **Documentation**
	- Updated setup and contribution guides to no longer mention the `--shamefully-hoist` flag for dependency installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->