### PR TITLE
Fix typo in swagger-2.0.yaml

### DIFF
--- a/docs/en/api/swagger-2.0.yaml
+++ b/docs/en/api/swagger-2.0.yaml
@@ -2161,7 +2161,7 @@ paths:
       summary: Import Items
       tags:
       - Items
-  /v1/labelmaker/assets/{id}:
+  /v1/labelmaker/asset/{id}:
     get:
       parameters:
       - description: Asset ID


### PR DESCRIPTION
Fixes an incorrect path in the Swagger docs.

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

- bug
- documentation

## What this PR does / why we need it:

This PR fixes an error in the Swagger documentation for the API.


<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->

Files changed:

- `docs/en/api/swagger-2.0.yaml`: Fixed labelmaker GET endpoint for getting labels by asset ID


## Which issue(s) this PR fixes:

The API endpoint in the `swagger-2.0.yml` file for the labelmaker GET operation by asset ID was incorrect -- it should be

```
/api/v1/labelmaker/asset/{id}
```

instead of

```
/api/v1/labelmaker/assets/{id}
```

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->


## Testing

I tested it by modifying my curl invocation to use the correct API endpoint.