### PR TITLE
Fix untranslated strings

### DIFF
--- a/frontend/components/App/CreateModal.vue
+++ b/frontend/components/App/CreateModal.vue
@@ -9,8 +9,7 @@
 
       <DialogFooter>
         <span class="flex items-center gap-1 text-sm">
-          Use <Shortcut size="sm" :keys="['Shift']" /> + <Shortcut size="sm" :keys="['Enter']" /> to create and add
-          another.
+          {{ $t("components.app.create_modal.use")}} <Shortcut size="sm" :keys="['Shift']" /> + <Shortcut size="sm" :keys="['Enter']" /> {{ $t("components.app.create_modal.create_and_add")}}
         </span>
       </DialogFooter>
     </DialogScrollContent>

--- a/frontend/components/Item/AttachmentsList.vue
+++ b/frontend/components/Item/AttachmentsList.vue
@@ -21,7 +21,7 @@
                 <MdiDownload />
               </a>
             </TooltipTrigger>
-            <TooltipContent> Download </TooltipContent>
+            <TooltipContent> {{ $t("components.item.attachments_list.download") }} </TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger as-child>
@@ -29,7 +29,7 @@
                 <MdiOpenInNew />
               </a>
             </TooltipTrigger>
-            <TooltipContent> Open in new tab </TooltipContent>
+            <TooltipContent> {{ $t("components.item.attachments_list.open_new_tab") }} </TooltipContent>
           </Tooltip>
         </TooltipProvider>
       </div>

--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -69,7 +69,7 @@
       <div v-if="form.photos.length > 0" class="mt-4 border-t px-4 pb-4">
         <div v-for="(photo, index) in form.photos" :key="index">
           <div class="mt-8 w-full">
-            <img :src="photo.fileBase64" class="w-full rounded object-fill shadow-sm" alt="Uploaded Photo" />
+            <img :src="photo.fileBase64" class="w-full rounded object-fill shadow-sm" :alt="$t('components.item.create_modal.uploaded')" />
           </div>
           <div class="mt-2 flex items-center gap-2">
             <TooltipProvider class="flex gap-2" :delay-duration="0">
@@ -77,11 +77,11 @@
                 <TooltipTrigger>
                   <Button size="icon" type="button" variant="destructive" @click.prevent="deleteImage(index)">
                     <MdiDelete />
-                    <div class="sr-only">Delete photo</div>
+                    <div class="sr-only"> {{ $t("components.item.create_modal.delete_photo") }} </div>
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>Delete photo</p>
+                  <p>{{ $t("components.item.create_modal.delete_photo") }}</p>
                 </TooltipContent>
               </Tooltip>
               <Tooltip>
@@ -97,11 +97,11 @@
                     "
                   >
                     <MdiRotateClockwise />
-                    <div class="sr-only">Rotate photo</div>
+                    <div class="sr-only"> {{ $t("components.item.create_modal.rotate_photo") }} </div>
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>Rotate photo</p>
+                  <p>{{ $t("components.item.create_modal.rotate_photo") }}</p>
                 </TooltipContent>
               </Tooltip>
               <Tooltip>
@@ -114,11 +114,11 @@
                   >
                     <MdiStar v-if="photo.primary" />
                     <MdiStarOutline v-else />
-                    <div class="sr-only">Set as {{ photo.primary ? "non" : "" }} primary photo</div>
+                    <div class="sr-only">{{ $t('components.item.create_modal.set_as') }} {{ photo.primary ? "non" : "" }} {{ $t("components.item.create_modal.primary_photo") }}</div>
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>Set as {{ photo.primary ? "non" : "" }} primary photo</p>
+                  <p>{{ $t('components.item.create_modal.set_as') }} {{ photo.primary ? "non" : "" }} {{ $t("components.item.create_modal.primary_photo") }}</p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/frontend/components/Item/Selector.vue
+++ b/frontend/components/Item/Selector.vue
@@ -47,6 +47,9 @@
   import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
   import { cn } from "~/lib/utils";
   import { useId } from "#imports";
+  import { useI18n } from "vue-i18n";
+
+  const { t } = useI18n();
 
   type ItemsObject = {
     [key: string]: unknown;
@@ -81,6 +84,10 @@
   const open = ref(false);
   const search = ref(props.search);
   const value = useVModel(props, "modelValue", emit);
+
+  const localizedSearchPlaceholder = computed(() => props.searchPlaceholder ?? t('components.item.selector.search_placeholder'));
+  const localizedNoResultsText = computed(() => props.noResultsText ?? t('components.item.selector.no_results'));
+  const localizedPlaceholder = computed(() => props.placeholder ?? t('components.item.selector.placeholder'));
 
   watch(
     () => props.search,

--- a/frontend/error.vue
+++ b/frontend/error.vue
@@ -17,7 +17,7 @@
     <h1 class="flex flex-col gap-5 text-center font-extrabold">
       <span class="text-7xl">{{ error.statusCode }}.</span>
       <span class="text-5xl"> {{ error.message }} </span>
-      <NuxtLink to="/" :class="buttonVariants({ size: 'lg' })"> Return Home </NuxtLink>
+      <NuxtLink to="/" :class="buttonVariants({ size: 'lg' })"> {{ $t("global.return_home") }} </NuxtLink>
     </h1>
   </main>
 </template>

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -12,6 +12,10 @@
                 "latest_version": "Latest Version",
                 "new_version_available": "New Version Available",
                 "new_version_available_link": "Click here to view the release notes"
+            },
+            "create_modal": {
+                "create_and_add": "to create and add another.",
+                "use": "Use"
             }
         },
         "global": {
@@ -62,14 +66,28 @@
             }
         },
         "item": {
+            "attachments_list": {
+                "download": "Download",
+                "open_new_tab": "Open in new tab"
+            },
             "create_modal": {
+                "delete_photo": "Delete photo",
                 "item_description": "Item Description",
                 "item_name": "Item Name",
                 "item_photo": "Item Photo 📷",
                 "item_quantity": "Item Quantity",
                 "parent_item" :"Parent Item",
+                "primary_photo": "primary photo",
+                "rotate_photo": "Rotate photo",
+                "set_as": "Set as",
                 "title": "Create Item",
-                "upload_photos": "Upload Photos"
+                "upload_photos": "Upload Photos",
+                "uploaded": "Uploaded Photo"
+            },
+            "selector": {
+                "no_results": "No Results Found",
+                "placeholder": "Select...",
+                "search_placeholder": "Type to search..."
             },
             "view": {
                 "selectable": {
@@ -128,6 +146,7 @@
         "created": "Created",
         "create_subitem": "Create Subitem",
         "delete": "Delete",
+        "demo_instance": "This is a demo instance",
         "details": "Details",
         "duplicate": "Duplicate",
         "edit": "Edit",
@@ -149,11 +168,13 @@
         "password": "Password",
         "quantity": "Quantity",
         "read_docs": "Read the Docs",
+        "return_home": "Return Home",
         "save": "Save",
         "search": "Search",
         "sign_out": "Sign Out",
         "submit": "Submit",
         "update": "Update",
+        "updating": "Updating",
         "value": "Value",
         "version": "Version: { version }",
         "welcome": "Welcome, { username }",
@@ -179,13 +200,15 @@
         "set_email": "What's your email?",
         "set_name": "What's your name?",
         "set_password": "Set your password",
-        "tagline": "Track, Organize, and Manage your Things."
+        "tagline": "Track, Organize, and Manage your Things.",
+        "title": "Organize and Tag Your Stuff"
     },
     "items": {
         "add": "Add",
         "advanced": "Advanced",
         "archived": "Archived",
         "asset_id": "Asset ID",
+        "associated_with_multiple": "This Asset Id is associated with multiple items",
         "attachment": "Attachment",
         "attachments": "Attachments",
         "changes_persisted_immediately": "Changes to attachments will be saved immediately",
@@ -194,6 +217,16 @@
         "description": "Description",
         "details": "Details",
         "drag_and_drop": "Drag and drop files here or click to select files",
+        "edit": {
+            "edit_attachment_dialog": {
+                "title": "Attachment Edit",
+                "attachment_title": "Attachment Title",
+                "attachment_type": "Attachment Type",
+                "select_type": "Select a type",
+                "primary_photo": "Primary Photo",
+                "primary_photo_sub": "This option is only available for photos. Only one photo can be primary. If you select this option, the current primary photo, if any will be unselected."
+            }
+        },
         "edit_details": "Edit Details",
         "field_selector": "Field Selector",
         "field_value": "Field Value",
@@ -210,6 +243,7 @@
         "name": "Name",
         "negate_labels": "Negate Selected Labels",
         "next_page": "Next Page",
+        "no_attachments": "No attachments found",
         "no_results": "No Items Found",
         "notes": "Notes",
         "only_with_photo": "Only items with photo",
@@ -237,6 +271,7 @@
         "sold_details": "Sold Details",
         "sold_price": "Sold Price",
         "sold_to": "Sold To",
+        "sync_child_locations": "Sync child items' locations",
         "tip_1": "Location and label filters use the 'OR' operation. If more than one is selected only one will be\n required for a match.",
         "tip_2": "Searches prefixed with '#'' will query for a asset ID (example '#000-001')",
         "tip_3": "Field filters use the 'OR' operation. If more than one is selected only one will be required for a\n match.",
@@ -371,6 +406,33 @@
         "url": "URL",
         "user_profile": "User Profile",
         "user_profile_sub": "Invite users, and manage your account."
+    },
+    "reports": {
+        "label_generator": {
+            "bordered_labels": "Bordered Labels",
+            "title": "Label Generator",
+            "asset_start": "Asset Start",
+            "asset_end": "Asset End",
+            "measure_type": "Measure Type",
+            "label_height": "Label Height",
+            "label_width": "Label Width",
+            "page_width": "Page Width",
+            "page_height": "Page Height",
+            "page_top_padding": "Page Top Padding",
+            "page_bottom_padding": "Page Bottom Padding",
+            "page_left_padding": "Page Left Padding",
+            "page_right_padding": "Page Right Padding",
+            "base_url": "Base URL",
+            "input_placeholder": "Type here",
+            "instruction_1": "The Homebox Label Generator is a tool to help you print labels for your Homebox inventory. These are intended to\n be print-ahead labels so you can print many labels and have them ready to apply",
+            "instruction_2": "As such, these labels work by printing a URL QR Code and AssetID information on a label. If you've disabled\n AssetID's in your Homebox settings, you can still use this tool, but the AssetID's won't reference any item",
+            "instruction_3": "This feature is in early development stages and may change in future releases, if you have feedback please\n provide it in the '<a href=\"https://github.com/sysadminsmedia/homebox/discussions/53\">'GitHub Discussion'</a>'",
+            "tip_1": "The defaults here are setup for the\n '<a href=\"https://www.avery.com/templates/5260\">'Avery 5260 label sheets'</a>'. If you're using a different sheet,\n you'll need to adjust the settings to match your sheet.",
+            "tip_2": "If you're customizing your sheet the dimensions are in inches. When building the 5260 sheet, I found that the\n dimensions used in their template, did not match what was needed to print within the boxes.\n '<b>'Be prepared for some trial and error.'</b>'",
+            "tip_3": "When printing be sure to:\n '<ol><li>'Set the margins to 0 or None'</li><li>'Set the scaling to 100%'</li><li>'Disable double-sided printing'</li><li>'Print a test page before printing multiple pages'</li></ol>'",
+            "tips": "Tips",
+            "qr_code_example": "QR Code Example"
+        }   
     },
     "scanner": {
         "error": "An error occurred while scanning",

--- a/frontend/pages/assets/[id].vue
+++ b/frontend/pages/assets/[id].vue
@@ -34,7 +34,7 @@
 <template>
   <BaseContainer>
     <section v-if="!pending">
-      <BaseSectionHeader class="mb-5"> This Asset Id is associated with multiple items</BaseSectionHeader>
+      <BaseSectionHeader class="mb-5"> {{ $t("items.associated_with_multiple") }} </BaseSectionHeader>
       <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
         <ItemCard v-for="item in items" :key="item.id" :item="item" />
       </div>

--- a/frontend/pages/home/index.vue
+++ b/frontend/pages/home/index.vue
@@ -3,12 +3,15 @@
   import { itemsTable } from "./table";
   import { useLabelStore } from "~~/stores/labels";
   import { useLocationStore } from "~~/stores/locations";
+  import { useI18n } from "vue-i18n";
+
+  const { t } = useI18n();
 
   definePageMeta({
     middleware: ["auth"],
   });
   useHead({
-    title: "Homebox | Home",
+    title: "HomeBox | " + t("menu.home"),
   });
 
   const api = useUserApi();

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -13,9 +13,12 @@
   import { Button } from "@/components/ui/button";
   import LanguageSelector from "~/components/App/LanguageSelector.vue";
   import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+  import { useI18n } from "vue-i18n";
+
+  const { t } = useI18n();
 
   useHead({
-    title: "Homebox | Organize and Tag Your Stuff",
+    title: "HomeBox | " + t("index.title"),
   });
 
   definePageMeta({
@@ -260,7 +263,7 @@
                 </CardHeader>
                 <CardContent class="flex flex-col gap-2">
                   <template v-if="status && status.demo">
-                    <p class="text-center text-xs italic">This is a demo instance</p>
+                    <p class="text-center text-xs italic">{{ $t("global.demo_instance") }}</p>
                     <p class="text-center text-xs">
                       <b>{{ $t("global.email") }}</b> demo@example.com
                     </p>

--- a/frontend/pages/item/[id]/index.vue
+++ b/frontend/pages/item/[id]/index.vue
@@ -714,7 +714,7 @@
               </template>
             </DetailsSection>
             <div v-else>
-              <p class="px-6 pb-4 text-foreground/70">No attachments found</p>
+              <p class="px-6 pb-4 text-foreground/70">{{ $t("items.no_attachments") }}</p>
             </div>
           </BaseCard>
 

--- a/frontend/pages/item/[id]/index/edit.vue
+++ b/frontend/pages/item/[id]/index/edit.vue
@@ -505,15 +505,15 @@
     <Dialog dialog-id="attachment-edit">
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Attachment Edit</DialogTitle>
+          <DialogTitle>{{ $t("items.edit.edit_attachment_dialog.title") }}</DialogTitle>
         </DialogHeader>
 
-        <FormTextField v-model="editState.title" label="Attachment Title" />
+        <FormTextField v-model="editState.title" :label="$t('items.edit.edit_attachment_dialog.attachment_title')" />
         <div>
-          <Label for="attachment-type"> Attachment Type </Label>
+          <Label for="attachment-type"> {{ $t("items.edit.edit_attachment_dialog.attachment_type") }} </Label>
           <Select id="attachment-type" v-model:model-value="editState.type">
             <SelectTrigger>
-              <SelectValue placeholder="Select a type" />
+              <SelectValue :placeholder="$t('items.edit.edit_attachment_dialog.select_type')" />
             </SelectTrigger>
             <SelectContent>
               <SelectItem v-for="opt in attachmentOpts" :key="opt.value" :value="opt.value">
@@ -523,16 +523,15 @@
           </Select>
         </div>
         <div v-if="editState.type == 'photo'" class="mt-3 flex items-center gap-2">
-          <Checkbox id="primary" v-model="editState.primary" label="Primary Photo" />
+          <Checkbox id="primary" v-model="editState.primary" :label="$t('items.edit.edit_attachment_dialog.primary_photo')" />
           <label class="cursor-pointer text-sm" for="primary">
-            <span class="font-semibold">Primary Photo</span>
-            This options is only available for photos. Only one photo can be primary. If you select this option, the
-            current primary photo, if any will be unselected.
+            <span class="font-semibold">{{ $t('items.edit.edit_attachment_dialog.primary_photo') }}</span>
+            {{ $t('items.edit.edit_attachment_dialog.primary_photo_sub') }}
           </label>
         </div>
 
         <DialogFooter>
-          <Button :loading="editState.loading" @click="updateAttachment"> Update </Button>
+          <Button :loading="editState.loading" @click="updateAttachment"> {{ $t("global.update") }} </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
@@ -570,7 +569,7 @@
               @update:model-value="maybeSyncWithParentLocation()"
             />
             <div class="flex flex-col gap-2">
-              <Label class="px-1">Sync child items' locations</Label>
+              <Label class="px-1">{{ $t("items.sync_child_locations") }}</Label>
               <Switch v-model="item.syncChildItemsLocations" @update:model-value="syncChildItemsLocations()" />
             </div>
             <LabelSelector v-model="item.labelIds" :labels="labels" />
@@ -803,7 +802,7 @@
 
         <Card v-if="preferences.editorAdvancedView" class="overflow-visible shadow-xl">
           <div class="px-4 py-5 sm:px-6">
-            <h3 class="text-lg font-medium leading-6">Sold Details</h3>
+            <h3 class="text-lg font-medium leading-6">{{ $t("items.sold_details") }}</h3>
           </div>
           <div class="border-t sm:p-0">
             <div v-for="field in soldFields" :key="field.ref" class="grid grid-cols-1 sm:divide-y">

--- a/frontend/pages/items.vue
+++ b/frontend/pages/items.vue
@@ -22,13 +22,16 @@
     PaginationList,
     PaginationListItem,
   } from "@/components/ui/pagination";
+  import { useI18n } from "vue-i18n";
+
+  const { t } = useI18n();
 
   definePageMeta({
     middleware: ["auth"],
   });
 
   useHead({
-    title: "Homebox | Items",
+    title: "HomeBox | " + t("global.items"),
   });
 
   const searchLocked = ref(false);

--- a/frontend/pages/locations.vue
+++ b/frontend/pages/locations.vue
@@ -6,6 +6,9 @@
   import { ButtonGroup, Button } from "@/components/ui/button";
   import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
   import type { TreeItem } from "~/lib/api/types/data-contracts";
+  import { useI18n } from "vue-i18n";
+
+  const { t } = useI18n();
 
   // TODO: eventually move to https://reka-ui.com/docs/components/tree#draggable-sortable-tree
 
@@ -14,7 +17,7 @@
   });
 
   useHead({
-    title: "Homebox | Items",
+    title: "HomeBox | " + t("menu.locations"),
   });
 
   const api = useUserApi();

--- a/frontend/pages/maintenance.vue
+++ b/frontend/pages/maintenance.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
+  import { useI18n } from "vue-i18n";
+
+  const { t } = useI18n();
+
   definePageMeta({
     middleware: ["auth"],
   });
   useHead({
-    title: "Homebox | Maintenance",
+    title: "HomeBox | " + t("menu.maintenance"),
   });
 </script>
 

--- a/frontend/pages/profile.vue
+++ b/frontend/pages/profile.vue
@@ -18,12 +18,15 @@
   import { badgeVariants } from "@/components/ui/badge";
   import LanguageSelector from "~/components/App/LanguageSelector.vue";
   import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+  import { useI18n } from "vue-i18n";
+
+  const { t } = useI18n();
 
   definePageMeta({
     middleware: ["auth"],
   });
   useHead({
-    title: "Homebox | Profile",
+    title: "HomeBox | " + t("menu.profile"),
   });
 
   const api = useUserApi();

--- a/frontend/pages/reports/label-generator.vue
+++ b/frontend/pages/reports/label-generator.vue
@@ -6,13 +6,17 @@
   import { Label } from "@/components/ui/label";
   import { Input } from "@/components/ui/input";
   import { Checkbox } from "@/components/ui/checkbox";
+  import { useI18n } from "vue-i18n";
+  import DOMPurify from "dompurify";
+  
+  const { t } = useI18n();
 
   definePageMeta({
     middleware: ["auth"],
     layout: false,
   });
   useHead({
-    title: "Homebox | Printer",
+    title: "HomeBox | " + t("reports.label_generator.title"),
   });
 
   const api = useUserApi();
@@ -119,52 +123,52 @@
   const propertyInputs = computed<InputDef[]>(() => {
     return [
       {
-        label: "Asset Start",
+        label: t("reports.label_generator.asset_start"),
         ref: "assetRange",
       },
       {
-        label: "Asset End",
+        label: t("reports.label_generator.asset_end"),
         ref: "assetRangeMax",
       },
       {
-        label: "Measure Type",
+        label: t("reports.label_generator.measure_type"),
         ref: "measure",
         type: "text",
       },
       {
-        label: "Label Height",
+        label: t("reports.label_generator.label_height"),
         ref: "cardHeight",
       },
       {
-        label: "Label Width",
+        label: t("reports.label_generator.label_width"),
         ref: "cardWidth",
       },
       {
-        label: "Page Width",
+        label: t("reports.label_generator.page_width"),
         ref: "pageWidth",
       },
       {
-        label: "Page Height",
+        label: t("reports.label_generator.page_height"),
         ref: "pageHeight",
       },
       {
-        label: "Page Top Padding",
+        label: t("reports.label_generator.page_top_padding"),
         ref: "pageTopPadding",
       },
       {
-        label: "Page Bottom Padding",
+        label: t("reports.label_generator.page_bottom_padding"),
         ref: "pageBottomPadding",
       },
       {
-        label: "Page Left Padding",
+        label: t("reports.label_generator.page_left_padding"),
         ref: "pageLeftPadding",
       },
       {
-        label: "Page Right Padding",
+        label: t("reports.label_generator.page_right_padding"),
         ref: "pageRightPadding",
       },
       {
-        label: "Base URL",
+        label: t("reports.label_generator.base_url"),
         ref: "baseURL",
         type: "text",
       },
@@ -333,44 +337,27 @@
   <div class="print:hidden">
     <Toaster />
     <div class="container prose mx-auto max-w-4xl p-4 pt-6">
-      <h1>Homebox Label Generator</h1>
+      <h1>HomeBox {{ $t("reports.label_generator.title") }}</h1>
       <p>
-        The Homebox Label Generator is a tool to help you print labels for your Homebox inventory. These are intended to
-        be print-ahead labels so you can print many labels and have them ready to apply
+        {{ $t("reports.label_generator.instruction_1") }}
       </p>
       <p>
-        As such, these labels work by printing a URL QR Code and AssetID information on a label. If you've disabled
-        AssetID's in your Homebox settings, you can still use this tool, but the AssetID's won't reference any item
+        {{ $t("reports.label_generator.instruction_2") }}
       </p>
-      <p>
-        This feature is in early development stages and may change in future releases, if you have feedback please
-        provide it in the <a href="https://github.com/sysadminsmedia/homebox/discussions/53">GitHub Discussion</a>
+      <p v-html="DOMPurify.sanitize($t('reports.label_generator.instruction_3'))">
       </p>
-      <h2>Tips</h2>
+      <h2>{{ $t("reports.label_generator.tips") }}</h2>
       <ul>
-        <li>
-          The defaults here are setup for the
-          <a href="https://www.avery.com/templates/5260">Avery 5260 label sheets</a>. If you're using a different sheet,
-          you'll need to adjust the settings to match your sheet.
+        <li v-html="DOMPurify.sanitize($t('reports.label_generator.tip_1'))">
         </li>
-        <li>
-          If you're customizing your sheet the dimensions are in inches. When building the 5260 sheet, I found that the
-          dimensions used in their template, did not match what was needed to print within the boxes.
-          <b>Be prepared for some trial and error</b>
+        <li v-html="DOMPurify.sanitize($t('reports.label_generator.tip_2'))">
         </li>
-        <li>
-          When printing be sure to:
-          <ol>
-            <li>Set the margins to 0 or None</li>
-            <li>Set the scaling to 100%</li>
-            <li>Disable double-sided printing</li>
-            <li>Print a test page before printing multiple pages</li>
-          </ol>
+        <li v-html="DOMPurify.sanitize($t('reports.label_generator.tip_3'))">
         </li>
       </ul>
       <div class="flex flex-wrap gap-2">
-        <NuxtLink href="/tools">Tools</NuxtLink>
-        <NuxtLink href="/home">Home</NuxtLink>
+        <NuxtLink href="/tools">{{ $t("menu.tools") }}</NuxtLink>
+        <NuxtLink href="/home">{{ $t("menu.home") }}</NuxtLink>
       </div>
     </div>
     <Separator class="mx-auto max-w-4xl" />
@@ -385,7 +372,7 @@
             v-model="displayProperties[prop.ref]"
             :type="prop.type ? prop.type : 'number'"
             step="0.01"
-            placeholder="Type here"
+            :placeholder="$t('reports.label_generator.input_placeholder')"
             class="w-full max-w-xs"
           />
         </div>
@@ -393,12 +380,12 @@
       <div class="max-w-xs">
         <div class="flex items-center gap-2 py-4">
           <Checkbox id="borderedLabels" v-model="bordered" />
-          <Label class="cursor-pointer" for="borderedLabels"> Bordered Labels </Label>
+          <Label class="cursor-pointer" for="borderedLabels"> {{ $t("reports.label_generator.bordered_labels") }} </Label>
         </div>
       </div>
 
       <div>
-        <p>QR Code Example {{ displayProperties.baseURL }}/a/{asset_id}</p>
+        <p>{{ $t("reports.label_generator.qr_code_example") }} {{ displayProperties.baseURL }}/a/{asset_id}</p>
         <Button size="lg" class="my-4 w-full" @click="calcPages"> Generate Page </Button>
       </div>
     </div>
@@ -452,7 +439,7 @@
           </div>
           <div class="ml-2 flex flex-col justify-center">
             <div class="font-bold">{{ item.assetID }}</div>
-            <div class="text-xs font-light italic">Homebox</div>
+            <div class="text-xs font-light italic">HomeBox</div>
             <div class="overflow-hidden text-wrap text-xs">{{ item.name }}</div>
             <div class="text-xs">{{ item.location }}</div>
           </div>

--- a/frontend/pages/tools.vue
+++ b/frontend/pages/tools.vue
@@ -98,12 +98,15 @@
   import MdiDatabase from "~icons/mdi/database";
   import MdiAlert from "~icons/mdi/alert";
   import { useDialog } from "~/components/ui/dialog-provider";
+  import { useI18n } from "vue-i18n";
+
+  const { t } = useI18n();
 
   definePageMeta({
     middleware: ["auth"],
   });
   useHead({
-    title: "Homebox | Tools",
+    title: "HomeBox | " + t("menu.tools"),
   });
 
   const { openDialog } = useDialog();


### PR DESCRIPTION
## What type of PR is this?
- bug
- cleanup

## What this PR does / why we need it:

Addresses untranslated/missing translation strings within the front end pages, components, and page titles. Adds all toast messages to localization as well (WIP).

## Which issue(s) this PR fixes:

Fixes #656

## Special notes for your reviewer:

For situations like in `frontend/components/App/CreateModal.vue`, where we have text split up by things like keyboard actions, I created separate strings for the front/back half. Not sure if this is standard or if we should include the keyboard buttons in the translation as well.

I noticed during development that some of the weblate translations (namely Czech and Dutch, but possibly others) don't have single quotes around some html tags (`<b>` instead of `'<b>'`) - this causes the page to fail loading where this is required and needs to be sanitized using DOMPurify. I started to go through weblate and check for more of these situations.