### PR TITLE
Issue437

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,19 @@ WORKDIR /app
 RUN npm install -g pnpm
 
 # Copy over source files and node_modules from dependencies stage
-COPY frontend . 
+COPY frontend .
 COPY --from=frontend-dependencies /app/node_modules ./node_modules
+
+# Accept build args for date format environment variables
+ARG HBOX_DATE_FORMAT_HUMAN
+ARG HBOX_DATE_FORMAT_LONG
+ARG HBOX_DATE_FORMAT_SHORT
+
+# Set environment variables for the build
+ENV HBOX_DATE_FORMAT_HUMAN=$HBOX_DATE_FORMAT_HUMAN
+ENV HBOX_DATE_FORMAT_LONG=$HBOX_DATE_FORMAT_LONG
+ENV HBOX_DATE_FORMAT_SHORT=$HBOX_DATE_FORMAT_SHORT
+
 RUN pnpm build
 
 # Go dependencies stage

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -19,6 +19,17 @@ RUN npm install -g pnpm
 # Copy over source files and node_modules from dependencies stage
 COPY frontend .
 COPY --from=frontend-dependencies /app/node_modules ./node_modules
+
+# Accept build args for date format environment variables
+ARG HBOX_DATE_FORMAT_HUMAN
+ARG HBOX_DATE_FORMAT_LONG
+ARG HBOX_DATE_FORMAT_SHORT
+
+# Set environment variables for the build
+ENV HBOX_DATE_FORMAT_HUMAN=$HBOX_DATE_FORMAT_HUMAN
+ENV HBOX_DATE_FORMAT_LONG=$HBOX_DATE_FORMAT_LONG
+ENV HBOX_DATE_FORMAT_SHORT=$HBOX_DATE_FORMAT_SHORT
+
 RUN pnpm build
 
 # Go dependencies stage

--- a/docs/en/configure/index.md
+++ b/docs/en/configure/index.md
@@ -53,6 +53,74 @@ aside: false
 | HBOX_THUMBNAIL_ENABLED                  | true                                                                       | enable thumbnail generation for images, supports PNG, JPEG, AVIF, WEBP, GIF file types                                                                                                    |
 | HBOX_THUMBNAIL_WIDTH                    | 500                                                                        | width for generated thumbnails in pixels                                                                                                                                                  |
 | HBOX_THUMBNAIL_HEIGHT                   | 500                                                                        | height for generated thumbnails in pixels                                                                                                                                                 |
+| HBOX_DATE_FORMAT_HUMAN                  |                                                                            | custom date format for "human" readable dates (e.g., "MMMM do, yyyy"). If not set, uses locale-aware format                                                                             |
+| HBOX_DATE_FORMAT_LONG                   |                                                                            | custom date format for "long" dates (e.g., "MMM dd, yyyy"). If not set, uses locale-aware format                                                                                        |
+| HBOX_DATE_FORMAT_SHORT                  |                                                                            | custom date format for "short" dates (e.g., "MM/dd/yyyy"). If not set, uses locale-aware format                                                                                         |
+
+### Date Format Configuration
+
+The date format environment variables allow you to customize how dates are displayed throughout the Homebox frontend. These variables use [date-fns format tokens](https://date-fns.org/v2.29.3/docs/format) for flexible date formatting.
+
+| Format Type | Environment Variable | Default Behavior | Example Custom Value | Example Output |
+|-------------|---------------------|------------------|---------------------|----------------|
+| Human       | `HBOX_DATE_FORMAT_HUMAN` | Locale-aware long format | `"MMMM do, yyyy"` | `"August 11th, 2025"` |
+| Long        | `HBOX_DATE_FORMAT_LONG`  | Locale-aware medium format | `"MMM dd, yyyy"` | `"Aug 11, 2025"` |
+| Short       | `HBOX_DATE_FORMAT_SHORT` | Locale-aware short format | `"MM/dd/yyyy"` | `"08/11/2025"` |
+
+#### Common Format Tokens
+
+| Token | Description | Example |
+|-------|-------------|---------|
+| `yyyy` | 4-digit year | `2025` |
+| `yy` | 2-digit year | `25` |
+| `MMMM` | Full month name | `August` |
+| `MMM` | Short month name | `Aug` |
+| `MM` | 2-digit month | `08` |
+| `M` | 1-digit month | `8` |
+| `dd` | 2-digit day | `11` |
+| `d` | 1-digit day | `11` |
+| `do` | Day with ordinal | `11th` |
+
+#### Usage Examples
+
+```bash
+# ISO 8601 format
+HBOX_DATE_FORMAT_SHORT="yyyy-MM-dd"
+
+# European format
+HBOX_DATE_FORMAT_SHORT="dd/MM/yyyy"
+
+# US format with full month names
+HBOX_DATE_FORMAT_LONG="MMMM d, yyyy"
+
+# Compact format
+HBOX_DATE_FORMAT_HUMAN="MMM d, yy"
+```
+
+::: tip
+If any of these environment variables are not set, Homebox will use the default locale-aware formatting based on the user's browser language settings.
+:::
+
+::: warning Docker Build Requirements
+When using Docker, these environment variables must be available at **build time** since the frontend is statically generated. You have two options:
+
+**Option 1: Set as build arguments in docker-compose.yml**
+```yaml
+services:
+  homebox:
+    build:
+      args:
+        - HBOX_DATE_FORMAT_SHORT=dd/MM/yyyy
+        - HBOX_DATE_FORMAT_LONG=dd MMM yyyy
+        - HBOX_DATE_FORMAT_HUMAN=EEEE, dd MMMM yyyy
+```
+
+**Option 2: Set as environment variables before building**
+```bash
+export HBOX_DATE_FORMAT_SHORT="dd/MM/yyyy"
+docker-compose up --build
+```
+:::
 
 ### HBOX_WEB_HOST examples
 

--- a/frontend/composables/use-formatters.test.ts
+++ b/frontend/composables/use-formatters.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fmtDate } from './use-formatters';
+
+// Mock required functions globally
+(global as any).validDate = vi.fn(() => true);
+(global as any).useNuxtApp = vi.fn(() => ({
+  $i18nGlobal: {
+    locale: {
+      value: 'en-US'
+    }
+  }
+}));
+(global as any).useViewPreferences = vi.fn(() => ({
+  value: {
+    overrideFormatLocale: null
+  }
+}));
+(global as any).useRuntimeConfig = vi.fn(() => mockRuntimeConfig);
+
+const mockRuntimeConfig = {
+  public: {
+    hboxDateFormatHuman: '',
+    hboxDateFormatLong: '',
+    hboxDateFormatShort: '',
+  }
+};
+
+vi.mock('#app', () => ({
+  useRuntimeConfig: () => mockRuntimeConfig,
+  useNuxtApp: () => ({
+    $i18nGlobal: {
+      locale: {
+        value: 'en-US'
+      }
+    }
+  })
+}));
+
+vi.mock('~/composables/utils', () => ({
+  validDate: vi.fn(() => true)
+}));
+
+vi.mock('~/composables/use-preferences', () => ({
+  useViewPreferences: () => ({
+    value: {
+      overrideFormatLocale: null
+    }
+  })
+}));
+
+vi.mock('date-fns', () => ({
+  format: vi.fn((date, formatStr) => {
+    if (formatStr === 'PPP') return 'January 2nd, 2006';
+    if (formatStr === 'PP') return 'Jan 2, 2006';
+    if (formatStr === 'P') return '01/02/2006';
+    if (formatStr === 'dd/MM/yyyy') return '02/01/2006';
+    if (formatStr === 'yyyy-MM-dd') return '2006-01-02';
+    if (formatStr === 'MMM d, yyyy') return 'Jan 2, 2006';
+    return formatStr; // fallback
+  })
+}));
+
+describe('fmtDate with environment variable overrides', () => {
+  const testDate = new Date('2006-01-02T15:04:05-07:00');
+
+  beforeEach(() => {
+    mockRuntimeConfig.public.hboxDateFormatHuman = '';
+    mockRuntimeConfig.public.hboxDateFormatLong = '';
+    mockRuntimeConfig.public.hboxDateFormatShort = '';
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('default behavior (no environment variables)', () => {
+    it('should use default PPP format for human', () => {
+      const result = fmtDate(testDate, 'human');
+      expect(result).toBe('January 2nd, 2006');
+    });
+
+    it('should use default PP format for long', () => {
+      const result = fmtDate(testDate, 'long');
+      expect(result).toBe('Jan 2, 2006');
+    });
+
+    it('should use default P format for short', () => {
+      const result = fmtDate(testDate, 'short');
+      expect(result).toBe('01/02/2006');
+    });
+  });
+
+  describe('with environment variable overrides', () => {
+    it('should use custom format for human when HBOX_DATE_FORMAT_HUMAN is set', () => {
+      mockRuntimeConfig.public.hboxDateFormatHuman = 'MMM d, yyyy';
+      const result = fmtDate(testDate, 'human');
+      expect(result).toBe('Jan 2, 2006');
+    });
+
+    it('should use custom format for long when HBOX_DATE_FORMAT_LONG is set', () => {
+      mockRuntimeConfig.public.hboxDateFormatLong = 'yyyy-MM-dd';
+      const result = fmtDate(testDate, 'long');
+      expect(result).toBe('2006-01-02');
+    });
+
+    it('should use custom format for short when HBOX_DATE_FORMAT_SHORT is set', () => {
+      mockRuntimeConfig.public.hboxDateFormatShort = 'dd/MM/yyyy';
+      const result = fmtDate(testDate, 'short');
+      expect(result).toBe('02/01/2006');
+    });
+
+    it('should fallback to default when custom format is empty string', () => {
+      mockRuntimeConfig.public.hboxDateFormatShort = '';
+      const result = fmtDate(testDate, 'short');
+      expect(result).toBe('01/02/2006');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return empty string for invalid format type', () => {
+      const result = fmtDate(testDate, 'invalid' as any);
+      expect(result).toBe('');
+    });
+
+    it('should handle string date input', () => {
+      const result = fmtDate('2006-01-02', 'short');
+      expect(result).toBe('01/02/2006');
+    });
+
+    it('should handle number date input', () => {
+      const result = fmtDate(1136239445000, 'short'); 
+      expect(result).toBe('01/02/2006');
+    });
+  });
+});

--- a/frontend/composables/use-formatters.ts
+++ b/frontend/composables/use-formatters.ts
@@ -67,15 +67,18 @@ export function fmtDate(
 
   let formatStr = "";
 
+  // Get runtime config for custom date formats
+  const config = useRuntimeConfig();
+
   switch (fmt) {
     case "human":
-      formatStr = "PPP";
+      formatStr = (config.public.hboxDateFormatHuman as string) || "PPP";
       break;
     case "long":
-      formatStr = "PP";
+      formatStr = (config.public.hboxDateFormatLong as string) || "PP";
       break;
     case "short":
-      formatStr = "P";
+      formatStr = (config.public.hboxDateFormatShort as string) || "P";
       break;
     default:
       return "";

--- a/frontend/lib/datelib/datelib.ts
+++ b/frontend/lib/datelib/datelib.ts
@@ -11,9 +11,7 @@ export function format(date: Date | string): string {
 }
 
 export function zeroTime(date: Date): Date {
-  return new Date(
-    new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime() - date.getTimezoneOffset() * 60000
-  );
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
 
 export function factorRange(offset: number = 7): [Date, Date] {

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -94,5 +94,13 @@ export default defineNuxtConfig({
     },
   },
 
+  runtimeConfig: {
+    public: {
+      hboxDateFormatHuman: process.env.HBOX_DATE_FORMAT_HUMAN || '',
+      hboxDateFormatLong: process.env.HBOX_DATE_FORMAT_LONG || '',
+      hboxDateFormatShort: process.env.HBOX_DATE_FORMAT_SHORT || '',
+    }
+  },
+
   compatibilityDate: "2024-11-29",
 });


### PR DESCRIPTION

## What type of PR is this?

- bug
- documentation
- feature

## What this PR does / why we need it:

Resolves most of the issues in #437 


## Which issue(s) this PR fixes:

Fixes #424 
Fixes #515 
Probably fixes #418
Resolves #331

## Special notes for your reviewer:

Tested locally with the following docker-compose.yml, provided for your convenience:

```
services:
  homebox:
    image: homebox-dev
    build:
      context: .
      dockerfile: ./Dockerfile.rootless
      args:
        - COMMIT=head
        - BUILD_TIME=0001-01-01T00:00:00Z
        #- HBOX_DATE_FORMAT_HUMAN=
        #- HBOX_DATE_FORMAT_LONG=
        - HBOX_DATE_FORMAT_SHORT=dd/MM/yyyy
        - TZ=America/New_York
      x-bake:
        platforms:
            - linux/amd64
            - linux/arm64
            - linux/arm/v7
    environment:
      - HBOX_DEBUG=true
      - HBOX_LOGGER_LEVEL=-1
      - TZ=America/New_York
    ports:
      - 3100:7745
    volumes:
      - ./data:/data
```

## Testing

- Edited multiple assets multiple times, setting different purchase/warranty/sold dates, saving changes, editing and saving again, confirming dates save as expected and don't change during subsequent saves
- Included automated tests for overriding date format, tested manually using env var in dev docker container