### PR TITLE
Fix create item modal form layout on mobile devices

### DIFF
--- a/frontend/components/App/CreateModal.vue
+++ b/frontend/components/App/CreateModal.vue
@@ -17,12 +17,12 @@
   </Dialog>
 
   <Drawer v-else :dialog-id="dialogId">
-    <DrawerContent class="max-h-[80%]">
+    <DrawerContent class="max-h-[90%]">
       <DrawerHeader>
         <DrawerTitle>{{ title }}</DrawerTitle>
       </DrawerHeader>
 
-      <div class="m-2 overflow-y-auto">
+      <div class="m-2 overflow-y-auto p-2">
         <slot />
       </div>
     </DrawerContent>


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Fixes the padding around the drawer component used to create items using mobile devices and increases its height.

## Which issue(s) this PR fixes:

Fixes #661

## Special notes for your reviewer:

Add padding it will look like that when a scrollbar is present:
![Captura de tela de 2025-05-01 13-47-55](https://github.com/user-attachments/assets/7ff4922a-0a30-42bc-acd1-3682c5d4c653)

Increasing its height will make the create button visible again:
![Captura de tela de 2025-05-01 13-48-47](https://github.com/user-attachments/assets/a4004203-9020-48ca-a4e9-5ba562b311b5)

## Testing

It will affect only mobile devices, that uses the drawer component, desktops still uses a modal dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Increased the maximum height of the drawer content from 80% to 90%.
  - Added extra padding to the content area inside the drawer for improved spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->