### PR TITLE
feat: Add table column for Asset ID

### DIFF
--- a/frontend/components/Item/View/Table.vue
+++ b/frontend/components/Item/View/Table.vue
@@ -185,6 +185,7 @@
   const preferences = useViewPreferences();
 
   const defaultHeaders = [
+    { text: "items.asset_id", value: "assetId", enabled: false },
     {
       text: "items.name",
       value: "name",


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Include a new `Asset ID` column in the item view table, disabled by default.

![image](https://github.com/user-attachments/assets/100ff3fd-dc8f-4641-ac71-80b7c858a109)
![image](https://github.com/user-attachments/assets/f6ae3bf8-8695-4a21-bcd0-9e060f6c29f4)


## Which issue(s) this PR fixes:

No related issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new (initially hidden) "Asset ID" column option to the item table, allowing users to enable it in their table view preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->