### PR TITLE
fix: Allow up to 1000 characters for label description

### DIFF
--- a/backend/app/api/static/docs/docs.go
+++ b/backend/app/api/static/docs/docs.go
@@ -3639,7 +3639,7 @@ const docTemplate = `{
                 },
                 "description": {
                     "type": "string",
-                    "maxLength": 255
+                    "maxLength": 1000
                 },
                 "name": {
                     "type": "string",

--- a/backend/app/api/static/docs/swagger.json
+++ b/backend/app/api/static/docs/swagger.json
@@ -3637,7 +3637,7 @@
                 },
                 "description": {
                     "type": "string",
-                    "maxLength": 255
+                    "maxLength": 1000
                 },
                 "name": {
                     "type": "string",

--- a/backend/app/api/static/docs/swagger.yaml
+++ b/backend/app/api/static/docs/swagger.yaml
@@ -1012,7 +1012,7 @@ definitions:
       color:
         type: string
       description:
-        maxLength: 255
+        maxLength: 1000
         type: string
       name:
         maxLength: 255

--- a/backend/internal/data/repo/repo_labels.go
+++ b/backend/internal/data/repo/repo_labels.go
@@ -20,14 +20,14 @@ type LabelRepository struct {
 type (
 	LabelCreate struct {
 		Name        string `json:"name"        validate:"required,min=1,max=255"`
-		Description string `json:"description" validate:"max=255"`
+		Description string `json:"description" validate:"max=1000"`
 		Color       string `json:"color"`
 	}
 
 	LabelUpdate struct {
 		ID          uuid.UUID `json:"id"`
 		Name        string    `json:"name"        validate:"required,min=1,max=255"`
-		Description string    `json:"description" validate:"max=255"`
+		Description string    `json:"description" validate:"max=1000"`
 		Color       string    `json:"color"`
 	}
 

--- a/docs/en/api/openapi-2.0.json
+++ b/docs/en/api/openapi-2.0.json
@@ -3637,7 +3637,7 @@
                 },
                 "description": {
                     "type": "string",
-                    "maxLength": 255
+                    "maxLength": 1000
                 },
                 "name": {
                     "type": "string",

--- a/docs/en/api/openapi-2.0.yaml
+++ b/docs/en/api/openapi-2.0.yaml
@@ -1012,7 +1012,7 @@ definitions:
       color:
         type: string
       description:
-        maxLength: 255
+        maxLength: 1000
         type: string
       name:
         maxLength: 255

--- a/frontend/components/Label/CreateModal.vue
+++ b/frontend/components/Label/CreateModal.vue
@@ -12,7 +12,7 @@
       <FormTextArea
         v-model="form.description"
         :label="$t('components.label.create_modal.label_description')"
-        :max-length="255"
+        :max-length="1000"
       />
       <ColorSelector v-model="form.color" :label="$t('components.label.create_modal.label_color')" :show-hex="true" />
       <div class="mt-4 flex flex-row-reverse">

--- a/frontend/lib/api/types/data-contracts.ts
+++ b/frontend/lib/api/types/data-contracts.ts
@@ -648,7 +648,7 @@ export interface ItemUpdate {
 
 export interface LabelCreate {
   color: string;
-  /** @maxLength 255 */
+  /** @maxLength 1000 */
   description: string;
   /**
    * @minLength 1

--- a/frontend/pages/label/[id].vue
+++ b/frontend/pages/label/[id].vue
@@ -129,7 +129,7 @@
         <FormTextArea
           v-model="updateData.description"
           :label="$t('components.label.create_modal.label_description')"
-          :max-length="255"
+          :max-length="1000"
         />
         <ColorSelector
           v-model="updateData.color"


### PR DESCRIPTION
## What type of PR is this?
- bug

## What this PR does / why we need it:
The database schema already supports 1,000 characters for label description, so this seems just like an oversight.

## Special notes for your reviewer:
The change fixes both the creation and update forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Increased label description limit from 255 to 1000 characters across create and edit flows.
  * Frontend forms and server-side validation now support the higher limit, with appropriate input constraints and messages.

* Documentation
  * API contract annotations updated to reflect the 1000-character maximum for label descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->