### PR TITLE
refactor(backend): use constants for database driver names

### DIFF
--- a/backend/app/api/main.go
+++ b/backend/app/api/main.go
@@ -108,7 +108,7 @@ func run(cfg *config.Config) error {
 		return err
 	}
 
-	if strings.ToLower(cfg.Database.Driver) == "postgres" {
+	if strings.ToLower(cfg.Database.Driver) == config.DriverPostgres {
 		if !validatePostgresSSLMode(cfg.Database.SslMode) {
 			log.Error().Str("sslmode", cfg.Database.SslMode).Msg("invalid sslmode")
 			return fmt.Errorf("invalid sslmode: %s", cfg.Database.SslMode)

--- a/backend/app/api/setup.go
+++ b/backend/app/api/setup.go
@@ -41,7 +41,7 @@ func setupStorageDir(cfg *config.Config) error {
 func setupDatabaseURL(cfg *config.Config) (string, error) {
 	databaseURL := ""
 	switch strings.ToLower(cfg.Database.Driver) {
-	case "sqlite3":
+	case config.DriverSqlite3:
 		databaseURL = cfg.Database.SqlitePath
 		dbFilePath := strings.Split(cfg.Database.SqlitePath, "?")[0]
 		dbDir := filepath.Dir(dbFilePath)
@@ -49,7 +49,7 @@ func setupDatabaseURL(cfg *config.Config) (string, error) {
 			log.Error().Err(err).Str("path", dbDir).Msg("failed to create SQLite database directory")
 			return "", fmt.Errorf("failed to create SQLite database directory: %w", err)
 		}
-	case "postgres":
+	case config.DriverPostgres:
 		databaseURL = fmt.Sprintf("host=%s port=%s dbname=%s sslmode=%s", cfg.Database.Host, cfg.Database.Port, cfg.Database.Database, cfg.Database.SslMode)
 		if cfg.Database.Username != "" {
 			databaseURL += fmt.Sprintf(" user=%s", cfg.Database.Username)

--- a/backend/internal/data/ent/item_predicates.go
+++ b/backend/internal/data/ent/item_predicates.go
@@ -4,6 +4,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/item"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/predicate"
+	conf "github.com/sysadminsmedia/homebox/backend/internal/sys/config"
 	"github.com/sysadminsmedia/homebox/backend/pkgs/textutils"
 )
 
@@ -24,7 +25,7 @@ func AccentInsensitiveContains(field string, searchValue string) predicate.Item 
 		dialect := s.Dialect()
 
 		switch dialect {
-		case "sqlite3":
+		case conf.DriverSqlite3:
 			// For SQLite, we'll create a custom normalization function using REPLACE
 			// to handle common accented characters
 			normalizeFunc := buildSQLiteNormalizeExpression(s.C(field))
@@ -32,7 +33,7 @@ func AccentInsensitiveContains(field string, searchValue string) predicate.Item 
 				"LOWER("+normalizeFunc+") LIKE ?",
 				"%"+normalizedSearch+"%",
 			))
-		case "postgres":
+		case conf.DriverPostgres:
 			// For PostgreSQL, use REPLACE-based normalization to avoid unaccent dependency
 			normalizeFunc := buildGenericNormalizeExpression(s.C(field))
 			// Use sql.P() for proper PostgreSQL parameter binding ($1, $2, etc.)

--- a/backend/internal/data/migrations/migrations.go
+++ b/backend/internal/data/migrations/migrations.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/rs/zerolog/log"
+	"github.com/sysadminsmedia/homebox/backend/internal/sys/config"
 )
 
 //go:embed all:postgres
@@ -21,9 +22,9 @@ var sqliteFiles embed.FS
 // embedded file system containing the migration files for the specified dialect.
 func Migrations(dialect string) (embed.FS, error) {
 	switch dialect {
-	case "postgres":
+	case config.DriverPostgres:
 		return postgresFiles, nil
-	case "sqlite3":
+	case config.DriverSqlite3:
 		return sqliteFiles, nil
 	default:
 		log.Error().Str("dialect", dialect).Msg("unknown sql dialect")

--- a/backend/internal/sys/config/conf_database.go
+++ b/backend/internal/sys/config/conf_database.go
@@ -1,7 +1,8 @@
 package config
 
 const (
-	DriverSqlite3 = "sqlite3"
+	DriverSqlite3  = "sqlite3"
+	DriverPostgres = "postgres"
 )
 
 type Storage struct {


### PR DESCRIPTION
I've been playing around with some of the database code, spitballing a few ideas and its been helpful to quickly identify all the unique db system specific code. 

while these magic constants are self explanatory, they are still somewhat magical and bad

## What type of PR is this?
- cleanup

## What this PR does / why we need it:

easier identification around database system specific code

## Which issue(s) this PR fixes:

N/A

<!--
If this PR fixes one of more issues, list them here.
One line each, like so:
Fixes #123
Fixes #39
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code maintainability by standardizing database driver configuration references throughout the backend.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->