### PR TITLE
fix: set page size to 24 in order to always display full rows of items

### DIFF
--- a/frontend/pages/items.vue
+++ b/frontend/pages/items.vue
@@ -512,7 +512,7 @@
       <div
         v-else
         ref="cardgrid"
-        class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5"
+        class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
       >
         <ItemCard v-for="item in items" :key="item.id" :item="item" :location-flat-tree="locationFlatTree" />
       </div>

--- a/frontend/pages/items.vue
+++ b/frontend/pages/items.vue
@@ -52,7 +52,7 @@
     },
   });
 
-  const pageSize = useRouteQuery("pageSize", 30);
+  const pageSize = useRouteQuery("pageSize", 24);
   const query = useRouteQuery("q", "");
   const advanced = useRouteQuery("advanced", false);
   const includeArchived = useRouteQuery("archived", false);
@@ -357,7 +357,7 @@
       query: {
         archived: "false",
         fieldSelector: "false",
-        pageSize: 10,
+        pageSize: pageSize.value,
         page: 1,
         orderBy: "name",
         q: "",


### PR DESCRIPTION
## What type of PR is this?

- cleanup

## What this PR does / why we need it:

Depending on the window size, the search page displays rows with 1, 2, 3 or 4 columns of items. Currently the page size is configured to 30 items per page, which results in an incomplete last row of items when displaying 4 columns.

This change modifies the page size to 24, which is divisible by 4 and 3, so that all the item rows are fully populated.

## Which issue(s) this PR fixes:

\-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Resetting search filters and pagination now correctly retains the current page size setting instead of reverting to a fixed value.
- **Chores**
  - Updated the default page size for item listings from 30 to 24.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->