### PR TITLE
docs: Add note about shortlinks for asset IDs

### DIFF
--- a/docs/en/user-guide/tips-tricks.md
+++ b/docs/en/user-guide/tips-tricks.md
@@ -108,7 +108,7 @@ To enable this feature:
 
 Items can be accessed through the following URL structure:
 
-`instance.com/item/uuid`
+`example.com/item/uuid`
 
 The UUID is a unique ID generated for each asset and corresponds to the database value in `items` with the same field name.
 
@@ -116,9 +116,9 @@ A shortlink path is also available and is used when constructing QR codes for mo
 
 Its structure is:
 
-`instance.com/a/asset-id`
+`example.com/a/asset-id`
 
-The asset ID is the parsed version of the asset ID (the sequence number without the trailing zeroes). If you have an asset `003-912`, for example, you can use: `instance.com/a/3192` to jump to its entry in Homebox.
+The asset ID is the parsed version of the asset ID (the sequence number without the trailing zeroes). If you have an asset `003-912`, for example, you can use: `example.com/a/3192` to jump to its entry in Homebox.
 
 
 ## Open Multiple Items in New Tabs


### PR DESCRIPTION
## Summary
- Added documentation about the shortlink feature for asset IDs to the tips and tricks page
- Explains that asset IDs can be accessed via `/a/{asset-id}` URLs for easy sharing and QR code generation

## Test plan
- [ ] Preview the documentation page to verify formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added user guide content for Asset Shortlinks: explains supported URL formats, how asset and item IDs are represented and parsed, the link between shortlinks and frontend-visible asset IDs, guidance for constructing QR codes, and instructions for enabling and using the feature (including copy-to-clipboard scenarios).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->