### PR TITLE
Allow github actions on forks

### DIFF
--- a/.github/workflows/docker-publish-rootless.yaml
+++ b/.github/workflows/docker-publish-rootless.yaml
@@ -33,7 +33,7 @@ permissions:
 
 env:
   DOCKERHUB_REPO: sysadminsmedia/homebox
-  GHCR_REPO: ghcr.io/sysadminsmedia/homebox
+  GHCR_REPO: ghcr.io/${{ github.repository }}
 
 jobs:
   build:
@@ -83,7 +83,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
+        if: (github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')) && secrets.DOCKER_USERNAME != ''
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -159,7 +159,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
+        if: (github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')) && secrets.DOCKER_USERNAME != ''
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -204,7 +204,7 @@ jobs:
       - name: Create manifest list and push Dockerhub
         id: push-dockerhub
         working-directory: /tmp/digests
-        if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
+        if: (github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')) && secrets.DOCKER_USERNAME != ''
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.DOCKERHUB_REPO }}@sha256:%s ' *)

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -27,7 +27,7 @@ on:
 
 env:
   DOCKERHUB_REPO: sysadminsmedia/homebox
-  GHCR_REPO: ghcr.io/sysadminsmedia/homebox
+  GHCR_REPO: ghcr.io/${{ github.repository }}
 
 permissions:
   contents: read        # Access to repository contents
@@ -78,7 +78,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
+        if: (github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')) && secrets.DOCKER_USERNAME != ''
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -152,6 +152,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
+        if: secrets.DOCKER_USERNAME != ''
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -194,7 +195,7 @@ jobs:
       - name: Create manifest list and push Dockerhub
         id: push-dockerhub
         working-directory: /tmp/digests
-        if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
+        if: (github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')) && secrets.DOCKER_USERNAME != ''
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.DOCKERHUB_REPO }}@sha256:%s ' *)


### PR DESCRIPTION
## What type of PR is this?

- cleanup / feature

## What this PR does / why we need it:

This PR remove the hardcoded image name for ghcr + make dockerhub optional (only if secret is set).
This allow to enable automatic build (with github actions) on forks.

## Testing

Tested on my fork (https://github.com/mcarbonne/homebox)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to use a dynamic repository reference for container publishing.
  * Enhanced workflow security by ensuring Docker Hub login and manifest push steps only run when Docker Hub credentials are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->