### PR TITLE
Item search query parameter modernisation

### DIFF
--- a/frontend/pages/items.vue
+++ b/frontend/pages/items.vue
@@ -229,20 +229,17 @@
 
     await router.push({
       query: {
-        // Reactive
-        archived: includeArchived.value ? "true" : "false",
-        fieldSelector: fieldSelector.value ? "true" : "false",
-        negateLabels: negateLabels.value ? "true" : "false",
-        onlyWithoutPhoto: onlyWithoutPhoto.value ? "true" : "false",
-        onlyWithPhoto: onlyWithPhoto.value ? "true" : "false",
-        orderBy: orderBy.value,
-        page: page.value,
-        q: query.value,
-
-        // Non-reactive
-        loc: locIDs.value,
-        lab: labIDs.value,
-        fields,
+        archived: includeArchived.value ? "true" : undefined,
+        fieldSelector: fieldSelector.value ? "true" : undefined,
+        negateLabels: negateLabels.value ? "true" : undefined,
+        onlyWithoutPhoto: onlyWithoutPhoto.value ? "true" : undefined,
+        onlyWithPhoto: onlyWithPhoto.value ? "true" : undefined,
+        orderBy: orderBy.value && orderBy.value !== "name" ? orderBy.value : undefined,
+        page: page.value && page.value !== 1 ? page.value : undefined,
+        q: query.value && query.value !== "" ? query.value : undefined,
+        loc: locIDs.value && locIDs.value.length > 0 ? locIDs.value : undefined,
+        lab: labIDs && labIDs.value.length > 0 ? labIDs.value : undefined,
+        fields: fields && fields.length > 0 ? fields : undefined,
       },
     });
 
@@ -287,9 +284,6 @@
 
   watchDebounced([page, pageSize, query, selectedLabels, selectedLocations], search, { debounce: 250, maxWait: 1000 });
 
-  async function updateRoute() {
-  }
-
   async function submit() {
     // Set URL Params
     const fields = [];
@@ -298,8 +292,6 @@
         fields.push(`${t[0]}=${t[1]}`);
       }
     }
-
-    await updateRoute()
 
     // Reset Pagination
     page.value = 1;

--- a/frontend/pages/items.vue
+++ b/frontend/pages/items.vue
@@ -63,15 +63,8 @@
 
   onMounted(async () => {
     loading.value = true;
-    // Wait until locations and labels are loaded
-    let maxRetry = 10;
-    while (!labels.value || !locations.value) {
-      await new Promise(resolve => setTimeout(resolve, 100));
-      if (maxRetry-- < 0) {
-        break;
-      }
-    }
     searchLocked.value = true;
+    await Promise.all([locationsStore.ensureLocationsFetched(), labelStore.ensureAllLabelsFetched()]);
     const qLoc = route.query.loc as string[];
     if (qLoc) {
       selectedLocations.value = locations.value.filter(l => qLoc.includes(l.id));
@@ -111,7 +104,7 @@
 
   const locationsStore = useLocationStore();
 
-  const locationFlatTree = await useFlatLocations();
+  const locationFlatTree = useFlatLocations();
 
   const locations = computed(() => locationsStore.allLocations);
 

--- a/frontend/stores/labels.ts
+++ b/frontend/stores/labels.ts
@@ -13,19 +13,22 @@ export const useLabelStore = defineStore("labels", {
      * response.
      */
     labels(state): LabelOut[] {
-      if (state.allLabels === null) {
-        this.client.labels.getAll().then(result => {
-          if (result.error) {
-            console.error(result.error);
-          }
-
-          this.allLabels = result.data;
-        });
-      }
+      // ensures that labels are eventually available but not synchronously
+      state.ensureAllLabelsFetched()
       return state.allLabels ?? [];
     },
   },
   actions: {
+    async ensureAllLabelsFetched() {
+      if (this.allLabels !== null) {
+          return;
+      }
+
+      if (this.refreshAllLabelsPromise === undefined) {
+          this.refreshAllLabelsPromise = this.refresh()
+      }
+      await this.refreshAllLabelsPromise;
+    },
     async refresh() {
       const result = await this.client.labels.getAll();
       if (result.error) {

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -ex
+cd "$(dirname "$0")"
+
+TAG=homebox:dev
+docker build -t=$TAG .
+docker run --rm -p 7745:7745 -v ./data:/data $TAG


### PR DESCRIPTION
Changes:
1. Fixes #812 in 59a6f68ed48f3d9ebd2fd9e50e993f5dcb2954ef
2. The search is triggered with every change in the query/filters, but it was not reflected in the query parameters until submit was pressed. This inconsistency was fixed in 41ba42d45ee09ba4b6f339fdb23a05fba5421eea
3. Previously an "advanced" query parameter was used to keep the URL clean until an explicit query/filter was applied. Then however, **all** settings were persisted in the query. This makes links less nice than they have to be, so prevented default settings from being persisted in 95b95d4fd79cc26ab455ce4423786c95ee5a4949 and e54f8247d94377154ac8d709f740927d7c24188e
4. Finally, I added script to easily test changes. This allowed me to contribute without a proper understanding of the vue/go development environment. 3c05f642c187370612573fca8f405abd3112dfd9

Feel free separate the changes, although 2 and 3 are slightly related since I removed "advanced" already in 2. :)