### PR TITLE
Add Create Item button on location page

### DIFF
--- a/frontend/pages/location/[id].vue
+++ b/frontend/pages/location/[id].vue
@@ -222,19 +222,25 @@
                 </div>
               </div>
             </div>
-            <div class="ml-auto mt-2 flex flex-wrap items-center justify-between gap-3">
+            <div class="ml-auto mt-2 flex flex-wrap items-center justify-between gap-2">
               <LabelMaker :id="location.id" type="location" />
-              <Button @click="openCreateItem">
+              <Button @click="openCreateItem" class="w-9 md:w-auto">
                 <MdiPlus name="mdi-plus" />
-                {{ $t("components.item.create_modal.title") }}
+                <span class="hidden md:inline">
+                  {{ $t("components.item.create_modal.title") }}
+                </span>
               </Button>
-              <Button @click="openUpdate">
+              <Button @click="openUpdate" class="w-9 md:w-auto">
                 <MdiPencil name="mdi-pencil" />
-                {{ $t("global.edit") }}
+                <span class="hidden md:inline">
+                  {{ $t("global.edit") }}
+                </span>
               </Button>
-              <Button variant="destructive" @click="confirmDelete()">
+              <Button variant="destructive" @click="confirmDelete()" class="w-9 md:w-auto">
                 <MdiDelete name="mdi-delete" />
-                {{ $t("global.delete") }}
+                <span class="hidden md:inline">
+                  {{ $t("global.delete") }}
+                </span>
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## What type of PR is this?
- [x] Feature

## Which issue(s) this PR fixes
- Fixes: N/A

## Summary
- Add a “Create Item” action on the location detail page
- Opens the existing Create Item modal and auto-selects the current location

## Why
Creating an item from a location currently requires creating it elsewhere and assigning the location afterward. This adds a direct, intuitive entry point when viewing a location.

## Testing
- Not run (UI change only)

## Screenshots
<img width="1920" height="976" alt="Screenshot (63)" src="https://github.com/user-attachments/assets/181770bb-7dd1-478a-b270-6e221bedad73" />
<img width="1920" height="992" alt="Screenshot (64)" src="https://github.com/user-attachments/assets/a6af6468-a56f-4c68-b7fe-0a48c02f866e" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a header action to create new items from the location view: a plus icon with a localized title that opens the Create Item dialog.
  * The new button appears alongside existing header controls and includes a small layout adjustment for consistent alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->