### PR TITLE
fix: Show item Purchase and Sold sections when date is set

### DIFF
--- a/frontend/pages/item/[id]/index.vue
+++ b/frontend/pages/item/[id]/index.vue
@@ -325,7 +325,7 @@
     if (preferences.value.showEmpty) {
       return true;
     }
-    return item.value?.purchaseFrom || item.value?.purchasePrice !== 0;
+    return item.value?.purchaseFrom || item.value?.purchasePrice !== 0 || validDate(item.value?.purchaseTime);
   });
 
   const purchaseDetails = computed<Details>(() => {
@@ -358,7 +358,7 @@
     if (preferences.value.showEmpty) {
       return true;
     }
-    return item.value?.soldTo || item.value?.soldPrice !== 0;
+    return item.value?.soldTo || item.value?.soldPrice !== 0 || validDate(item.value?.soldTime);
   });
 
   const soldDetails = computed<Details>(() => {


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Consider the case where an item has a purchase or sold date set, but no other details, and display the sections in this case.

## Which issue(s) this PR fixes:

Fixes #759

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the display logic for purchase and sold sections to better account for valid date information, ensuring these sections appear when relevant date fields are set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->