### PR TITLE
chore: update icon for button to duplicate items

### DIFF
--- a/frontend/pages/item/[id]/index.vue
+++ b/frontend/pages/item/[id]/index.vue
@@ -7,8 +7,8 @@
   import MdiPackageVariant from "~icons/mdi/package-variant";
   import MdiPlus from "~icons/mdi/plus";
   import MdiMinus from "~icons/mdi/minus";
-  import MdiContentCopy from "~icons/mdi/content-copy";
   import MdiDelete from "~icons/mdi/delete";
+  import MdiPlusBoxMultipleOutline from "~icons/mdi/plus-box-multiple-outline";
   import { Separator } from "@/components/ui/separator";
   import {
     Breadcrumb,
@@ -652,7 +652,7 @@
                 <span class="hidden md:inline">{{ $t("global.create_subitem") }}</span>
               </Button>
               <Button class="w-9 md:w-auto" :aria-label="$t('global.duplicate')" @click="handleDuplicateClick">
-                <MdiContentCopy />
+                <MdiPlusBoxMultipleOutline />
                 <span class="hidden md:inline">{{ $t("global.duplicate") }}</span>
               </Button>
               <Button variant="destructive" class="w-9 md:w-auto" :aria-label="$t('global.delete')" @click="deleteItem">


### PR DESCRIPTION
## What type of PR is this?

- enhancement

## What this PR does / why we need it:

The icon used for the buttons used to duplicate an item and to copy the URL are the same. This is especially a problem on mobile devices, where the "Duplicate item" button does not display its text.

This change updates the icon for the "Duplicate item" button to [`plus-box-multiple-outline`](https://pictogrammers.com/library/mdi/icon/plus-box-multiple-outline/) so both actions can be more easily differenced.

## Which issue(s) this PR fixes:

\-

## Special notes for your reviewer:

\-

## Testing

\-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the duplicate button icon on the item page to a clearer "add multiple" symbol, improving visual clarity and discoverability.
  * Aligns the button’s appearance with other icons across the app for better UI consistency.
  * No functional changes; the duplicate action behaves the same, with a refreshed visual presentation for improved usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->