### PR TITLE
Create a rotate 90 degrees clockwise button for each image

### DIFF
--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -75,6 +75,22 @@
                   <p>Delete photo</p>
                 </TooltipContent>
               </Tooltip>
+              <Tooltip>
+                <TooltipTrigger>
+                  <Button
+                    size="icon"
+                    type="button"
+                    variant="default"
+                    @click.prevent="rotateBase64Image90Deg(photo.fileBase64, index)"
+                  >
+                    <MdiRotateClockwise />
+                    <div class="sr-only">Rotate photo</div>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Rotate photo</p>
+                </TooltipContent>
+              </Tooltip>
               <!-- TODO: re-enable when we have a way to set primary photos -->
               <!-- <Tooltip>
                 <TooltipTrigger>
@@ -114,6 +130,7 @@
   import MdiPackageVariant from "~icons/mdi/package-variant";
   import MdiPackageVariantClosed from "~icons/mdi/package-variant-closed";
   import MdiDelete from "~icons/mdi/delete";
+  import MdiRotateClockwise from "~icons/mdi/rotate-clockwise";
   // import MdiStarOutline from "~icons/mdi/star-outline";
   // import MdiStar from "~icons/mdi/star";
   import { AttachmentTypes } from "~~/lib/api/types/non-generated";
@@ -293,5 +310,42 @@
       closeDialog("create-item");
       navigateTo(`/item/${data.id}`);
     }
+  }
+
+  function dataURLtoFile(dataURL: string, fileName: string) {
+    const arr = dataURL.split(",");
+    const mime = arr[0].match(/:(.*?);/)[1];
+    const bstr = atob(arr[arr.length - 1]);
+    let n = bstr.length;
+    const u8arr = new Uint8Array(n);
+    while (n--) {
+      u8arr[n] = bstr.charCodeAt(n);
+    }
+    return new File([u8arr], fileName, { type: mime });
+  }
+
+  function rotateBase64Image90Deg(base64Image: string, index: number) {
+    // Create an off-screen canvas
+    const offScreenCanvas = document.createElement("canvas");
+    const offScreenCanvasCtx = offScreenCanvas.getContext("2d");
+
+    // Create an image
+    const img = new Image();
+    img.src = base64Image;
+
+    // Set its dimensions to rotated size
+    offScreenCanvas.height = img.width;
+    offScreenCanvas.width = img.height;
+
+    // Rotate and draw source image into the off-screen canvas
+    offScreenCanvasCtx.rotate((90 * Math.PI) / 180);
+    offScreenCanvasCtx.translate(0, -offScreenCanvas.width);
+    offScreenCanvasCtx.drawImage(img, 0, 0);
+
+    const imageType = base64Image.match(/^data:(.+);base64/)?.[1];
+
+    // Encode image to data-uri with base64
+    form.photos[index].fileBase64 = offScreenCanvas.toDataURL(imageType, 100);
+    form.photos[index].file = dataURLtoFile(form.photos[index].fileBase64, form.photos[index].photoName);
   }
 </script>


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Add a button to rotate the photo 90 degrees clockwise that can be pressed several times until the photo is in the correct orientation in case the photo was taken and appeared rotated.

## Which issue(s) this PR fixes:

Fixes #621

## Special notes for your reviewer:

The new layout using shadcn was maintained, follow a preview how it looks like.
![Captura de tela de 2025-05-01 21-22-16](https://github.com/user-attachments/assets/63919d50-5a3b-48ee-835a-3e323dc3439d)

## Testing

Just try to create an item, add photos, rotate some photos and verify if it will be saved in the correct orientation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a photo rotation option in the item creation modal, allowing users to rotate uploaded photos 90 degrees clockwise directly before submitting.
	- Introduced a rotate button with an intuitive icon and tooltip for each uploaded photo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->