### PR TITLE
Revert "Fix/Set single connection pool for sqlite3"

### DIFF
--- a/backend/app/api/main.go
+++ b/backend/app/api/main.go
@@ -138,13 +138,6 @@ func run(cfg *config.Config) error {
 		)
 	}
 
-	if strings.ToLower(cfg.Database.Driver) == "sqlite3" {
-		db := c.Sql()
-		db.SetMaxOpenConns(1)
-		db.SetMaxIdleConns(1)
-		log.Info().Msg("SQLite connection pool configured: max_open=1, max_idle=1")
-	}
-
 	migrationsFs, err := migrations.Migrations(strings.ToLower(cfg.Database.Driver))
 	if err != nil {
 		return fmt.Errorf("failed to get migrations for %s: %w", strings.ToLower(cfg.Database.Driver), err)


### PR DESCRIPTION
Reverts sysadminsmedia/homebox#1039

Currently this introduces a lot of bugs, while eventually we should probably reintroduce this for now im going to revert it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Database connection pool configuration is now applied uniformly across all database types. SQLite-specific connection pooling limits have been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->