### PR TITLE
Add external label service support to label maker

### DIFF
--- a/backend/app/api/handlers/v1/v1_ctrl_labelmaker.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_labelmaker.go
@@ -29,7 +29,7 @@ func generateOrPrint(ctrl *V1Controller, w http.ResponseWriter, r *http.Request,
 		_, err = w.Write([]byte("Printed!"))
 		return err
 	} else {
-		return labelmaker.GenerateLabel(w, &params)
+		return labelmaker.GenerateLabel(w, &params, ctrl.config)
 	}
 }
 

--- a/backend/internal/sys/config/conf.go
+++ b/backend/internal/sys/config/conf.go
@@ -61,14 +61,16 @@ type WebConfig struct {
 }
 
 type LabelMakerConf struct {
-	Width                 int64   `yaml:"width"     conf:"default:526"`
-	Height                int64   `yaml:"height"    conf:"default:200"`
-	Padding               int64   `yaml:"padding"   conf:"default:32"`
-	Margin                int64   `yaml:"margin"    conf:"default:32"`
-	FontSize              float64 `yaml:"font_size" conf:"default:32.0"`
-	PrintCommand          *string `yaml:"string"`
-	AdditionalInformation *string `yaml:"string"`
-	DynamicLength         bool    `yaml:"bool"      conf:"default:true"`
+	Width                 int64          `yaml:"width"     conf:"default:526"`
+	Height                int64          `yaml:"height"    conf:"default:200"`
+	Padding               int64          `yaml:"padding"   conf:"default:32"`
+	Margin                int64          `yaml:"margin"    conf:"default:32"`
+	FontSize              float64        `yaml:"font_size" conf:"default:32.0"`
+	PrintCommand          *string        `yaml:"string"`
+	AdditionalInformation *string        `yaml:"string"`
+	DynamicLength         bool           `yaml:"bool"      conf:"default:true"`
+	LabelServiceUrl       *string        `yaml:"label_service_url"`
+	LabelServiceTimeout   *time.Duration `yaml:"label_service_timeout"`
 }
 
 type BarcodeAPIConf struct {


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- feature

## What this PR does / why we need it:

_(REQUIRED)_

Allow to customize generated label using external label service

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixed #912
Relates #436

## Special notes for your reviewer:

_(fill-in or delete this section)_

Just specify url in `HBOX_LABEL_MAKER_LABEL_SERVICE_URL` for service which generates PNG labels.