### PR TITLE
fix: Table sorting for ID and date columns

### DIFF
--- a/frontend/components/Item/View/Table.vue
+++ b/frontend/components/Item/View/Table.vue
@@ -256,8 +256,8 @@
   function extractSortable(item: ItemSummary, property: keyof ItemSummary): string | number | boolean {
     const value = item[property];
     if (typeof value === "string") {
-      // Try parse float
-      const parsed = parseFloat(value);
+      // Try to parse number
+      const parsed = Number(value);
       if (!isNaN(parsed)) {
         return parsed;
       }


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

The usage of `parseFloat` was breaking the sorting of ID and date columns in the table.

This is because `parseFloat("000-123")` returns `0` instead of `123` or `NaN`, and `parseFloat("2025-01-02T03:04:05.678Z")` returns `2025`.

Replacing `parseFloat` with `Number` fixes the issue, as now the values received for Asset ID and date columns will correctly return `NaN`, and end up being sorted as strings.

## Testing

- Create items with different Asset ID values.
- Try to sort them by "Asset ID", "Created at", and "Updated at" columns, using the table view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sorting accuracy for numeric values in tables by updating the value parsing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->