### PR TITLE
docs: add missing barcodespider env var

### DIFF
--- a/docs/en/configure/index.md
+++ b/docs/en/configure/index.md
@@ -71,6 +71,7 @@ aside: false
 | HBOX_THUMBNAIL_ENABLED                  | true                                                                       | enable thumbnail generation for images, supports PNG, JPEG, AVIF, WEBP, GIF file types                                                                                                    |
 | HBOX_THUMBNAIL_WIDTH                    | 500                                                                        | width for generated thumbnails in pixels                                                                                                                                                  |
 | HBOX_THUMBNAIL_HEIGHT                   | 500                                                                        | height for generated thumbnails in pixels                                                                                                                                                 |
+| HBOX_BARCODE_TOKEN_BARCODESPIDER        |                                                                            | API token for BarcodeSpider.com service used for barcode product lookups. If not set, barcode product lookups will not be performed.                                                 |    
 
 ### HBOX_WEB_HOST examples
 


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

Adds missing `HBOX_BARCODE_TOKEN_BARCODESPIDER` environment variable to the configuration documentation table.
This variable was previously only mentioned in the CLI help output but was missing from the main environment variables overview table

## Testing

- Verified the variable exists in the codebase and is properly configured
- Confirmed the documentation format matches other environment variables in the table


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for BarcodeSpider API token configuration. Users can now enable barcode product lookups by configuring an optional API token in their environment settings. Barcode lookup functionality is disabled by default and requires proper token configuration to activate.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->