### PR TITLE
docs: update links in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can also try the demo instances of Homebox:
 
 ## Quick Start
 
-[Configuration & Docker Compose](https://homebox.software/en/quick-start.html)
+[Configuration & Docker Compose](https://homebox.software/en/quick-start/)
 
 ```bash
 # If using the rootless or hardened image, ensure data 
@@ -78,7 +78,7 @@ docker run -d \
 
 Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**.
 
-To get started with code based contributions, please see our [contributing guide](https://homebox.software/en/contribute/get-started.html).
+To get started with code based contributions, please see our [contributing guide](https://homebox.software/en/contribute/).
 
 If you are not a coder and can't help translate, you can still contribute financially. Financial contributions help us maintain the project and keep demos running.
 


### PR DESCRIPTION
## What type of PR is this?

- documentation

## What this PR does / why we need it:

Some links in `README.md` to the docs is broken and returns a 404. I have updated them to the available link:
- [Configuration & Docker Compose](https://homebox.software/en/quick-start.html) -> [Configuration & Docker Compose](https://homebox.software/en/quick-start/)
- [contributing guide](https://homebox.software/en/contribute/get-started.html) -> [contributing guide](https://homebox.software/en/contribute/)

## Which issue(s) this PR fixes:

I didn't found related issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start and Contributing guide links in README for improved navigation clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->