### PR TITLE
Update passwords to use Argon2ID

### DIFF
--- a/backend/pkgs/hasher/password.go
+++ b/backend/pkgs/hasher/password.go
@@ -1,13 +1,34 @@
 package hasher
 
 import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
 	"fmt"
 	"os"
+	"strings"
 
+	"golang.org/x/crypto/argon2"
 	"golang.org/x/crypto/bcrypt"
 )
 
 var enabled = true
+
+type params struct {
+	memory      uint32
+	iterations  uint32
+	parallelism uint8
+	saltLength  uint32
+	keyLength   uint32
+}
+
+var p = &params{
+	memory:      64 * 1024,
+	iterations:  3,
+	parallelism: 2,
+	saltLength:  16,
+	keyLength:   32,
+}
 
 func init() { // nolint: gochecknoinits
 	disableHas := os.Getenv("UNSAFE_DISABLE_PASSWORD_PROJECTION") == "yes_i_am_sure"
@@ -18,20 +39,108 @@ func init() { // nolint: gochecknoinits
 	}
 }
 
+func GenerateRandomBytes(n uint32) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
 func HashPassword(password string) (string, error) {
 	if !enabled {
 		return password, nil
 	}
 
-	bytes, err := bcrypt.GenerateFromPassword([]byte(password), 14)
-	return string(bytes), err
+	salt, err := GenerateRandomBytes(p.saltLength)
+	if err != nil {
+		return "", err
+	}
+	hash := argon2.IDKey([]byte(password), salt, p.iterations, p.memory, p.parallelism, p.keyLength)
+
+	b64Salt := base64.StdEncoding.EncodeToString(salt)
+	b64Hash := base64.StdEncoding.EncodeToString(hash)
+
+	encodedHash := fmt.Sprintf("$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s", argon2.Version, 64*1024, 3, 2, b64Salt, b64Hash)
+	return encodedHash, err
 }
 
-func CheckPasswordHash(password, hash string) bool {
+// CheckPasswordHash checks if the provided password matches the hash.
+// Additionally, it returns a boolean indicating whether the password should be rehashed.
+func CheckPasswordHash(password, hash string) (bool, bool) {
 	if !enabled {
-		return password == hash
+		return password == hash, false
 	}
 
-	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
-	return err == nil
+	// Compare Argon2id hash first
+	match, err := comparePasswordAndHash(password, hash)
+	if err != nil {
+		// If argon2id hash fails, try bcrypt
+		err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+		if err == nil {
+			// If bcrypt hash matches, return true and indicate rehashing
+			return true, true
+		} else {
+			// If both fail, return false and indicate no rehashing
+			return false, false
+		}
+	}
+	return match, false
+}
+
+func comparePasswordAndHash(password, encodedHash string) (match bool, err error) {
+	// Extract the parameters, salt and derived key from the encoded password
+	// hash.
+	p, salt, hash, err := decodeHash(encodedHash)
+	if err != nil {
+		return false, err
+	}
+
+	// Derive the key from the other password using the same parameters.
+	otherHash := argon2.IDKey([]byte(password), salt, p.iterations, p.memory, p.parallelism, p.keyLength)
+
+	// Check that the contents of the hashed passwords are identical. Note
+	// that we are using the subtle.ConstantTimeCompare() function for this
+	// to help prevent timing attacks.
+	if subtle.ConstantTimeCompare(hash, otherHash) == 1 {
+		return true, nil
+	}
+	return false, nil
+}
+
+func decodeHash(encodedHash string) (p *params, salt, hash []byte, err error) {
+	vals := strings.Split(encodedHash, "$")
+	if len(vals) != 6 {
+		return nil, nil, nil, fmt.Errorf("invalid hash format")
+	}
+
+	var version int
+	_, err = fmt.Sscanf(vals[2], "v=%d", &version)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if version != argon2.Version {
+		return nil, nil, nil, fmt.Errorf("unsupported argon2 version: %d", version)
+	}
+
+	p = &params{}
+	_, err = fmt.Sscanf(vals[3], "m=%d,t=%d,p=%d", &p.memory, &p.iterations, &p.parallelism)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	salt, err = base64.RawStdEncoding.Strict().DecodeString(vals[4])
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	p.saltLength = uint32(len(salt))
+
+	hash, err = base64.RawStdEncoding.Strict().DecodeString(vals[5])
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	p.keyLength = uint32(len(hash))
+
+	return p, salt, hash, nil
 }

--- a/backend/pkgs/hasher/password_test.go
+++ b/backend/pkgs/hasher/password_test.go
@@ -8,21 +8,38 @@ func TestHashPassword(t *testing.T) {
 		password string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name          string
+		args          args
+		wantErr       bool
+		invalidInputs []string
 	}{
 		{
 			name: "letters_and_numbers",
 			args: args{
 				password: "password123456788",
 			},
+			invalidInputs: []string{"testPassword", "AnotherBadPassword", "ThisShouldNeverWork", "1234567890"},
 		},
 		{
 			name: "letters_number_and_special",
 			args: args{
 				password: "!2afj3214pofajip3142j;fa",
 			},
+			invalidInputs: []string{"testPassword", "AnotherBadPassword", "ThisShouldNeverWork", "1234567890"},
+		},
+		{
+			name: "extra_long_password",
+			args: args{
+				password: "this_is_a_very_long_password_that_should_be_hashed_properly_and_still_work_with_the_check_function",
+			},
+			invalidInputs: []string{"testPassword", "AnotherBadPassword", "ThisShouldNeverWork", "1234567890"},
+		},
+		{
+			name: "empty_password",
+			args: args{
+				password: "",
+			},
+			invalidInputs: []string{"testPassword", "AnotherBadPassword", "ThisShouldNeverWork", "1234567890"},
 		},
 	}
 	for _, tt := range tests {
@@ -32,8 +49,16 @@ func TestHashPassword(t *testing.T) {
 				t.Errorf("HashPassword() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !CheckPasswordHash(tt.args.password, got) {
+			check, _ := CheckPasswordHash(tt.args.password, got)
+			if check {
 				t.Errorf("CheckPasswordHash() failed to validate password=%v against hash=%v", tt.args.password, got)
+			}
+
+			for _, invalid := range tt.invalidInputs {
+				check, _ := CheckPasswordHash(invalid, got)
+				if check {
+					t.Errorf("CheckPasswordHash() improperly validated password=%v against hash=%v", invalid, got)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Updates the passwords to use Argon2ID, with validation against bcrypt for old passwords. Additionally adds unit tests to validate bad passwords don't work.

## What type of PR is this?

- bug
- feature

## What this PR does / why we need it:
Updates the password hashing system to use a much more modern Argon2ID hashing algorithm. Which also supports longer passwords.

## Which issue(s) this PR fixes:
Fixes: #693 

## Special notes for your reviewer:
Validate against databases with old bcrypt passwords