### PR TITLE
Create hardened docker image

### DIFF
--- a/.github/workflows/docker-publish-hardened.yaml
+++ b/.github/workflows/docker-publish-hardened.yaml
@@ -1,4 +1,4 @@
-name: Docker publish rootless
+name: Docker publish hardened
 
 on:
   schedule:
@@ -8,9 +8,9 @@ on:
     paths:
       - 'backend/**'
       - 'frontend/**'
-      - 'Dockerfile.rootless'
+      - 'Dockerfile.hardened'
       - '.dockerignore'
-      - '.github/workflows/docker-publish-rootless.yaml'
+      - '.github/workflows/docker-publish-hardened.yaml'
     ignore:
       - 'docs/**'
     tags: [ 'v*.*.*' ]
@@ -19,9 +19,9 @@ on:
     paths:
       - 'backend/**'
       - 'frontend/**'
-      - 'Dockerfile.rootless'
+      - 'Dockerfile.hardened'
       - '.dockerignore'
-      - '.github/workflows/docker-publish-rootless.yaml'
+      - '.github/workflows/docker-publish-hardened.yaml.yaml'
     ignore:
       - 'docs/**'
 
@@ -111,12 +111,12 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: . # Explicitly specify the build context
-          file: ./Dockerfile.rootless # Explicitly specify the Dockerfile
+          file: ./Dockerfile.hardened # Explicitly specify the Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,"name=${{ env.DOCKERNAMES }}",push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
-          cache-from: type=registry,ref=ghcr.io/sysadminsmedia/devcache:${{ env.PLATFORM_PAIR }}-${{ env.BRANCH }}-rootless
-          cache-to: type=registry,ref=ghcr.io/sysadminsmedia/devcache:${{ env.PLATFORM_PAIR }}-${{ env.BRANCH }}-rootless,mode=max,ignore-error=true
+          cache-from: type=registry,ref=ghcr.io/sysadminsmedia/devcache:${{ env.PLATFORM_PAIR }}-${{ env.BRANCH }}-hardened
+          cache-to: type=registry,ref=ghcr.io/sysadminsmedia/devcache:${{ env.PLATFORM_PAIR }}-${{ env.BRANCH }}-hardened,mode=max,ignore-error=true
           build-args: |
             VERSION=${{ github.ref_name }}
             COMMIT=${{ github.sha }}
@@ -192,7 +192,7 @@ jobs:
             type=semver,pattern={{major}}
             type=schedule,pattern=nightly
           flavor: |
-            suffix=-rootless,onlatest=true
+            suffix=-hardened,onlatest=true
 
       - name: Create manifest list and push GHCR
         id: push-ghcr

--- a/Dockerfile.hardened
+++ b/Dockerfile.hardened
@@ -63,7 +63,7 @@ RUN mkdir /app
 RUN mkdir /data
 
 # Production stage
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/static:nonroot
 ENV HBOX_MODE=production
 ENV HBOX_STORAGE_CONN_STRING=file:///?no_tmp_dir=true
 ENV HBOX_STORAGE_PREFIX_PATH=data
@@ -81,10 +81,6 @@ LABEL org.opencontainers.image.source="https://github.com/sysadminsmedia/homebox
 # Expose necessary ports for Homebox
 EXPOSE 7745
 WORKDIR /app
-
-# Healthcheck configuration
-HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD [ "wget", "--no-verbose", "--tries=1", "-O", "-", "http://localhost:7745/api/v1/status" ]
 
 # Persist volume for data
 VOLUME [ "/data" ]

--- a/Dockerfile.hardened
+++ b/Dockerfile.hardened
@@ -1,0 +1,95 @@
+# Node dependencies stage
+FROM public.ecr.aws/docker/library/node:lts-alpine AS frontend-dependencies
+WORKDIR /app
+
+# Install pnpm globally (caching layer)
+RUN npm install -g pnpm
+
+# Copy package.json and lockfile to leverage caching
+COPY frontend/package.json frontend/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Build Nuxt (frontend) stage
+FROM public.ecr.aws/docker/library/node:lts-alpine AS frontend-builder
+WORKDIR /app
+
+# Install pnpm globally again (it can reuse the cache if not changed)
+RUN npm install -g pnpm
+
+# Copy over source files and node_modules from dependencies stage
+COPY frontend .
+COPY --from=frontend-dependencies /app/node_modules ./node_modules
+RUN pnpm build
+
+# Go dependencies stage
+FROM public.ecr.aws/docker/library/golang:alpine AS builder-dependencies
+WORKDIR /go/src/app
+
+# Copy go.mod and go.sum for better caching
+COPY ./backend/go.mod ./backend/go.sum ./
+RUN go mod download
+
+# Build API stage
+FROM public.ecr.aws/docker/library/golang:alpine AS builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG BUILD_TIME
+ARG COMMIT
+ARG VERSION
+
+# Install necessary build tools
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache git build-base gcc g++
+
+WORKDIR /go/src/app
+
+# Copy Go modules (from dependencies stage) and source code
+COPY --from=builder-dependencies /go/pkg/mod /go/pkg/mod
+COPY ./backend .
+
+# Clear old public files and copy new ones from frontend build
+RUN rm -rf ./app/api/public
+COPY --from=frontend-builder /app/.output/public ./app/api/static/public
+
+# Use cache for Go build artifacts
+RUN --mount=type=cache,target=/root/.cache/go-build \
+     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
+        -ldflags "-s -w -X main.commit=$COMMIT -X main.buildTime=$BUILD_TIME -X main.version=$VERSION" \
+        -tags nodynamic -o /go/bin/api -v ./app/api/*.go;
+
+RUN chmod +x /go/bin/api
+RUN mkdir /app
+RUN mkdir /data
+
+# Production stage
+FROM gcr.io/distroless/base
+ENV HBOX_MODE=production
+ENV HBOX_STORAGE_CONN_STRING=file:///?no_tmp_dir=true
+ENV HBOX_STORAGE_PREFIX_PATH=data
+ENV HBOX_DATABASE_SQLITE_PATH=/data/homebox.db?_pragma=busy_timeout=2000&_pragma=journal_mode=WAL&_fk=1&_time_format=sqlite
+
+# Create application directory and copy over built Go binary
+COPY --from=builder --chown=65532:65532 /app /app
+COPY --from=builder --chown=65532:65532 --chmod=775 /go/bin/api /app
+COPY --from=builder --chown=65532:65532 /data /data
+
+# Labels and configuration for the final image
+LABEL Name=homebox Version=0.0.1
+LABEL org.opencontainers.image.source="https://github.com/sysadminsmedia/homebox"
+
+# Expose necessary ports for Homebox
+EXPOSE 7745
+WORKDIR /app
+
+# Healthcheck configuration
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD [ "wget", "--no-verbose", "--tries=1", "-O", "-", "http://localhost:7745/api/v1/status" ]
+
+# Persist volume for data
+VOLUME [ "/data" ]
+
+# Entrypoint and CMD
+USER 65532
+ENTRYPOINT [ "/app/api" ]
+CMD [ "/data/config.yml" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: homebox
     build:
       context: .
-      dockerfile: ./Dockerfile.rootless
+      dockerfile: ./Dockerfile.hardened
       args:
         - COMMIT=head
         - BUILD_TIME=0001-01-01T00:00:00Z


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Adds a "hardened" docker image option, this provides a "hardened" image that contains just the bare minimum required essentially. Providing the benefits of docker, without any of the fluff of a full blown distro like Alpine.

## Note
This image does not have a healthcheck as it stands, adding wget/curl has proven to be a rather complex en-devour. 