### PR TITLE
fix: display all item labels in the element card

### DIFF
--- a/frontend/components/Item/Card.vue
+++ b/frontend/components/Item/Card.vue
@@ -47,7 +47,7 @@
         </TooltipProvider>
         <Markdown class="mb-2 line-clamp-3 text-ellipsis" :source="item.description" />
         <div class="-mr-1 mt-auto flex flex-wrap justify-end gap-2">
-          <LabelChip v-for="label in top3" :key="label.id" :label="label" size="sm" />
+          <LabelChip v-for="label in itemLabels" :key="label.id" :label="label" size="sm" />
         </div>
       </div>
     </NuxtLink>
@@ -76,8 +76,8 @@
     }
   });
 
-  const top3 = computed(() => {
-    return props.item.labels.slice(0, 3) || [];
+  const itemLabels = computed(() => {
+    return props.item.labels || [];
   });
 
   const props = defineProps({


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

This change updates the item card to display all the labels of an item. Displaying only the top 3 labels can be confusing and misleading, since an item can have more labels and these will be hidden unless the user opens the item page.

## Which issue(s) this PR fixes:

Fixes #808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - All item labels are now displayed on item cards, instead of being limited to the top three.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->