### PR TITLE
fix(items): update quantity display immediately on increment/decrement

### DIFF
--- a/frontend/pages/item/[id]/index.vue
+++ b/frontend/pages/item/[id]/index.vue
@@ -115,7 +115,9 @@
       return;
     }
 
-    item.value.quantity = newQuantity;
+    if (resp.data) {
+      item.value = resp.data;
+    }
   }
 
   type FilteredAttachments = {


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:
Use API response data to update item state instead of directly mutating the quantity property. Fixes #1180 


## Which issue(s) this PR fixes:

Fixes #1180 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed item data synchronization when updating quantities to ensure the displayed item information stays in sync with server state, replacing the entire item object with the authoritative API response instead of partial local updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->