### PR TITLE
fix(item): remove line break in Items label in location view

### DIFF
--- a/frontend/components/global/DetailsSection/DetailsSection.vue
+++ b/frontend/components/global/DetailsSection/DetailsSection.vue
@@ -171,7 +171,6 @@
     word-wrap: break-word;
     -ms-word-break: break-all;
     word-break: break-all;
-    word-break: break-word;
     -ms-hyphens: auto;
     -moz-hyphens: auto;
     -webkit-hyphens: auto;


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

<!--
  Delete any of the following that do not apply:
 -->

bug


## What this PR does / why we need it:


<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

## Which issue(s) this PR fixes:

Fix #972 

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->

## Special notes for your reviewer:

Fix was to remove deprecated CSS properties based on Mozilla official documentation https://developer.mozilla.org/en-US/docs/Web/CSS/word-break 

<!--
   Is there any particular feedback you would / wouldn't like?
   Which parts of the code should reviewers focus on?
-->

## Testing

### Before changes

**FIrefox**
<img width="1325" height="213" alt="image" src="https://github.com/user-attachments/assets/ef3522ea-78d8-4b2c-8837-34979923f140" />

**Brave**
<img width="1322" height="182" alt="image" src="https://github.com/user-attachments/assets/363cecbb-637d-4c1f-900e-e15c2646415e" />

### After changes

**FIrefox**
<img width="1448" height="225" alt="image" src="https://github.com/user-attachments/assets/3c54262f-92b8-4b31-aa38-e8080575cd3f" />

**Brave**
<img width="1322" height="182" alt="image" src="https://github.com/user-attachments/assets/be6ddfbd-da4b-45be-9f67-a5dfc01a6b81" />
 
<!--
  Describe how you tested this change.
-->