### PR TITLE
Add Documentation Detailing Websocket Requirement for Reverse Proxies

### DIFF
--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -106,15 +106,22 @@ You can learn more about Docker by [reading the official Docker documentation.](
 
 ## Reverse Proxy
 
-If you use a reverse proxy, you will need to ensure websockets are properly proxied in addition to setting the `HBOX_OPTIONS_TRUST_PROXY` environment variable to `true`
-For example, if you use Nginx you will need to add the following config options in the `location` block that proxies at least `/api/v1/ws`:
+If you use a reverse proxy, there are a few things that need to be in place:
+
+::: warning
+Only set `HBOX_OPTIONS_TRUST_PROXY=true` when Homebox is behind a trusted reverse proxy. This setting makes the application trust proxy headers (X-Forwarded-Proto, X-Forwarded-For) which can be spoofed by clients if not protected by a reverse proxy.
+:::
+
+1. Set the `HBOX_OPTIONS_TRUST_PROXY` environment variable to `true`.
+2. Ensure the `Host` HTTP header is configured (e.g. `proxy_set_header Host $host;` for nginx).
+3. Ensure websockets are proxied properly (e.g. for nginx, add the following config in the `location` block).
+
+::: tip
+Setting websocket-specific configuration should be limited to the location that serves websockets (`/api/v1/ws`) to prevent potential issues with other site URLs.
+:::
 
 ```nginx
 proxy_http_version 1.1;
 proxy_set_header Upgrade $http_upgrade;
 proxy_set_header Connection "upgrade";
-proxy_connect_timeout 3600;
-proxy_read_timeout 3600;
-proxy_send_timeout 3600;
-send_timeout 3600;
 ```


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

This PR adds info in the installation documentation explaining that extra configuration is required for reverse proxies to support websockets, and providing an example config for Nginx.

I found out about the websocket connection while troubleshooting some other issue, and added the required Nginx configuration to resolve it. I figure this documentation addition will help future users.

## Which issue(s) this PR fixes:

A related issue/discussion can be found in:
#834 
#837 

## Special notes

I clicked the "Sync fork" button instead of simply rebasing, which is why there's a random merge commit that I can't easily remove now...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Reverse Proxy guidance to installation docs: warning about enabling trust only behind a trusted proxy, instructions to set the trust environment variable and preserve the Host header, websocket proxying guidance (scope recommended to /api/v1/ws), and an Nginx snippet for websocket proxy setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->