### PR TITLE
fix: store selected filter locations and labels in the URL

### DIFF
--- a/frontend/pages/items.vue
+++ b/frontend/pages/items.vue
@@ -71,7 +71,10 @@
     loading.value = true;
     // Wait until locations and labels are loaded
     let maxRetry = 10;
-    while (!labels.value || !locations.value) {
+    while (
+        (!labels.value || labels.value.length == 0)
+        || (!locations.value || locations.value.length == 0)
+    ) {
       await new Promise(resolve => setTimeout(resolve, 100));
       if (maxRetry-- < 0) {
         break;
@@ -129,6 +132,30 @@
 
   const locIDs = computed(() => selectedLocations.value.map(l => l.id));
   const labIDs = computed(() => selectedLabels.value.map(l => l.id));
+
+  watch(selectedLocations, newLocs => {
+    if (!queryParamsInitialized.value) return;
+
+    const loc = newLocs.map(l => l.id);
+    router.replace({
+      query: {
+        ...route.query,
+        loc,
+      },
+    });
+  });
+
+  watch(selectedLabels, newLabs => {
+    if (!queryParamsInitialized.value) return;
+
+    const lab = newLabs.map(l => l.id);
+    router.replace({
+      query: {
+        ...route.query,
+        lab,
+      },
+    });
+  });
 
   function parseAssetIDString(d: string) {
     d = d.replace(/"/g, "").replace(/-/g, "");
@@ -329,10 +356,10 @@
         pageSize: pageSize.value,
         page: page.value,
         q: query.value,
-
-        // Non-reactive
         loc: locIDs.value,
         lab: labIDs.value,
+
+        // Non-reactive
         fields,
       },
     });


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

This change updates the URL whenever the location/label filter is modified, so that the filter configuration can be retained when reloading the page.

## Which issue(s) this PR fixes:

Fixes #812