### PR TITLE
allow templates that dont have a location set to be saved & dupe

### DIFF
--- a/backend/internal/data/repo/repo_item_templates.go
+++ b/backend/internal/data/repo/repo_item_templates.go
@@ -53,7 +53,7 @@ type (
 		DefaultWarrantyDetails  *string `json:"defaultWarrantyDetails,omitempty" extensions:"x-nullable" validate:"omitempty,max=1000"`
 
 		// Default location and labels
-		DefaultLocationID *uuid.UUID   `json:"defaultLocationId,omitempty" extensions:"x-nullable"`
+		DefaultLocationID uuid.UUID    `json:"defaultLocationId,omitempty" extensions:"x-nullable"`
 		DefaultLabelIDs   *[]uuid.UUID `json:"defaultLabelIds,omitempty" extensions:"x-nullable"`
 
 		// Metadata flags
@@ -82,7 +82,7 @@ type (
 		DefaultWarrantyDetails  *string `json:"defaultWarrantyDetails,omitempty" extensions:"x-nullable" validate:"omitempty,max=1000"`
 
 		// Default location and labels
-		DefaultLocationID *uuid.UUID   `json:"defaultLocationId,omitempty" extensions:"x-nullable"`
+		DefaultLocationID uuid.UUID    `json:"defaultLocationId,omitempty" extensions:"x-nullable"`
 		DefaultLabelIDs   *[]uuid.UUID `json:"defaultLabelIds,omitempty" extensions:"x-nullable"`
 
 		// Metadata flags
@@ -262,6 +262,7 @@ func (r *ItemTemplatesRepository) GetOne(ctx context.Context, gid uuid.UUID, id 
 
 // Create creates a new template
 func (r *ItemTemplatesRepository) Create(ctx context.Context, gid uuid.UUID, data ItemTemplateCreate) (ItemTemplateOut, error) {
+	// Set up create builder
 	q := r.db.ItemTemplate.Create().
 		SetName(data.Name).
 		SetDescription(data.Description).
@@ -277,9 +278,12 @@ func (r *ItemTemplatesRepository) Create(ctx context.Context, gid uuid.UUID, dat
 		SetIncludeWarrantyFields(data.IncludeWarrantyFields).
 		SetIncludePurchaseFields(data.IncludePurchaseFields).
 		SetIncludeSoldFields(data.IncludeSoldFields).
-		SetGroupID(gid).
-		SetNillableLocationID(data.DefaultLocationID)
+		SetGroupID(gid)
 
+	// If a default location was provided (uuid != Nil) set it, otherwise leave empty
+	if data.DefaultLocationID != uuid.Nil {
+		q.SetLocationID(data.DefaultLocationID)
+	}
 	// Set default label IDs (stored as JSON)
 	if data.DefaultLabelIDs != nil && len(*data.DefaultLabelIDs) > 0 {
 		q.SetDefaultLabelIds(*data.DefaultLabelIDs)
@@ -340,9 +344,9 @@ func (r *ItemTemplatesRepository) Update(ctx context.Context, gid uuid.UUID, dat
 		SetIncludePurchaseFields(data.IncludePurchaseFields).
 		SetIncludeSoldFields(data.IncludeSoldFields)
 
-	// Update location
-	if data.DefaultLocationID != nil {
-		updateQ.SetLocationID(*data.DefaultLocationID)
+	// Update location: set when provided (not uuid.Nil), otherwise clear
+	if data.DefaultLocationID != uuid.Nil {
+		updateQ.SetLocationID(data.DefaultLocationID)
 	} else {
 		updateQ.ClearLocation()
 	}

--- a/backend/internal/data/repo/repo_item_templates_test.go
+++ b/backend/internal/data/repo/repo_item_templates_test.go
@@ -249,7 +249,7 @@ func TestItemTemplatesRepository_CreateWithLocation(t *testing.T) {
 
 	// Create template with location
 	data := templateFactory()
-	data.DefaultLocationID = &loc.ID
+	data.DefaultLocationID = loc.ID
 
 	template, err := tRepos.ItemTemplates.Create(context.Background(), tGroup.ID, data)
 	require.NoError(t, err)
@@ -311,7 +311,7 @@ func TestItemTemplatesRepository_UpdateRemoveLocation(t *testing.T) {
 
 	// Create template with location
 	data := templateFactory()
-	data.DefaultLocationID = &loc.ID
+	data.DefaultLocationID = loc.ID
 
 	template, err := tRepos.ItemTemplates.Create(context.Background(), tGroup.ID, data)
 	require.NoError(t, err)
@@ -323,7 +323,7 @@ func TestItemTemplatesRepository_UpdateRemoveLocation(t *testing.T) {
 		ID:                template.ID,
 		Name:              template.Name,
 		DefaultQuantity:   &qty,
-		DefaultLocationID: nil, // Remove location
+		DefaultLocationID: uuid.Nil, // Remove location
 	}
 
 	updated, err := tRepos.ItemTemplates.Update(context.Background(), tGroup.ID, updateData)

--- a/frontend/components/Template/Card.vue
+++ b/frontend/components/Template/Card.vue
@@ -58,7 +58,7 @@
       defaultModelNumber: fullTemplate.defaultModelNumber,
       defaultLifetimeWarranty: fullTemplate.defaultLifetimeWarranty,
       defaultWarrantyDetails: fullTemplate.defaultWarrantyDetails,
-      defaultLocationId: fullTemplate.defaultLocation?.id ?? "",
+      defaultLocationId: fullTemplate.defaultLocation?.id ?? null,
       defaultLabelIds: fullTemplate.defaultLabels?.map(l => l.id) || [],
       includeWarrantyFields: fullTemplate.includeWarrantyFields,
       includePurchaseFields: fullTemplate.includePurchaseFields,

--- a/frontend/pages/template/[id].vue
+++ b/frontend/pages/template/[id].vue
@@ -119,7 +119,7 @@
     // Prepare the data with proper format for API
     const payload = {
       ...updateData,
-      defaultLocationId: updateData.defaultLocation?.id ?? "",
+      defaultLocationId: updateData.defaultLocation?.id ?? null,
     };
 
     const { error, data } = await api.templates.update(templateId.value, payload);


### PR DESCRIPTION
<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## Which issue(s) this PR fixes:

Fixes #1157 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced internal logic for managing location associations in item templates, improving consistency in how optional location values are handled during template creation and updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->