### PR TITLE
fix(sidebar): prevent dropdown menu layout shift on hover

### DIFF
--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -47,7 +47,7 @@
                 {{ btn.name.value }}
                 <Shortcut
                   v-if="btn.shortcut"
-                  class="ml-auto hidden group-hover:inline"
+                  class="invisible ml-auto group-hover:visible"
                   :keys="btn.shortcut.replace('Shift', '⇧').split('+')"
                 />
               </DropdownMenuItem>


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Fixes a layout shift issue in the sidebar dropdown menu where hovering over items with long labels (e.g., "Artikel / Vermögenswert") caused the container to jump when the shortcut indicator appeared.

**Changes:**
- Changed the `Shortcut` component visibility from `hidden group-hover:inline` to `invisible group-hover:visible` in `frontend/layouts/default.vue`
- This reserves space for the shortcut even when hidden, preventing layout shifts on hover

**Before:** The shortcut was completely removed from the layout flow (`hidden`), causing the dropdown item to expand horizontally when it appeared on hover.

https://github.com/user-attachments/assets/a95b49c4-88ed-4e16-814a-593153d97aaa

**After:** The shortcut remains in the layout flow but invisible (`invisible`), so its space is always reserved and no jumping occurs.

https://github.com/user-attachments/assets/6a5b15f0-81b2-47e0-9682-b1522dfdab5a

## Special notes for your reviewer:

The fix is minimal and uses standard Tailwind CSS visibility utilities. The `invisible` class maintains layout space while `hidden` removes it entirely, which was causing the jump.

## Testing

- Hover over dropdown menu items with long labels (especially "Artikel / Vermögenswert" in German locale)
- Verify that the shortcut indicator appears smoothly without causing the container to jump or expand
- Test with different label lengths to ensure consistent behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced hover visibility behavior for interactive components. Improved visual feedback and smoother transitions when hovering over interface elements, refining the overall interactive experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->