### PR TITLE
Force printable label sheets to be black on white background

### DIFF
--- a/frontend/pages/reports/label-generator.vue
+++ b/frontend/pages/reports/label-generator.vue
@@ -414,6 +414,8 @@
         paddingLeft: `${out.page.pl}${out.measure}`,
         paddingRight: `${out.page.pr}${out.measure}`,
         width: `${out.page.width}${out.measure}`,
+        background: `white`,
+        color: `black`,
       }"
     >
       <div


### PR DESCRIPTION
## What type of PR is this?
- bugfix

## What this PR does / why we need it:
[As discussed here](https://github.com/sysadminsmedia/homebox/discussions/749), and [also mentioned here](https://github.com/sysadminsmedia/homebox/discussions/53#discussioncomment-11996463) themes cause issues in label-generator where the page is black or the text is off-block (and thus dithered).

## Which issue(s) this PR fixes:
Fixes : https://github.com/sysadminsmedia/homebox/discussions/749
Fixes part of : https://github.com/sysadminsmedia/homebox/discussions/53#discussioncomment-11996463 (dithering issue for text)

## Special notes for your reviewer:
This is my first PR to this repo and my first PR in a long while, feel free to tell me if I've done anything wrong.
Implementation note: I chose to have this in `style` rather than in a new class since I wanted to be relatively sure this would not be overridden by any future themes that may get added.

## Testing
1. Choose a dark theme
2. Go to Label Generator (`/reports/label-generator`)
3 Compare main to this branch and confirm page is shown correctly regardless of theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the label generator page to use a white background and black text for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->