### PR TITLE
fix: tenant miss in export download URLs

### DIFF
--- a/frontend/lib/api/classes/items.ts
+++ b/frontend/lib/api/classes/items.ts
@@ -183,7 +183,11 @@ export class ItemsApi extends BaseAPI {
     });
   }
 
-  exportURL() {
+  exportURL(tenant?: string) {
+    if (tenant) {
+      return route("/items/export", { tenant });
+    }
+
     return route("/items/export");
   }
 }

--- a/frontend/lib/api/classes/reports.ts
+++ b/frontend/lib/api/classes/reports.ts
@@ -1,7 +1,11 @@
 import { BaseAPI, route } from "../base";
 
 export class ReportsAPI extends BaseAPI {
-  billOfMaterialsURL(): string {
+  billOfMaterialsURL(tenant?: string): string {
+    if (tenant) {
+      return route("/reporting/bill-of-materials", { tenant });
+    }
+
     return route("/reporting/bill-of-materials");
   }
 }

--- a/frontend/pages/collection/index/tools.vue
+++ b/frontend/pages/collection/index/tools.vue
@@ -119,6 +119,7 @@
   import DetailAction from "@/components/DetailAction.vue";
 
   const { t } = useI18n();
+  const prefs = useViewPreferences();
 
   definePageMeta({
     middleware: ["auth"],
@@ -138,12 +139,12 @@
   });
 
   const getBillOfMaterials = () => {
-    const url = api.reports.billOfMaterialsURL();
+    const url = api.reports.billOfMaterialsURL(prefs.value.collectionId ?? undefined);
     window.open(url, "_blank");
   };
 
   const getExportCSV = () => {
-    const url = api.items.exportURL();
+    const url = api.items.exportURL(prefs.value.collectionId ?? undefined);
     window.open(url, "_blank");
   };
 


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Export action in the tool page always exports the default collection: The export uses `window.open()` which doesn't send the X-Tenant header, and the URL doesn't include the `tenant` parameter, causing it to fall back to the default collection.

I fixed this issue by adding the `tenant` parameter. The changes are as follows:

- `frontend/pages/collection/index/tools.vue`: Provide the parameter `tenant` in generating URLs.
- `frontend/lib/api/classes/items.ts` `frontend/lib/api/classes/reports.ts`: Append the parameter `tenant` when provided in `exportURL()` and `billOfMaterialsURL()`.

## Which issue(s) this PR fixes:

Fixes #1310 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export and reporting functionality now support collection-specific context, enabling users to scope operations within their selected collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->