### PR TITLE
feat: add skip-first-labels and location-row toggle to label generator

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -757,8 +757,10 @@
         "label_generator": {
             "asset_end": "Asset End",
             "asset_start": "Asset Start",
+            "skip_first_labels": "Skip First Labels",
             "base_url": "Base URL",
             "bordered_labels": "Bordered Labels",
+            "print_location_row": "Print Location Row",
             "generate_page": "Generate Page",
             "input_placeholder": "Type here",
             "instruction_1": "The HomeBox Label Generator is a tool to help you print labels for your HomeBox inventory. These are intended to\n be print-ahead labels so you can print many labels and have them ready to apply",


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

This PR improves label printing flexibility and addresses requests from Discussion #53.

Main changes:
- Added support to skip the first N labels when printing.
- Added a toggle to show/hide the location row on labels.
- Updated label layout rendering to handle skipped/empty slots correctly.
- Prevented generating an empty page when there are no labels to print.
- Added required English translation keys for the new options.

## Which issue(s) this PR fixes:

Related to: https://github.com/sysadminsmedia/homebox/discussions/53  
Addresses requests in that discussion for:
- "Skip first x labels" behavior
- Option to remove/hide printed location row

## Special notes for your reviewer:

Please focus review on label pagination and placeholder rendering behavior in `frontend/pages/reports/label-generator.vue`.

## Testing

- Lint check:
  - `pnpm -C frontend exec eslint pages/reports/label-generator.vue`
- Manual behavior checks:
  - Verified skip offset works.
  - Verified no blank page is generated when there are no printable items.
  - Verified location row toggle works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skip a configurable number of initial labels in the label generator
  * Toggle location row visibility for label cards

* **Localization**
  * Added translations for label generator customization options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->