### PR TITLE
Attempt to revert NodeJS so ARM 32bit builds work again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Node dependencies stage
-FROM public.ecr.aws/docker/library/node:24.9-alpine AS frontend-dependencies
+FROM public.ecr.aws/docker/library/node:22-alpine AS frontend-dependencies
 WORKDIR /app
 
 # Install pnpm globally (caching layer)
@@ -10,7 +10,7 @@ COPY frontend/package.json frontend/pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
 # Build Nuxt (frontend) stage
-FROM public.ecr.aws/docker/library/node:24.9-alpine AS frontend-builder
+FROM public.ecr.aws/docker/library/node:22-alpine AS frontend-builder
 WORKDIR /app
 
 # Install pnpm globally again (it can reuse the cache if not changed)

--- a/Dockerfile.hardened
+++ b/Dockerfile.hardened
@@ -1,7 +1,7 @@
 # ---------------------------------------
 # Node dependencies stage
 # ---------------------------------------
-FROM public.ecr.aws/docker/library/node:24.9-alpine AS frontend-dependencies
+FROM public.ecr.aws/docker/library/node:22-alpine AS frontend-dependencies
 WORKDIR /app
 
 # Install pnpm globally (caching layer)
@@ -14,7 +14,7 @@ RUN pnpm install --frozen-lockfile
 # ---------------------------------------
 # Build Nuxt (frontend) stage
 # ---------------------------------------
-FROM public.ecr.aws/docker/library/node:24.9-alpine AS frontend-builder
+FROM public.ecr.aws/docker/library/node:22-alpine AS frontend-builder
 WORKDIR /app
 
 # Install pnpm globally again (it can reuse the cache if not changed)

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -1,5 +1,5 @@
 # Node dependencies stage
-FROM public.ecr.aws/docker/library/node:24.9-alpine AS frontend-dependencies
+FROM public.ecr.aws/docker/library/node:22-alpine AS frontend-dependencies
 WORKDIR /app
 
 # Install pnpm globally (caching layer)
@@ -10,7 +10,7 @@ COPY frontend/package.json frontend/pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
 # Build Nuxt (frontend) stage
-FROM public.ecr.aws/docker/library/node:24.9-alpine AS frontend-builder
+FROM public.ecr.aws/docker/library/node:22-alpine AS frontend-builder
 WORKDIR /app
 
 # Install pnpm globally again (it can reuse the cache if not changed)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: homebox
     build:
       context: .
-      dockerfile: ./Dockerfile.hardened
+      dockerfile: ./Dockerfile
       args:
         - COMMIT=head
         - BUILD_TIME=0001-01-01T00:00:00Z
@@ -11,7 +11,7 @@ services:
         platforms:
             - linux/amd64
             - linux/arm64
-            - linux/arm/v7
+            - linux/arm
     environment:
       - HBOX_DEBUG=true
       - HBOX_LOGGER_LEVEL=-1


### PR DESCRIPTION
Fixing the ARM 32bit builds breaking because the NodeJS image we use doesn't support it anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated frontend build stages to use Node.js 22 (alpine) as the base runtime for builds.
  * Switched which build configuration is used for local/container orchestration and adjusted supported ARM platform variant (replaced a specific ARM v7 target with a broader linux/arm target).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->