### PR TITLE
fix: Remove log.Fatal in favor of returning errors

### DIFF
--- a/backend/app/api/main.go
+++ b/backend/app/api/main.go
@@ -103,31 +103,50 @@ func run(cfg *config.Config) error {
 
 	// =========================================================================
 	// Initialize Database & Repos
-	setupStorageDir(cfg)
+	err := setupStorageDir(cfg)
+	if err != nil {
+		return err
+	}
 
 	if strings.ToLower(cfg.Database.Driver) == "postgres" {
 		if !validatePostgresSSLMode(cfg.Database.SslMode) {
-			log.Fatal().Str("sslmode", cfg.Database.SslMode).Msg("invalid sslmode")
+			log.Error().Str("sslmode", cfg.Database.SslMode).Msg("invalid sslmode")
+			return fmt.Errorf("invalid sslmode: %s", cfg.Database.SslMode)
 		}
 	}
 
-	databaseURL := setupDatabaseURL(cfg)
+	databaseURL, err := setupDatabaseURL(cfg)
+	if err != nil {
+		return err
+	}
 
 	c, err := ent.Open(strings.ToLower(cfg.Database.Driver), databaseURL)
 	if err != nil {
-		log.Fatal().
+		log.Error().
 			Err(err).
 			Str("driver", strings.ToLower(cfg.Database.Driver)).
 			Str("host", cfg.Database.Host).
 			Str("port", cfg.Database.Port).
 			Str("database", cfg.Database.Database).
 			Msg("failed opening connection to {driver} database at {host}:{port}/{database}")
+		return fmt.Errorf("failed opening connection to %s database at %s:%s/%s: %w",
+			strings.ToLower(cfg.Database.Driver),
+			cfg.Database.Host,
+			cfg.Database.Port,
+			cfg.Database.Database,
+			err,
+		)
 	}
 
-	goose.SetBaseFS(migrations.Migrations(strings.ToLower(cfg.Database.Driver)))
+	migrationsFs, err := migrations.Migrations(strings.ToLower(cfg.Database.Driver))
+	if err != nil {
+		return fmt.Errorf("failed to get migrations for %s: %w", strings.ToLower(cfg.Database.Driver), err)
+	}
+
+	goose.SetBaseFS(migrationsFs)
 	err = goose.SetDialect(strings.ToLower(cfg.Database.Driver))
 	if err != nil {
-		log.Fatal().Str("driver", cfg.Database.Driver).Msg("unsupported database driver")
+		log.Error().Str("driver", cfg.Database.Driver).Msg("unsupported database driver")
 		return fmt.Errorf("unsupported database driver: %s", cfg.Database.Driver)
 	}
 

--- a/backend/app/api/recurring.go
+++ b/backend/app/api/recurring.go
@@ -3,13 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/hay-kot/httpkit/graceful"
-	"github.com/sysadminsmedia/homebox/backend/internal/sys/config"
 	"net/http"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hay-kot/httpkit/graceful"
 	"github.com/rs/zerolog/log"
+	"github.com/sysadminsmedia/homebox/backend/internal/sys/config"
 	"github.com/sysadminsmedia/homebox/backend/pkgs/utils"
 	"gocloud.dev/pubsub"
 )
@@ -22,7 +22,8 @@ func registerRecurringTasks(app *app, cfg *config.Config, runner *graceful.Runne
 			log.Info().Msg("Running in demo mode, creating demo data")
 			err := app.SetupDemo()
 			if err != nil {
-				log.Fatal().Msg(err.Error())
+				log.Error().Err(err).Msg("failed to setup demo data")
+				return fmt.Errorf("failed to setup demo data: %w", err)
 			}
 		}
 		return nil

--- a/backend/internal/data/migrations/migrations.go
+++ b/backend/internal/data/migrations/migrations.go
@@ -3,6 +3,8 @@ package migrations
 
 import (
 	"embed"
+	"fmt"
+
 	"github.com/rs/zerolog/log"
 )
 
@@ -17,15 +19,16 @@ var sqliteFiles embed.FS
 // migration files in the binary at build time. The function takes a string
 // parameter "dialect" which specifies the SQL dialect to use. It returns an
 // embedded file system containing the migration files for the specified dialect.
-func Migrations(dialect string) embed.FS {
+func Migrations(dialect string) (embed.FS, error) {
 	switch dialect {
 	case "postgres":
-		return postgresFiles
+		return postgresFiles, nil
 	case "sqlite3":
-		return sqliteFiles
+		return sqliteFiles, nil
 	default:
-		log.Fatal().Str("dialect", dialect).Msg("unknown sql dialect")
+		log.Error().Str("dialect", dialect).Msg("unknown sql dialect")
+		return embed.FS{}, fmt.Errorf("unknown sql dialect: %s", dialect)
 	}
 	// This should never get hit, but just in case
-	return sqliteFiles
+	return sqliteFiles, nil
 }


### PR DESCRIPTION
## What type of PR is this?
- cleanup

## What this PR does / why we need it:
This change is useful for including error tracking, which needs the application to not terminate immediately, and instead give the tracer time to capture and flush errors.