### PR TITLE
Fix unable to change password in password modal due to missing component import

### DIFF
--- a/frontend/pages/profile.vue
+++ b/frontend/pages/profile.vue
@@ -32,6 +32,7 @@
   import DetailsSection from "@/components/global/DetailsSection/DetailsSection.vue";
   import CopyText from "@/components/global/CopyText.vue";
   import DateTime from "@/components/global/DateTime.vue";
+  import PasswordScore from "~/components/global/PasswordScore.vue";
 
   const { t } = useI18n();
 


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

<!--
  Delete any of the following that do not apply:
 -->

- bug

## What this PR does / why we need it:

The password strength component is referenced in the password change modal, but is not imported, which causes the form to never be valid, and the password cannot be changed.

Before (demo instance):

<img width="619" height="457" alt="Screenshot_20260113_002611" src="https://github.com/user-attachments/assets/fd1707da-3d71-4360-a895-25816e5b4b1c" />

After (local environment):

<img width="619" height="457" alt="Screenshot_20260113_002547" src="https://github.com/user-attachments/assets/e7a53411-8aa5-48c7-b405-bd4776dd6ea1" />

_(REQUIRED)_

## Which issue(s) this PR fixes:

_(REQUIRED)_

Fixes #1233

## Testing

Made change, rebuilt container locally and verified password strength indicator appears on change password form, and password can be changed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password strength validation to the password change dialog. Users now receive real-time feedback on password security when updating their credentials.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->