### PR TITLE
Daily Analytics

### DIFF
--- a/backend/app/api/main.go
+++ b/backend/app/api/main.go
@@ -404,11 +404,11 @@ func run(cfg *config.Config) error {
 	if cfg.Options.AllowAnalytics {
 		runner.AddPlugin(NewTask("send-analytics", time.Duration(24)*time.Hour, func(ctx context.Context) {
 			log.Debug().Msg("running send analytics")
-			analytics.Send(version, build())
+			err := analytics.Send(version, build())
 			if err != nil {
 				log.Error().
 					Err(err).
-					Msg("failed to send analytics")
+					Msg("failed to send scheduled analytics")
 			}
 		}))
 	}

--- a/backend/app/api/main.go
+++ b/backend/app/api/main.go
@@ -45,8 +45,6 @@ var (
 	buildTime = "now"
 )
 
-var analyticsTime time.Duration
-
 func build() string {
 	short := commit
 	if len(short) > 7 {
@@ -105,7 +103,6 @@ func run(cfg *config.Config) error {
 		err := analytics.Send(version, build())
 		if err != nil {
 			log.Error().Err(err).Msg("failed to send analytics")
-			return err
 		}
 	}
 

--- a/backend/app/api/main.go
+++ b/backend/app/api/main.go
@@ -98,14 +98,6 @@ func run(cfg *config.Config) error {
 	app := new(cfg)
 	app.setupLogger()
 
-	// Send analytics if enabled on startup
-	if cfg.Options.AllowAnalytics {
-		err := analytics.Send(version, build())
-		if err != nil {
-			log.Error().Err(err).Msg("failed to send analytics")
-		}
-	}
-
 	// =========================================================================
 	// Initialize Database & Repos
 	setupStorageDir(cfg)

--- a/backend/app/api/main.go
+++ b/backend/app/api/main.go
@@ -45,6 +45,8 @@ var (
 	buildTime = "now"
 )
 
+var analyticsTime time.Duration
+
 func build() string {
 	short := commit
 	if len(short) > 7 {
@@ -208,11 +210,13 @@ func run(cfg *config.Config) error {
 
 	// Send analytics if enabled at around midnight UTC
 	if cfg.Options.AllowAnalytics {
-		runner.AddPlugin(NewTask("send-analytics", time.Hour, func(ctx context.Context) {
+		analyticsTime := time.Second
+		runner.AddPlugin(NewTask("send-analytics", analyticsTime, func(ctx context.Context) {
 			for {
 				now := time.Now().UTC()
 				nextMidnight := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, time.UTC)
 				dur := time.Until(nextMidnight)
+				analyticsTime = dur
 				select {
 				case <-ctx.Done():
 					return

--- a/backend/internal/sys/analytics/analytics.go
+++ b/backend/internal/sys/analytics/analytics.go
@@ -34,7 +34,7 @@ func Send(version, buildInfo string) error {
 			"platform_version": hostData.PlatformVersion,
 			"kernel_arch":      hostData.KernelArch,
 			"virt_type":        hostData.VirtualizationSystem,
-			"uptime_sec":       time.Since(startTime).Seconds(),
+			"uptime_min":       time.Since(startTime).Minutes(),
 		},
 	}
 	jsonBody, err := json.Marshal(analytics)
@@ -50,7 +50,7 @@ func Send(version, buildInfo string) error {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "Homebox/"+version+"/"+buildInfo+" (https://homebox.software)")
+	req.Header.Set("User-Agent", "Homebox/"+version+"/(https://homebox.software)")
 
 	client := &http.Client{
 		Timeout: 10 * time.Second,

--- a/backend/internal/sys/analytics/analytics.go
+++ b/backend/internal/sys/analytics/analytics.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+var startTime = time.Now()
+
 type Data struct {
 	Domain string                 `json:"domain"`
 	Name   string                 `json:"name"`
@@ -18,7 +20,7 @@ type Data struct {
 	Props  map[string]interface{} `json:"props"`
 }
 
-func Send(version, buildInfo string) {
+func Send(version, buildInfo string) error {
 	hostData, _ := host.Info()
 	analytics := Data{
 		Domain: "homebox.software",
@@ -32,18 +34,19 @@ func Send(version, buildInfo string) {
 			"platform_version": hostData.PlatformVersion,
 			"kernel_arch":      hostData.KernelArch,
 			"virt_type":        hostData.VirtualizationSystem,
+			"uptime_sec":       time.Since(startTime).Seconds(),
 		},
 	}
 	jsonBody, err := json.Marshal(analytics)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to marshal analytics data")
-		return
+		return err
 	}
 	bodyReader := bytes.NewReader(jsonBody)
 	req, err := http.NewRequest("POST", "https://a.sysadmins.zone/api/event", bodyReader)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to create analytics request")
-		return
+		return err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -56,7 +59,7 @@ func Send(version, buildInfo string) {
 	res, err := client.Do(req)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to send analytics request")
-		return
+		return err
 	}
 
 	defer func() {
@@ -65,4 +68,5 @@ func Send(version, buildInfo string) {
 			log.Error().Err(err).Msg("failed to close response body")
 		}
 	}()
+	return nil
 }


### PR DESCRIPTION
## What type of PR is this?
- feature

## What this PR does / why we need it:
Currently when analytics are enabled the data is only sent on the server startup, while this does give us some insights it's bad for actual analytical data for things like how many instances are running Homebox with analytics enabled in any given day.

This PR moves the analytics to a 24/hr scheduled task that will run once per day for better analytics use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added daily automated analytics reporting at midnight UTC.
  * Improved error handling and logging for analytics data transmission.
  * Included system uptime tracking in analytics for enhanced insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->