### PR TITLE
linting improvements and apply formatting fixes

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+948e21d70e64cfe3d0d2a0d0821fc55743990450 # linter fixes after enabling swaggo to golangci-lint
+

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -72,6 +72,7 @@ issues:
 formatters:
   enable:
     - gofmt
+    - swaggo
   exclusions:
     generated: lax
     paths:

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - errcheck
     - errorlint
     - exhaustive
+    - forbidigo
     - gochecknoinits
     - goconst
     - gocritic
@@ -41,6 +42,11 @@ linters:
                 details.
     exhaustive:
       default-signifies-exhaustive: true
+    forbidigo:
+      forbid:
+        - pattern: ^log\.Fatal.*$
+          msg: Do not use log.Fatal - return errors instead
+      analyze-types: true
     goconst:
       min-len: 5
       min-occurrences: 5
@@ -67,6 +73,10 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - path: '(.+)_test\.go'
+        linters:
+          - forbidigo
 issues:
   fix: false
 formatters:

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -68,7 +68,7 @@ linters:
       - builtin$
       - examples$
 issues:
-  fix: true
+  fix: false
 formatters:
   enable:
     - gofmt

--- a/backend/app/api/handlers/v1/v1_ctrl_actions.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_actions.go
@@ -110,8 +110,8 @@ type WipeInventoryOptions struct {
 //	@Description	Deletes all items in the inventory
 //	@Tags			Actions
 //	@Produce		json
-//	@Param			options	body	WipeInventoryOptions	false	"Wipe options"
-//	@Success		200	{object}	ActionAmountResult
+//	@Param			options	body		WipeInventoryOptions	false	"Wipe options"
+//	@Success		200		{object}	ActionAmountResult
 //	@Router			/v1/actions/wipe-inventory [Post]
 //	@Security		Bearer
 func (ctrl *V1Controller) HandleWipeInventory() errchain.HandlerFunc {
@@ -119,14 +119,14 @@ func (ctrl *V1Controller) HandleWipeInventory() errchain.HandlerFunc {
 		if ctrl.isDemo {
 			return validate.NewRequestError(errors.New("wipe inventory is not allowed in demo mode"), http.StatusForbidden)
 		}
-		
+
 		ctx := services.NewContext(r.Context())
-		
+
 		// Check if user is owner
 		if !ctx.User.IsOwner {
 			return validate.NewRequestError(errors.New("only group owners can wipe inventory"), http.StatusForbidden)
 		}
-		
+
 		// Parse options from request body
 		var options WipeInventoryOptions
 		if err := server.Decode(r, &options); err != nil {
@@ -137,13 +137,13 @@ func (ctrl *V1Controller) HandleWipeInventory() errchain.HandlerFunc {
 				WipeMaintenance: false,
 			}
 		}
-		
+
 		totalCompleted, err := ctrl.repo.Items.WipeInventory(ctx, ctx.GID, options.WipeLabels, options.WipeLocations, options.WipeMaintenance)
 		if err != nil {
 			log.Err(err).Str("action_ref", "wipe inventory").Msg("failed to run action")
 			return validate.NewRequestError(err, http.StatusInternalServerError)
 		}
-		
+
 		// Publish mutation events for wiped resources
 		if ctrl.bus != nil {
 			if options.WipeLabels {
@@ -153,7 +153,7 @@ func (ctrl *V1Controller) HandleWipeInventory() errchain.HandlerFunc {
 				ctrl.bus.Publish(eventbus.EventLocationMutation, eventbus.GroupMutationEvent{GID: ctx.GID})
 			}
 		}
-		
+
 		return server.JSON(w, http.StatusOK, ActionAmountResult{Completed: totalCompleted})
 	}
 }

--- a/backend/app/api/handlers/v1/v1_ctrl_reporting.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_reporting.go
@@ -1,9 +1,10 @@
 package v1
 
 import (
+	"net/http"
+
 	"github.com/hay-kot/httpkit/errchain"
 	"github.com/sysadminsmedia/homebox/backend/internal/core/services"
-	"net/http"
 )
 
 // HandleBillOfMaterialsExport godoc

--- a/backend/app/api/handlers/v1/v1_ctrl_user.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_user.go
@@ -20,7 +20,7 @@ import (
 //	@Produce	json
 //	@Param		payload	body	services.UserRegistration	true	"User Data"
 //	@Success	204
-//  @Failure    403 {string} string "Local login is not enabled"
+//	@Failure	403	{string}	string	"Local login is not enabled"
 //	@Router		/v1/users/register [Post]
 func (ctrl *V1Controller) HandleUserRegistration() errchain.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) error {

--- a/backend/internal/core/services/main_test.go
+++ b/backend/internal/core/services/main_test.go
@@ -2,10 +2,11 @@ package services
 
 import (
 	"context"
-	"github.com/sysadminsmedia/homebox/backend/internal/sys/config"
 	"log"
 	"os"
 	"testing"
+
+	"github.com/sysadminsmedia/homebox/backend/internal/sys/config"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/sysadminsmedia/homebox/backend/internal/core/currencies"

--- a/backend/internal/core/services/service_items_attachments.go
+++ b/backend/internal/core/services/service_items_attachments.go
@@ -2,12 +2,13 @@ package services
 
 import (
 	"context"
+	"io"
+
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/attachment"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/repo"
-	"io"
 )
 
 func (svc *ItemService) AttachmentPath(ctx context.Context, gid uuid.UUID, attachmentID uuid.UUID) (*ent.Attachment, error) {

--- a/backend/internal/data/migrations/migrations.go
+++ b/backend/internal/data/migrations/migrations.go
@@ -31,5 +31,4 @@ func Migrations(dialect string) (embed.FS, error) {
 		return embed.FS{}, fmt.Errorf("unknown sql dialect: %s", dialect)
 	}
 	// This should never get hit, but just in case
-	return sqliteFiles, nil
 }

--- a/backend/internal/data/migrations/postgres/20250112202302_sync_children.go
+++ b/backend/internal/data/migrations/postgres/20250112202302_sync_children.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
 	"github.com/pressly/goose/v3"
 )
 

--- a/backend/internal/data/migrations/sqlite3/20241226183416_sync_children.go
+++ b/backend/internal/data/migrations/sqlite3/20241226183416_sync_children.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
 	"github.com/pressly/goose/v3"
 )
 

--- a/backend/internal/data/repo/main_test.go
+++ b/backend/internal/data/repo/main_test.go
@@ -2,10 +2,11 @@ package repo
 
 import (
 	"context"
-	"github.com/sysadminsmedia/homebox/backend/internal/sys/config"
 	"log"
 	"os"
 	"testing"
+
+	"github.com/sysadminsmedia/homebox/backend/internal/sys/config"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/sysadminsmedia/homebox/backend/internal/core/services/reporting/eventbus"

--- a/backend/internal/data/repo/repo_item_attachments.go
+++ b/backend/internal/data/repo/repo_item_attachments.go
@@ -114,17 +114,17 @@ func (r *AttachmentRepo) fullPath(relativePath string) string {
 	// Normalize path separators to forward slashes for blob storage
 	// The blob library expects forward slashes in keys regardless of OS
 	normalizedRelativePath := normalizePath(relativePath)
-	
+
 	// Always use forward slashes when joining paths for blob storage
 	if r.storage.PrefixPath == "" {
 		return normalizedRelativePath
 	}
 	normalizedPrefix := normalizePath(r.storage.PrefixPath)
-	
+
 	if normalizedPrefix == "" {
 		return normalizedRelativePath
 	}
-	
+
 	return fmt.Sprintf("%s/%s", normalizedPrefix, normalizedRelativePath)
 }
 

--- a/backend/internal/data/repo/repo_item_attachments_test.go
+++ b/backend/internal/data/repo/repo_item_attachments_test.go
@@ -290,25 +290,25 @@ func TestAttachmentRepo_PathNormalization(t *testing.T) {
 			PrefixPath: ".data",
 		},
 	}
-	
+
 	testGUID := uuid.MustParse("eb6bf410-a1a8-478d-a803-ca3948368a0c")
 	testHash := "f295eb01-18a9-4631-a797-70bd9623edd4.png"
-	
+
 	// Test path() method - should always return forward slashes
 	relativePath := repo.path(testGUID, testHash)
 	assert.Equal(t, "eb6bf410-a1a8-478d-a803-ca3948368a0c/documents/f295eb01-18a9-4631-a797-70bd9623edd4.png", relativePath)
 	assert.NotContains(t, relativePath, "\\", "path() should not contain backslashes")
-	
+
 	// Test fullPath() with forward slash input (from database)
 	fullPath := repo.fullPath("eb6bf410-a1a8-478d-a803-ca3948368a0c/documents/f295eb01-18a9-4631-a797-70bd9623edd4.png")
 	assert.Equal(t, ".data/eb6bf410-a1a8-478d-a803-ca3948368a0c/documents/f295eb01-18a9-4631-a797-70bd9623edd4.png", fullPath)
 	assert.NotContains(t, fullPath, "\\", "fullPath() should not contain backslashes")
-	
+
 	// Test fullPath() with backslash input (legacy Windows paths from old database)
 	fullPathWithBackslash := repo.fullPath("eb6bf410-a1a8-478d-a803-ca3948368a0c\\documents\\f295eb01-18a9-4631-a797-70bd9623edd4.png")
 	assert.Equal(t, ".data/eb6bf410-a1a8-478d-a803-ca3948368a0c/documents/f295eb01-18a9-4631-a797-70bd9623edd4.png", fullPathWithBackslash)
 	assert.NotContains(t, fullPathWithBackslash, "\\", "fullPath() should normalize backslashes to forward slashes")
-	
+
 	// Test with Windows-style prefix path
 	repoWindows := &AttachmentRepo{
 		storage: config.Storage{
@@ -317,7 +317,7 @@ func TestAttachmentRepo_PathNormalization(t *testing.T) {
 	}
 	fullPathWindows := repoWindows.fullPath("eb6bf410-a1a8-478d-a803-ca3948368a0c/documents/f295eb01-18a9-4631-a797-70bd9623edd4.png")
 	assert.NotContains(t, fullPathWindows, "\\", "fullPath() should normalize Windows paths")
-	
+
 	// Test empty prefix
 	repoNoPrefix := &AttachmentRepo{
 		storage: config.Storage{
@@ -326,7 +326,7 @@ func TestAttachmentRepo_PathNormalization(t *testing.T) {
 	}
 	fullPathNoPrefix := repoNoPrefix.fullPath("eb6bf410-a1a8-478d-a803-ca3948368a0c/documents/f295eb01-18a9-4631-a797-70bd9623edd4.png")
 	assert.Equal(t, "eb6bf410-a1a8-478d-a803-ca3948368a0c/documents/f295eb01-18a9-4631-a797-70bd9623edd4.png", fullPathNoPrefix)
-	
+
 	// Test with single slash prefix (like in tests)
 	repoSlashPrefix := &AttachmentRepo{
 		storage: config.Storage{

--- a/backend/internal/data/repo/repo_item_templates.go
+++ b/backend/internal/data/repo/repo_item_templates.go
@@ -43,18 +43,18 @@ type (
 		Notes       string `json:"notes"       validate:"max=1000"`
 
 		// Default values for items
-		DefaultQuantity         *int    `json:"defaultQuantity,omitempty" extensions:"x-nullable"`
+		DefaultQuantity         *int    `json:"defaultQuantity,omitempty"        extensions:"x-nullable"`
 		DefaultInsured          bool    `json:"defaultInsured"`
-		DefaultName             *string `json:"defaultName,omitempty"   extensions:"x-nullable"          validate:"omitempty,max=255"`
-		DefaultDescription      *string `json:"defaultDescription,omitempty"   extensions:"x-nullable"   validate:"omitempty,max=1000"`
-		DefaultManufacturer     *string `json:"defaultManufacturer,omitempty" extensions:"x-nullable"    validate:"omitempty,max=255"`
-		DefaultModelNumber      *string `json:"defaultModelNumber,omitempty"  extensions:"x-nullable"    validate:"omitempty,max=255"`
+		DefaultName             *string `json:"defaultName,omitempty"            validate:"omitempty,max=255"  extensions:"x-nullable"`
+		DefaultDescription      *string `json:"defaultDescription,omitempty"     validate:"omitempty,max=1000" extensions:"x-nullable"`
+		DefaultManufacturer     *string `json:"defaultManufacturer,omitempty"    validate:"omitempty,max=255"  extensions:"x-nullable"`
+		DefaultModelNumber      *string `json:"defaultModelNumber,omitempty"     validate:"omitempty,max=255"  extensions:"x-nullable"`
 		DefaultLifetimeWarranty bool    `json:"defaultLifetimeWarranty"`
-		DefaultWarrantyDetails  *string `json:"defaultWarrantyDetails,omitempty" extensions:"x-nullable" validate:"omitempty,max=1000"`
+		DefaultWarrantyDetails  *string `json:"defaultWarrantyDetails,omitempty" validate:"omitempty,max=1000" extensions:"x-nullable"`
 
 		// Default location and labels
 		DefaultLocationID uuid.UUID    `json:"defaultLocationId,omitempty" extensions:"x-nullable"`
-		DefaultLabelIDs   *[]uuid.UUID `json:"defaultLabelIds,omitempty" extensions:"x-nullable"`
+		DefaultLabelIDs   *[]uuid.UUID `json:"defaultLabelIds,omitempty"   extensions:"x-nullable"`
 
 		// Metadata flags
 		IncludeWarrantyFields bool `json:"includeWarrantyFields"`
@@ -72,18 +72,18 @@ type (
 		Notes       string    `json:"notes"       validate:"max=1000"`
 
 		// Default values for items
-		DefaultQuantity         *int    `json:"defaultQuantity,omitempty" extensions:"x-nullable"`
+		DefaultQuantity         *int    `json:"defaultQuantity,omitempty"        extensions:"x-nullable"`
 		DefaultInsured          bool    `json:"defaultInsured"`
-		DefaultName             *string `json:"defaultName,omitempty"   extensions:"x-nullable"          validate:"omitempty,max=255"`
-		DefaultDescription      *string `json:"defaultDescription,omitempty"   extensions:"x-nullable"   validate:"omitempty,max=1000"`
-		DefaultManufacturer     *string `json:"defaultManufacturer,omitempty" extensions:"x-nullable"    validate:"omitempty,max=255"`
-		DefaultModelNumber      *string `json:"defaultModelNumber,omitempty"  extensions:"x-nullable"    validate:"omitempty,max=255"`
+		DefaultName             *string `json:"defaultName,omitempty"            validate:"omitempty,max=255"  extensions:"x-nullable"`
+		DefaultDescription      *string `json:"defaultDescription,omitempty"     validate:"omitempty,max=1000" extensions:"x-nullable"`
+		DefaultManufacturer     *string `json:"defaultManufacturer,omitempty"    validate:"omitempty,max=255"  extensions:"x-nullable"`
+		DefaultModelNumber      *string `json:"defaultModelNumber,omitempty"     validate:"omitempty,max=255"  extensions:"x-nullable"`
 		DefaultLifetimeWarranty bool    `json:"defaultLifetimeWarranty"`
-		DefaultWarrantyDetails  *string `json:"defaultWarrantyDetails,omitempty" extensions:"x-nullable" validate:"omitempty,max=1000"`
+		DefaultWarrantyDetails  *string `json:"defaultWarrantyDetails,omitempty" validate:"omitempty,max=1000" extensions:"x-nullable"`
 
 		// Default location and labels
 		DefaultLocationID uuid.UUID    `json:"defaultLocationId,omitempty" extensions:"x-nullable"`
-		DefaultLabelIDs   *[]uuid.UUID `json:"defaultLabelIds,omitempty" extensions:"x-nullable"`
+		DefaultLabelIDs   *[]uuid.UUID `json:"defaultLabelIds,omitempty"   extensions:"x-nullable"`
 
 		// Metadata flags
 		IncludeWarrantyFields bool `json:"includeWarrantyFields"`

--- a/backend/internal/data/repo/repo_items_search_test.go
+++ b/backend/internal/data/repo/repo_items_search_test.go
@@ -164,7 +164,7 @@ func TestItemsRepository_AccentInsensitiveSearch(t *testing.T) {
 			if tc.shouldMatch {
 				// If it should match, then either the original query should match
 				// or the normalized query should match when applied to the stored data
-				assert.NotEqual(t, "", normalizedSearch, "Normalized search should not be empty")
+				assert.NotEmpty(t, normalizedSearch, "Normalized search should not be empty")
 
 				// The key insight is that we're searching with both the original and normalized queries
 				// So "electrónica" will be found when searching for "electronica" because:

--- a/backend/internal/data/repo/repo_items_test.go
+++ b/backend/internal/data/repo/repo_items_test.go
@@ -400,33 +400,33 @@ func TestItemsRepository_DeleteByGroupWithAttachments(t *testing.T) {
 
 func TestItemsRepository_WipeInventory(t *testing.T) {
 	// Create test data: items, labels, locations, and maintenance entries
-	
+
 	// Create locations
 	loc1, err := tRepos.Locations.Create(context.Background(), tGroup.ID, LocationCreate{
 		Name:        "Test Location 1",
 		Description: "Test location for wipe test",
 	})
 	require.NoError(t, err)
-	
+
 	loc2, err := tRepos.Locations.Create(context.Background(), tGroup.ID, LocationCreate{
 		Name:        "Test Location 2",
 		Description: "Another test location",
 	})
 	require.NoError(t, err)
-	
+
 	// Create labels
 	label1, err := tRepos.Labels.Create(context.Background(), tGroup.ID, LabelCreate{
 		Name:        "Test Label 1",
 		Description: "Test label for wipe test",
 	})
 	require.NoError(t, err)
-	
+
 	label2, err := tRepos.Labels.Create(context.Background(), tGroup.ID, LabelCreate{
 		Name:        "Test Label 2",
 		Description: "Another test label",
 	})
 	require.NoError(t, err)
-	
+
 	// Create items
 	item1, err := tRepos.Items.Create(context.Background(), tGroup.ID, ItemCreate{
 		Name:        "Test Item 1",
@@ -435,7 +435,7 @@ func TestItemsRepository_WipeInventory(t *testing.T) {
 		LabelIDs:    []uuid.UUID{label1.ID},
 	})
 	require.NoError(t, err)
-	
+
 	item2, err := tRepos.Items.Create(context.Background(), tGroup.ID, ItemCreate{
 		Name:        "Test Item 2",
 		Description: "Another test item",
@@ -443,7 +443,7 @@ func TestItemsRepository_WipeInventory(t *testing.T) {
 		LabelIDs:    []uuid.UUID{label2.ID},
 	})
 	require.NoError(t, err)
-	
+
 	// Create maintenance entries for items
 	_, err = tRepos.MaintEntry.Create(context.Background(), item1.ID, MaintenanceEntryCreate{
 		CompletedDate: types.DateFromTime(time.Now()),
@@ -452,7 +452,7 @@ func TestItemsRepository_WipeInventory(t *testing.T) {
 		Cost:          100.0,
 	})
 	require.NoError(t, err)
-	
+
 	_, err = tRepos.MaintEntry.Create(context.Background(), item2.ID, MaintenanceEntryCreate{
 		CompletedDate: types.DateFromTime(time.Now()),
 		Name:          "Test Maintenance 2",
@@ -460,40 +460,40 @@ func TestItemsRepository_WipeInventory(t *testing.T) {
 		Cost:          200.0,
 	})
 	require.NoError(t, err)
-	
+
 	// Test 1: Wipe inventory with all options enabled
 	t.Run("wipe all including labels, locations, and maintenance", func(t *testing.T) {
 		deleted, err := tRepos.Items.WipeInventory(context.Background(), tGroup.ID, true, true, true)
 		require.NoError(t, err)
-		assert.Greater(t, deleted, 0, "Should have deleted at least some entities")
-		
+		assert.Positive(t, deleted, "Should have deleted at least some entities")
+
 		// Verify items are deleted
 		_, err = tRepos.Items.GetOneByGroup(context.Background(), tGroup.ID, item1.ID)
 		require.Error(t, err, "Item 1 should be deleted")
-		
+
 		_, err = tRepos.Items.GetOneByGroup(context.Background(), tGroup.ID, item2.ID)
 		require.Error(t, err, "Item 2 should be deleted")
-		
+
 		// Verify maintenance entries are deleted (query by item ID, should return empty)
 		maint1List, err := tRepos.MaintEntry.GetMaintenanceByItemID(context.Background(), tGroup.ID, item1.ID, MaintenanceFilters{})
 		require.NoError(t, err)
 		assert.Empty(t, maint1List, "Maintenance entry 1 should be deleted")
-		
+
 		maint2List, err := tRepos.MaintEntry.GetMaintenanceByItemID(context.Background(), tGroup.ID, item2.ID, MaintenanceFilters{})
 		require.NoError(t, err)
 		assert.Empty(t, maint2List, "Maintenance entry 2 should be deleted")
-		
+
 		// Verify labels are deleted
 		_, err = tRepos.Labels.GetOneByGroup(context.Background(), tGroup.ID, label1.ID)
 		require.Error(t, err, "Label 1 should be deleted")
-		
+
 		_, err = tRepos.Labels.GetOneByGroup(context.Background(), tGroup.ID, label2.ID)
 		require.Error(t, err, "Label 2 should be deleted")
-		
+
 		// Verify locations are deleted
 		_, err = tRepos.Locations.Get(context.Background(), loc1.ID)
 		require.Error(t, err, "Location 1 should be deleted")
-		
+
 		_, err = tRepos.Locations.Get(context.Background(), loc2.ID)
 		require.Error(t, err, "Location 2 should be deleted")
 	})
@@ -506,13 +506,13 @@ func TestItemsRepository_WipeInventory_OnlyItems(t *testing.T) {
 		Description: "Test location for wipe test",
 	})
 	require.NoError(t, err)
-	
+
 	label, err := tRepos.Labels.Create(context.Background(), tGroup.ID, LabelCreate{
 		Name:        "Test Label",
 		Description: "Test label for wipe test",
 	})
 	require.NoError(t, err)
-	
+
 	item, err := tRepos.Items.Create(context.Background(), tGroup.ID, ItemCreate{
 		Name:        "Test Item",
 		Description: "Test item for wipe test",
@@ -520,7 +520,7 @@ func TestItemsRepository_WipeInventory_OnlyItems(t *testing.T) {
 		LabelIDs:    []uuid.UUID{label.ID},
 	})
 	require.NoError(t, err)
-	
+
 	_, err = tRepos.MaintEntry.Create(context.Background(), item.ID, MaintenanceEntryCreate{
 		CompletedDate: types.DateFromTime(time.Now()),
 		Name:          "Test Maintenance",
@@ -528,31 +528,30 @@ func TestItemsRepository_WipeInventory_OnlyItems(t *testing.T) {
 		Cost:          100.0,
 	})
 	require.NoError(t, err)
-	
+
 	// Test: Wipe inventory with only items (no labels, locations, or maintenance)
 	deleted, err := tRepos.Items.WipeInventory(context.Background(), tGroup.ID, false, false, false)
 	require.NoError(t, err)
-	assert.Greater(t, deleted, 0, "Should have deleted at least the item")
-	
+	assert.Positive(t, deleted, "Should have deleted at least the item")
+
 	// Verify item is deleted
 	_, err = tRepos.Items.GetOneByGroup(context.Background(), tGroup.ID, item.ID)
 	require.Error(t, err, "Item should be deleted")
-	
+
 	// Verify maintenance entry is deleted due to cascade
 	maintList, err := tRepos.MaintEntry.GetMaintenanceByItemID(context.Background(), tGroup.ID, item.ID, MaintenanceFilters{})
 	require.NoError(t, err)
 	assert.Empty(t, maintList, "Maintenance entry should be cascade deleted with item")
-	
+
 	// Verify label still exists
 	_, err = tRepos.Labels.GetOneByGroup(context.Background(), tGroup.ID, label.ID)
 	require.NoError(t, err, "Label should still exist")
-	
+
 	// Verify location still exists
 	_, err = tRepos.Locations.Get(context.Background(), loc.ID)
 	require.NoError(t, err, "Location should still exist")
-	
+
 	// Cleanup
 	_ = tRepos.Labels.DeleteByGroup(context.Background(), tGroup.ID, label.ID)
 	_ = tRepos.Locations.delete(context.Background(), loc.ID)
 }
-

--- a/backend/internal/data/repo/repo_wipe_integration_test.go
+++ b/backend/internal/data/repo/repo_wipe_integration_test.go
@@ -21,26 +21,26 @@ func TestWipeInventory_Integration(t *testing.T) {
 		Description: "Garage location",
 	})
 	require.NoError(t, err)
-	
+
 	loc2, err := tRepos.Locations.Create(context.Background(), tGroup.ID, LocationCreate{
 		Name:        "Test Basement",
 		Description: "Basement location",
 	})
 	require.NoError(t, err)
-	
+
 	// 2. Create labels
 	label1, err := tRepos.Labels.Create(context.Background(), tGroup.ID, LabelCreate{
 		Name:        "Test Electronics",
 		Description: "Electronics label",
 	})
 	require.NoError(t, err)
-	
+
 	label2, err := tRepos.Labels.Create(context.Background(), tGroup.ID, LabelCreate{
 		Name:        "Test Tools",
 		Description: "Tools label",
 	})
 	require.NoError(t, err)
-	
+
 	// 3. Create items
 	item1, err := tRepos.Items.Create(context.Background(), tGroup.ID, ItemCreate{
 		Name:        "Test Laptop",
@@ -49,7 +49,7 @@ func TestWipeInventory_Integration(t *testing.T) {
 		LabelIDs:    []uuid.UUID{label1.ID},
 	})
 	require.NoError(t, err)
-	
+
 	item2, err := tRepos.Items.Create(context.Background(), tGroup.ID, ItemCreate{
 		Name:        "Test Drill",
 		Description: "Power drill",
@@ -57,7 +57,7 @@ func TestWipeInventory_Integration(t *testing.T) {
 		LabelIDs:    []uuid.UUID{label2.ID},
 	})
 	require.NoError(t, err)
-	
+
 	item3, err := tRepos.Items.Create(context.Background(), tGroup.ID, ItemCreate{
 		Name:        "Test Monitor",
 		Description: "Computer monitor",
@@ -65,7 +65,7 @@ func TestWipeInventory_Integration(t *testing.T) {
 		LabelIDs:    []uuid.UUID{label1.ID},
 	})
 	require.NoError(t, err)
-	
+
 	// 4. Create maintenance entries
 	_, err = tRepos.MaintEntry.Create(context.Background(), item1.ID, MaintenanceEntryCreate{
 		CompletedDate: types.DateFromTime(time.Now()),
@@ -74,7 +74,7 @@ func TestWipeInventory_Integration(t *testing.T) {
 		Cost:          0,
 	})
 	require.NoError(t, err)
-	
+
 	_, err = tRepos.MaintEntry.Create(context.Background(), item2.ID, MaintenanceEntryCreate{
 		CompletedDate: types.DateFromTime(time.Now()),
 		Name:          "Drill maintenance",
@@ -82,7 +82,7 @@ func TestWipeInventory_Integration(t *testing.T) {
 		Cost:          5.00,
 	})
 	require.NoError(t, err)
-	
+
 	_, err = tRepos.MaintEntry.Create(context.Background(), item3.ID, MaintenanceEntryCreate{
 		CompletedDate: types.DateFromTime(time.Now()),
 		Name:          "Monitor calibration",
@@ -90,47 +90,47 @@ func TestWipeInventory_Integration(t *testing.T) {
 		Cost:          0,
 	})
 	require.NoError(t, err)
-	
+
 	// 5. Verify items exist
 	allItems, err := tRepos.Items.GetAll(context.Background(), tGroup.ID)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(allItems), 3, "Should have at least 3 items")
-	
+
 	// 6. Verify maintenance entries exist
 	maint1List, err := tRepos.MaintEntry.GetMaintenanceByItemID(context.Background(), tGroup.ID, item1.ID, MaintenanceFilters{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, maint1List, "Item 1 should have maintenance records")
-	
+
 	maint2List, err := tRepos.MaintEntry.GetMaintenanceByItemID(context.Background(), tGroup.ID, item2.ID, MaintenanceFilters{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, maint2List, "Item 2 should have maintenance records")
-	
+
 	// 7. Test wipe inventory with all options enabled
 	deleted, err := tRepos.Items.WipeInventory(context.Background(), tGroup.ID, true, true, true)
 	require.NoError(t, err)
-	assert.Greater(t, deleted, 0, "Should have deleted entities")
-	
+	assert.Positive(t, deleted, "Should have deleted entities")
+
 	// 8. Verify all items are deleted
 	allItemsAfter, err := tRepos.Items.GetAll(context.Background(), tGroup.ID)
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(allItemsAfter), "All items should be deleted")
-	
+	assert.Empty(t, allItemsAfter, "All items should be deleted")
+
 	// 9. Verify maintenance entries are deleted
 	maint1After, err := tRepos.MaintEntry.GetMaintenanceByItemID(context.Background(), tGroup.ID, item1.ID, MaintenanceFilters{})
 	require.NoError(t, err)
 	assert.Empty(t, maint1After, "Item 1 maintenance records should be deleted")
-	
+
 	// 10. Verify labels are deleted
 	_, err = tRepos.Labels.GetOneByGroup(context.Background(), tGroup.ID, label1.ID)
 	require.Error(t, err, "Label 1 should be deleted")
-	
+
 	_, err = tRepos.Labels.GetOneByGroup(context.Background(), tGroup.ID, label2.ID)
 	require.Error(t, err, "Label 2 should be deleted")
-	
+
 	// 11. Verify locations are deleted
 	_, err = tRepos.Locations.Get(context.Background(), loc1.ID)
 	require.Error(t, err, "Location 1 should be deleted")
-	
+
 	_, err = tRepos.Locations.Get(context.Background(), loc2.ID)
 	require.Error(t, err, "Location 2 should be deleted")
 }
@@ -143,13 +143,13 @@ func TestWipeInventory_SelectiveWipe(t *testing.T) {
 		Description: "Office location",
 	})
 	require.NoError(t, err)
-	
+
 	label, err := tRepos.Labels.Create(context.Background(), tGroup.ID, LabelCreate{
 		Name:        "Test Important",
 		Description: "Important label",
 	})
 	require.NoError(t, err)
-	
+
 	item, err := tRepos.Items.Create(context.Background(), tGroup.ID, ItemCreate{
 		Name:        "Test Computer",
 		Description: "Desktop computer",
@@ -157,7 +157,7 @@ func TestWipeInventory_SelectiveWipe(t *testing.T) {
 		LabelIDs:    []uuid.UUID{label.ID},
 	})
 	require.NoError(t, err)
-	
+
 	_, err = tRepos.MaintEntry.Create(context.Background(), item.ID, MaintenanceEntryCreate{
 		CompletedDate: types.DateFromTime(time.Now()),
 		Name:          "System update",
@@ -165,29 +165,29 @@ func TestWipeInventory_SelectiveWipe(t *testing.T) {
 		Cost:          0,
 	})
 	require.NoError(t, err)
-	
+
 	// Test: Wipe only items (keep labels and locations)
 	deleted, err := tRepos.Items.WipeInventory(context.Background(), tGroup.ID, false, false, false)
 	require.NoError(t, err)
-	assert.Greater(t, deleted, 0, "Should have deleted at least items")
-	
+	assert.Positive(t, deleted, "Should have deleted at least items")
+
 	// Verify item is deleted
 	_, err = tRepos.Items.GetOneByGroup(context.Background(), tGroup.ID, item.ID)
 	require.Error(t, err, "Item should be deleted")
-	
+
 	// Verify maintenance is cascade deleted
 	maintList, err := tRepos.MaintEntry.GetMaintenanceByItemID(context.Background(), tGroup.ID, item.ID, MaintenanceFilters{})
 	require.NoError(t, err)
 	assert.Empty(t, maintList, "Maintenance should be cascade deleted")
-	
+
 	// Verify label still exists
 	_, err = tRepos.Labels.GetOneByGroup(context.Background(), tGroup.ID, label.ID)
 	require.NoError(t, err, "Label should still exist")
-	
+
 	// Verify location still exists
 	_, err = tRepos.Locations.Get(context.Background(), loc.ID)
 	require.NoError(t, err, "Location should still exist")
-	
+
 	// Cleanup
 	_ = tRepos.Labels.DeleteByGroup(context.Background(), tGroup.ID, label.ID)
 	_ = tRepos.Locations.delete(context.Background(), loc.ID)

--- a/backend/internal/sys/analytics/analytics.go
+++ b/backend/internal/sys/analytics/analytics.go
@@ -4,9 +4,10 @@ package analytics
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/shirou/gopsutil/v4/host"
 	"net/http"
 	"time"
+
+	"github.com/shirou/gopsutil/v4/host"
 
 	"github.com/rs/zerolog/log"
 )

--- a/backend/internal/sys/config/conf.go
+++ b/backend/internal/sys/config/conf.go
@@ -65,14 +65,14 @@ type WebConfig struct {
 }
 
 type LabelMakerConf struct {
-	Width                 int64          `yaml:"width"     conf:"default:526"`
-	Height                int64          `yaml:"height"    conf:"default:200"`
-	Padding               int64          `yaml:"padding"   conf:"default:32"`
-	Margin                int64          `yaml:"margin"    conf:"default:32"`
-	FontSize              float64        `yaml:"font_size" conf:"default:32.0"`
+	Width                 int64          `yaml:"width"                 conf:"default:526"`
+	Height                int64          `yaml:"height"                conf:"default:200"`
+	Padding               int64          `yaml:"padding"               conf:"default:32"`
+	Margin                int64          `yaml:"margin"                conf:"default:32"`
+	FontSize              float64        `yaml:"font_size"             conf:"default:32.0"`
 	PrintCommand          *string        `yaml:"string"`
 	AdditionalInformation *string        `yaml:"string"`
-	DynamicLength         bool           `yaml:"bool"      conf:"default:true"`
+	DynamicLength         bool           `yaml:"bool"                  conf:"default:true"`
 	LabelServiceUrl       *string        `yaml:"label_service_url"`
 	LabelServiceTimeout   *time.Duration `yaml:"label_service_timeout"`
 	RegularFontPath       *string        `yaml:"regular_font_path"`
@@ -80,13 +80,13 @@ type LabelMakerConf struct {
 }
 
 type OIDCConf struct {
-	Enabled            bool          `yaml:"enabled"             conf:"default:false"`
+	Enabled            bool          `yaml:"enabled"              conf:"default:false"`
 	IssuerURL          string        `yaml:"issuer_url"`
 	ClientID           string        `yaml:"client_id"`
 	ClientSecret       string        `yaml:"client_secret"`
 	Scope              string        `yaml:"scope"                conf:"default:openid profile email"`
 	AllowedGroups      string        `yaml:"allowed_groups"`
-	AutoRedirect       bool          `yaml:"auto_redirect"                conf:"default:false"`
+	AutoRedirect       bool          `yaml:"auto_redirect"        conf:"default:false"`
 	VerifyEmail        bool          `yaml:"verify_email"         conf:"default:false"`
 	GroupClaim         string        `yaml:"group_claim"          conf:"default:groups"`
 	EmailClaim         string        `yaml:"email_claim"          conf:"default:email"`

--- a/backend/pkgs/textutils/normalize.go
+++ b/backend/pkgs/textutils/normalize.go
@@ -22,13 +22,13 @@ func RemoveAccents(text string) string {
 	// 2. Removes diacritical marks (combining characters)
 	// 3. Normalizes back to NFC (canonical composition)
 	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
-	
+
 	result, _, err := transform.String(t, text)
 	if err != nil {
 		// If transformation fails, return the original text
 		return text
 	}
-	
+
 	return result
 }
 


### PR DESCRIPTION
## What type of PR is this?
- cleanup

## What this PR does / why we need it:

- Added the swag formatter to golangci-lint so API doc comments are formatted consistently. Then ran golangci-lint across the codebase. 
- Diabled autofixing which was giving the false impression everything was fine as it was fixing issues before reporting them
- Add forbidigo linter to prevent log.Fatal usage (see https://github.com/sysadminsmedia/homebox/pull/953)

I've also thrown in a git-blame-ignore-revs which can be enabled with 
`git config blame.ignoreRevsFile .git-blame-ignore-revs`

## Which issue(s) this PR fixes:

None, this was done under my own initiative 

## Special notes for your reviewer:

Not all of these changes are the result of the addition of the swag formatter, many seemingly missed the standard go fmt of golangci-lint when they were written at the time

## Testing

I ran it, the changes look ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inventory wipe now tolerates missing/invalid request bodies and defaults to no-wipe options instead of returning an error.

* **Tests**
  * Test assertions updated to more semantic/expressive validation styles.

* **Chores**
  * Linting rules updated (added forbid warnings and enabled an additional formatter).
  * General code formatting, import reordering, and minor cleanups across backend files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->