### PR TITLE
Set default postgres sql_mode to require

### DIFF
--- a/backend/internal/sys/config/conf_database.go
+++ b/backend/internal/sys/config/conf_database.go
@@ -17,7 +17,7 @@ type Database struct {
 	Host             string `yaml:"host"`
 	Port             string `yaml:"port"`
 	Database         string `yaml:"database"`
-	SslMode          string `yaml:"ssl_mode"           conf:"default:prefer"`
+	SslMode          string `yaml:"ssl_mode"           conf:"default:require"`
 	SslRootCert      string `yaml:"ssl_rootcert"`
 	SslCert          string `yaml:"ssl_cert"`
 	SslKey           string `yaml:"ssl_key"`


### PR DESCRIPTION

## What type of PR is this?

_(REQUIRED)_
- bug

## What this PR does / why we need it:

libpq does not support the current default (prefer). This sets the default sql_mode to match libpq's default which is require

## Which issue(s) this PR fixes:

fixes #985