### PR TITLE
Fixed labelmaker endpoints pagination on PostgreSQL

### DIFF
--- a/backend/internal/data/repo/pagination.go
+++ b/backend/internal/data/repo/pagination.go
@@ -8,5 +8,10 @@ type PaginationResult[T any] struct {
 }
 
 func calculateOffset(page, pageSize int) int {
-	return (page - 1) * pageSize
+	offset := (page - 1) * pageSize
+	if offset < 0 {
+		return 0
+	} else {
+		return offset
+	}
 }


### PR DESCRIPTION
Fixed #753

## What type of PR is this?

- bug

## What this PR does / why we need it:

- Fixed labelmaker endpoints throwing an internal server error when using PostgreSQL as the database
- Added a check for negative values to the pagination offset calculation function, it will never return a value less than 0 now

## Which issue(s) this PR fixes:

Fixes #753 

## Testing

1. went through the dev environment setup in `CONTRIBUTING.md`
2. deployed a local Postgres `podman run --rm -p 5432:5432 -e POSTGRES_PASSWORD=d0a9041d docker.io/postgres:17-alpine`
3. started the backend `HBOX_DATABASE_DRIVER=postgres HBOX_DATABASE_HOST=localhost HBOX_DATABASE_PORT=5432 HBOX_DATABASE_DATABASE=postgres HBOX_DATABASE_USERNAME=postgres HBOX_DATABASE_PASSWORD=d0a9041d HBOX_DATABASE_SSL_MODE=disable HBOX_LABEL_MAKER_PRINT_COMMAND="brother_ql --backend network --model QL-580N --printer tcp://example.com:9100 print --label 62 --rotate 0 {{.FileName}}" HBOX_LABEL_MAKER_WIDTH=696 PATH="$GOPATH/bin/:$PATH" go-task go:run`
4. started the frontend `go-task ui:dev`
5. verified that the bug from the linked issue no longer occurs, i.e. a label gets generated and no errors are reported
6. ran go unit tests with all the envars from step 3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where negative offset values could occur during pagination, ensuring more reliable page navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->