### PR TITLE
feat: Display number of items in Location/Label page

### DIFF
--- a/frontend/components/Item/View/Selectable.vue
+++ b/frontend/components/Item/View/Selectable.vue
@@ -3,6 +3,7 @@
   import type { ItemSummary } from "~~/lib/api/types/data-contracts";
   import MdiCardTextOutline from "~icons/mdi/card-text-outline";
   import MdiTable from "~icons/mdi/table";
+  import { Badge } from "@/components/ui/badge";
   import { Button, ButtonGroup } from "@/components/ui/button";
 
   type Props = {
@@ -29,7 +30,12 @@
 <template>
   <section>
     <BaseSectionHeader class="mb-2 mt-4 flex items-center justify-between">
-      {{ $t("components.item.view.selectable.items") }}
+      <div>
+        {{ $t("components.item.view.selectable.items") }}
+        <Badge>
+          {{ items.length }}
+        </Badge>
+      </div>
       <template #description>
         <div v-if="!viewSet">
           <ButtonGroup>

--- a/frontend/components/Item/View/Selectable.vue
+++ b/frontend/components/Item/View/Selectable.vue
@@ -30,7 +30,7 @@
 <template>
   <section>
     <BaseSectionHeader class="mb-2 mt-4 flex items-center justify-between">
-      <div>
+      <div class="flex gap-2">
         {{ $t("components.item.view.selectable.items") }}
         <Badge>
           {{ items.length }}


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

When viewing a Location or Label page, the number of items directly associated with that Location or Label is now displayed in the section header.

![image](https://github.com/user-attachments/assets/2dd8d06d-e950-4478-81ed-43840eb588a0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The total number of items is now displayed next to the "items" label in the section header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->