### PR TITLE
fix(frontend/scanner): close scanner modal after successful QR code scan

### DIFF
--- a/frontend/components/App/ScannerModal.vue
+++ b/frontend/components/App/ScannerModal.vue
@@ -33,12 +33,12 @@
 </template>
 
 <script setup lang="ts">
-  import { Dialog, DialogHeader, DialogScrollContent, DialogTitle } from "@/components/ui/dialog";
-  import { useDialog } from "@/components/ui/dialog-provider";
-  import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
   import { BrowserMultiFormatReader, NotFoundException } from "@zxing/library";
   import { computed, ref, watch } from "vue";
   import { useI18n } from "vue-i18n";
+  import { Dialog, DialogHeader, DialogScrollContent, DialogTitle } from "@/components/ui/dialog";
+  import { useDialog } from "@/components/ui/dialog-provider";
+  import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
   import MdiAlertCircleOutline from "~icons/mdi/alert-circle-outline";
 
   const { t } = useI18n();


### PR DESCRIPTION
## What type of PR is this?
- bug

## What this PR does / why we need it:

This PR fixes an issue where the scanner modal remains open after successfully scanning a QR code and navigating to the item page. This creates a poor user experience, especially on mobile devices where the modal occupies most of the screen and users can't tell that navigation has occurred.

**Changes made:**
- Added `closeDialog("scanner")` call after successful QR code scan and before navigation
- Updated the dialog provider import to include `closeDialog` function
- Reordered imports for better organization (alphabetical order)

The fix ensures that when a QR code is successfully scanned and the URL is validated, the scanner modal is automatically dismissed before navigating to the target page, providing clear visual feedback to the user that the scan was successful.

## Which issue(s) this PR fixes:
Fixes #866

## Special notes for your reviewer:

The key change is on line 132 where `closeDialog("scanner")` is called before `navigateTo(sanitizedPath)`. This ensures the modal is closed before navigation occurs, giving users immediate visual feedback that the scan was successful.

The import reordering is a minor cleanup to maintain consistent code style but doesn't affect functionality.

## Testing

- Tested on Safari and Brave browsers on iOS 18.4.1 & Brave browsers on MacOS 15.0.1
- Verified that the scanner modal now closes automatically after successful QR code scan
- Confirmed that navigation still works correctly after the modal is dismissed
- Tested error scenarios to ensure the modal remains open when scan fails (expected behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The scanner dialog now closes automatically after a successful QR code scan and navigation, improving the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->