### PR TITLE
fix: Add page title for Label and Location pages

### DIFF
--- a/frontend/pages/label/[id].vue
+++ b/frontend/pages/label/[id].vue
@@ -137,6 +137,9 @@
   </Dialog>
 
   <BaseContainer v-if="label">
+    <!-- set page title -->
+    <Title>{{ label.name }}</Title>
+
     <Card class="p-3">
       <header :class="{ 'mb-2': label.description }">
         <div class="flex flex-wrap items-end gap-2">

--- a/frontend/pages/location/[id].vue
+++ b/frontend/pages/location/[id].vue
@@ -159,6 +159,9 @@
     </Dialog>
 
     <BaseContainer v-if="location">
+      <!-- set page title -->
+      <Title>{{ location.name }}</Title>
+
       <Card class="p-3">
         <header :class="{ 'mb-2': location?.description }">
           <div class="flex flex-wrap items-end gap-2">


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

When accessing a specific label or location, the page title is now set to the name of that label or location.

The issue was more notorious when opening these pages in new tabs, which didn't inherit the title from the previous page, resulting in a title with the raw page URL.

## Testing

- Use the middle click to open a specific Label or Location.
- The page title should update correctly, instead of showing the page URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The page title now dynamically updates to display the current label or location name on the respective detail pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->