### PR TITLE
Prevent self-referencing locations and items as parents

### DIFF
--- a/frontend/components/Item/Selector.vue
+++ b/frontend/components/Item/Selector.vue
@@ -65,6 +65,7 @@
     searchPlaceholder?: string;
     noResultsText?: string;
     placeholder?: string;
+    excludeId?: string | null;
   }
 
   const emit = defineEmits(["update:modelValue", "update:search"]);
@@ -78,6 +79,7 @@
     searchPlaceholder: undefined,
     noResultsText: undefined,
     placeholder: undefined,
+    excludeId: null,
   });
 
   const id = useId();
@@ -137,12 +139,18 @@
   }
 
   const filtered = computed(() => {
-    if (!search.value) return props.items;
-    if (isStrings(props.items)) {
-      return props.items.filter(item => item.toLowerCase().includes(search.value.toLowerCase()));
+    let baseItems = props.items;
+
+    if (!isStrings(baseItems) && props.excludeId) {
+      baseItems = baseItems.filter(item => item.id != props.excludeId);
+    }
+    if (!search.value) return baseItems;
+
+    if (isStrings(baseItems)) {
+      return baseItems.filter(item => item.toLowerCase().includes(search.value.toLowerCase()));
     } else {
       // Fuzzy search on itemText
-      return fuzzysort.go(search.value, props.items, { key: props.itemText, all: true }).map(i => i.obj);
+      return fuzzysort.go(search.value, baseItems, { key: props.itemText, all: true }).map(i => i.obj);
     }
   });
 </script>

--- a/frontend/components/Item/Selector.vue
+++ b/frontend/components/Item/Selector.vue
@@ -142,7 +142,7 @@
     let baseItems = props.items;
 
     if (!isStrings(baseItems) && props.excludeItems) {
-      let excludeIds = props.excludeItems.map(i => i.id);
+      const excludeIds = props.excludeItems.map(i => i.id);
       baseItems = baseItems.filter(item => !excludeIds?.includes(item.id));
     }
     if (!search.value) return baseItems;

--- a/frontend/components/Item/Selector.vue
+++ b/frontend/components/Item/Selector.vue
@@ -65,7 +65,7 @@
     searchPlaceholder?: string;
     noResultsText?: string;
     placeholder?: string;
-    excludeId?: string | null;
+    excludeItems?: ItemsObject[];
   }
 
   const emit = defineEmits(["update:modelValue", "update:search"]);
@@ -79,7 +79,7 @@
     searchPlaceholder: undefined,
     noResultsText: undefined,
     placeholder: undefined,
-    excludeId: null,
+    excludeItems: undefined,
   });
 
   const id = useId();
@@ -141,8 +141,9 @@
   const filtered = computed(() => {
     let baseItems = props.items;
 
-    if (!isStrings(baseItems) && props.excludeId) {
-      baseItems = baseItems.filter(item => item.id != props.excludeId);
+    if (!isStrings(baseItems) && props.excludeItems) {
+      let excludeIds = props.excludeItems.map(i => i.id);
+      baseItems = baseItems.filter(item => !excludeIds?.includes(item.id));
     }
     if (!search.value) return baseItems;
 

--- a/frontend/components/Location/Selector.vue
+++ b/frontend/components/Location/Selector.vue
@@ -58,7 +58,7 @@
 
   type Props = {
     modelValue?: LocationSummary | null;
-    currentLocationId?: string | undefined;
+    currentLocation?: LocationSummary;
   };
 
   const props = defineProps<Props>();
@@ -67,7 +67,7 @@
   const open = ref(false);
   const search = ref("");
   const id = useId();
-  const locations = useFlatLocations(props.currentLocationId);
+  const locations = useFlatLocations(props.currentLocation);
   const value = useVModel(props, "modelValue", emit);
 
   function selectLocation(location: LocationSummary) {
@@ -80,7 +80,7 @@
   }
 
   const filteredLocations = computed(() => {
-    const filtered = fuzzysort.go(search.value, locations.value, { key: "name", all: true }).map(i => i.obj).filter(loc => loc.id !== props.currentLocationId);
+    const filtered = fuzzysort.go(search.value, locations.value, { key: "name", all: true }).map(i => i.obj);
 
     return filtered;
   });

--- a/frontend/components/Location/Selector.vue
+++ b/frontend/components/Location/Selector.vue
@@ -58,6 +58,7 @@
 
   type Props = {
     modelValue?: LocationSummary | null;
+    currentLocationId?: string | undefined;
   };
 
   const props = defineProps<Props>();
@@ -66,7 +67,7 @@
   const open = ref(false);
   const search = ref("");
   const id = useId();
-  const locations = useFlatLocations();
+  const locations = useFlatLocations(props.currentLocationId);
   const value = useVModel(props, "modelValue", emit);
 
   function selectLocation(location: LocationSummary) {
@@ -79,7 +80,7 @@
   }
 
   const filteredLocations = computed(() => {
-    const filtered = fuzzysort.go(search.value, locations.value, { key: "name", all: true }).map(i => i.obj);
+    const filtered = fuzzysort.go(search.value, locations.value, { key: "name", all: true }).map(i => i.obj).filter(loc => loc.id !== props.currentLocationId);
 
     return filtered;
   });

--- a/frontend/composables/use-location-helpers.ts
+++ b/frontend/composables/use-location-helpers.ts
@@ -1,5 +1,5 @@
 import type { Ref } from "vue";
-import type { TreeItem } from "~~/lib/api/types/data-contracts";
+import type { TreeItem, LocationSummary } from "~~/lib/api/types/data-contracts";
 
 export interface FlatTreeItem {
   id: string;
@@ -55,9 +55,9 @@ function filterOutSubtree(tree: TreeItem[], excludeId: string): TreeItem[] {
   return result;
 }
 
-export function useFlatLocations(excludeSubtreeForId?: string): Ref<FlatTreeItem[]> {
+export function useFlatLocations(excludeSubtreeForLocation?: LocationSummary): Ref<FlatTreeItem[]> {
   const locations = useLocationStore();
-
+  
   if (locations.tree === null) {
     locations.refreshTree();
   }
@@ -67,8 +67,8 @@ export function useFlatLocations(excludeSubtreeForId?: string): Ref<FlatTreeItem
       return [];
     }
 
-    const filteredTree = excludeSubtreeForId
-      ? filterOutSubtree(locations.tree, excludeSubtreeForId)
+    const filteredTree = excludeSubtreeForLocation
+      ? filterOutSubtree(locations.tree, excludeSubtreeForLocation.id)
       : locations.tree;
 
     return flatTree(filteredTree);

--- a/frontend/composables/use-location-helpers.ts
+++ b/frontend/composables/use-location-helpers.ts
@@ -35,7 +35,27 @@ function flatTree(tree: TreeItem[]): FlatTreeItem[] {
   return v;
 }
 
-export function useFlatLocations(): Ref<FlatTreeItem[]> {
+function filterOutSubtree(tree: TreeItem[], excludeId: string): TreeItem[] {
+  // Recursively filters out a subtree starting from excludeId
+  const result: TreeItem[] = [];
+
+  for (const item of tree) {
+    if (item.id === excludeId) {
+      continue;
+    }
+
+    const newItem = { ...item };
+    if (item.children) {
+      newItem.children = filterOutSubtree(item.children, excludeId);
+    }
+
+    result.push(newItem);
+  }
+
+  return result;
+}
+
+export function useFlatLocations(excludeSubtreeForId?: string): Ref<FlatTreeItem[]> {
   const locations = useLocationStore();
 
   if (locations.tree === null) {
@@ -47,6 +67,10 @@ export function useFlatLocations(): Ref<FlatTreeItem[]> {
       return [];
     }
 
-    return flatTree(locations.tree);
+    const filteredTree = excludeSubtreeForId
+      ? filterOutSubtree(locations.tree, excludeSubtreeForId)
+      : locations.tree;
+
+    return flatTree(filteredTree);
   });
 }

--- a/frontend/pages/item/[id]/index/edit.vue
+++ b/frontend/pages/item/[id]/index/edit.vue
@@ -573,6 +573,7 @@
               item-text="name"
               :label="$t('items.parent_item')"
               no-results-text="Type to search..."
+              :exclude-id="item.id"
               @update:model-value="maybeSyncWithParentLocation()"
             />
             <div class="flex flex-col gap-2">

--- a/frontend/pages/item/[id]/index/edit.vue
+++ b/frontend/pages/item/[id]/index/edit.vue
@@ -573,7 +573,7 @@
               item-text="name"
               :label="$t('items.parent_item')"
               no-results-text="Type to search..."
-              :exclude-id="item.id"
+              :exclude-items="[item]"
               @update:model-value="maybeSyncWithParentLocation()"
             />
             <div class="flex flex-col gap-2">

--- a/frontend/pages/location/[id].vue
+++ b/frontend/pages/location/[id].vue
@@ -146,7 +146,7 @@
             :label="$t('components.location.create_modal.location_description')"
             :max-length="1000"
           />
-          <LocationSelector v-model="parent" :currentLocationId="location.id" />
+          <LocationSelector v-model="parent" :currentLocation="location" />
           <DialogFooter>
             <Button type="submit" :loading="updating"> {{ $t("global.update") }} </Button>
           </DialogFooter>

--- a/frontend/pages/location/[id].vue
+++ b/frontend/pages/location/[id].vue
@@ -146,7 +146,7 @@
             :label="$t('components.location.create_modal.location_description')"
             :max-length="1000"
           />
-          <LocationSelector v-model="parent" />
+          <LocationSelector v-model="parent" :currentLocationId="location.id" />
           <DialogFooter>
             <Button type="submit" :loading="updating"> {{ $t("global.update") }} </Button>
           </DialogFooter>

--- a/frontend/pages/location/[id].vue
+++ b/frontend/pages/location/[id].vue
@@ -146,7 +146,7 @@
             :label="$t('components.location.create_modal.location_description')"
             :max-length="1000"
           />
-          <LocationSelector v-model="parent" :currentLocation="location" />
+          <LocationSelector v-model="parent" :current-location="location" />
           <DialogFooter>
             <Button type="submit" :loading="updating"> {{ $t("global.update") }} </Button>
           </DialogFooter>


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Addresses issues when selecting a location as its own parent (or any descendant of itself), as well as selecting an item to be its own parent.

## Which issue(s) this PR fixes:

Fixes #311 

## Special notes for your reviewer:

This seemed straight forward to fix from the user interface from the perspective that we shouldn't allow this situation to be possible to begin with.

## Testing

- Verified through the user interface that the parent locations list does not show the current location or any descendants. Selecting another parent location works as expected.

- Similarly for items, confirmed that the items list loads and the current item does not appear when searching or when browsing the full list of items. Still able to select a different parent item as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to exclude specific items or location subtrees from selection lists.
  - Enhanced selection components to accept current item or location context for exclusion during editing.
- **Improvements**
  - Selection lists now automatically filter out the current item or location for a more intuitive editing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->