### PR TITLE
docs: reference disable_https instead of disableSsl on Storage Config Page

### DIFF
--- a/docs/en/configure/storage.md
+++ b/docs/en/configure/storage.md
@@ -30,19 +30,19 @@ the bucket name in the connection string.
 ### S3-Compatible Storage
 
 You can also use S3-compatible storage by setting the `HBOX_STORAGE_CONN_STRING` to
-`s3://my-bucket?awssdk=v2&endpoint=http://my-s3-compatible-endpoint.tld&disableSSL=true&s3ForcePathStyle=true`.
+`s3://my-bucket?awssdk=v2&endpoint=http://my-s3-compatible-endpoint.tld&disable_https=true&s3ForcePathStyle=true`.
 
 This allows you to connect to S3-compatible services like MinIO, DigitalOcean Spaces, or any other service that supports
-the S3 API. Configure the `disableSSL`, `s3ForcePathStyle`, and `endpoint` parameters as needed for your specific
+the S3 API. Configure the `disable_https`, `s3ForcePathStyle`, and `endpoint` parameters as needed for your specific
 service.
 
 #### Tested S3-Compatible Storage
 
 | Service             | Working | Connection String                                                                                                        |
 |---------------------|---------|--------------------------------------------------------------------------------------------------------------------------|
-| MinIO               | Yes     | `s3://my-bucket?awssdk=v2&endpoint=http://minio:9000&disableSSL=true&s3ForcePathStyle=true`                              |
-| Cloudflare R2       | Yes     | `s3://my-bucket?awssdk=v2&endpoint=https://<account-id>.r2.cloudflarestorage.com&disableSSL=false&s3ForcePathStyle=true` |
-| Backblaze B2        | Yes     | `s3://my-bucket?awssdk=v2&endpoint=https://s3.us-west-004.backblazeb2.com&disableSSL=false&s3ForcePathStyle=true`        |
+| MinIO               | Yes     | `s3://my-bucket?awssdk=v2&endpoint=http://minio:9000&disable_https=true&s3ForcePathStyle=true`                              |
+| Cloudflare R2       | Yes     | `s3://my-bucket?awssdk=v2&endpoint=https://<account-id>.r2.cloudflarestorage.com&disable_https=false&s3ForcePathStyle=true` |
+| Backblaze B2        | Yes     | `s3://my-bucket?awssdk=v2&endpoint=https://s3.us-west-004.backblazeb2.com&disable_https=false&s3ForcePathStyle=true`        |
 
 ::: info
 If you know of any other S3-compatible storage that works with Homebox, please let us know or create a pull request to update the table.
@@ -57,7 +57,7 @@ Additionally, the parameters in the URL can be used to configure specific S3 set
   features.)
 - `endpoint`: The custom endpoint for S3-compatible storage services.
 - `s3ForcePathStyle`: Whether to force path-style access (set to `true` or `false`).
-- `disableSSL`: Whether to disable SSL (set to `true` or `false`).
+- `disable_https`: Whether to disable SSL (set to `true` or `false`).
 - `sseType`: The server-side encryption type (e.g., `AES256` or `aws:kms` or `aws:kms:dsse`).
 - `kmskeyid`: The KMS key ID for server-side encryption.
 - `fips`: Whether to use FIPS endpoints (set to `true` or `false`).


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

I ran into errors when attempting to configure an S3-compatible storage provider using the example connection strings supplied on the docs page:
```
homebox  | 10:40PM ERR ../go/src/app/app/api/handlers/v1/v1_ctrl_items_attachments.go:186 > failed to open bucket error="open bucket s3://homebox?awssdk=v2&endpoint=https://REDACTED.r2.cloudflarestorage.com&disableSSL=false&s3ForcePathStyle=true: unknown query parameter \"disableSSL\""
homebox  | 10:40PM ERR ../go/src/app/internal/web/mid/errors.go:31 > ERROR occurred error="open bucket s3://homebox?awssdk=v2&endpoint=https://REDACTED.r2.cloudflarestorage.com&disableSSL=false&s3ForcePathStyle=true: unknown query parameter \"disableSSL\"" req_id=ef0d26f355bb/RhtLmQVbMD-000045
```

It seems like in s3blob's library, `disableSSL` is no longer a valid option and instead, `disable_https` should be used: https://github.com/google/go-cloud/blob/v0.44.0/blob/s3blob/s3blob.go#L136

## Which issue(s) this PR fixes:

Fixes https://github.com/sysadminsmedia/homebox/issues/990

I re-tested the S3 Storage Integration after this change, and it worked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated S3-Compatible Storage configuration documentation with parameter naming clarifications in connection string examples and configuration guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->