### PR TITLE
Prevent negative item quantity in edit form

### DIFF
--- a/backend/app/api/handlers/v1/v1_ctrl_item_templates.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_item_templates.go
@@ -108,7 +108,7 @@ type ItemTemplateCreateItemRequest struct {
 	Description string      `json:"description" validate:"max=1000"`
 	LocationID  uuid.UUID   `json:"locationId"  validate:"required"`
 	TagIDs      []uuid.UUID `json:"tagIds"`
-	Quantity    *int        `json:"quantity"`
+	Quantity    *int        `json:"quantity"    validate:"omitempty,min=0"`
 }
 
 // HandleItemTemplatesCreateItem godoc

--- a/backend/internal/data/repo/repo_item_templates.go
+++ b/backend/internal/data/repo/repo_item_templates.go
@@ -44,7 +44,7 @@ type (
 		Notes       string `json:"notes"       validate:"max=1000"`
 
 		// Default values for items
-		DefaultQuantity         *int    `json:"defaultQuantity,omitempty"        extensions:"x-nullable"`
+		DefaultQuantity         *int    `json:"defaultQuantity,omitempty"        validate:"omitempty,min=0"   extensions:"x-nullable"`
 		DefaultInsured          bool    `json:"defaultInsured"`
 		DefaultName             *string `json:"defaultName,omitempty"            validate:"omitempty,max=255"  extensions:"x-nullable"`
 		DefaultDescription      *string `json:"defaultDescription,omitempty"     validate:"omitempty,max=1000" extensions:"x-nullable"`
@@ -73,7 +73,7 @@ type (
 		Notes       string    `json:"notes"       validate:"max=1000"`
 
 		// Default values for items
-		DefaultQuantity         *int    `json:"defaultQuantity,omitempty"        extensions:"x-nullable"`
+		DefaultQuantity         *int    `json:"defaultQuantity,omitempty"        validate:"omitempty,min=0"   extensions:"x-nullable"`
 		DefaultInsured          bool    `json:"defaultInsured"`
 		DefaultName             *string `json:"defaultName,omitempty"            validate:"omitempty,max=255"  extensions:"x-nullable"`
 		DefaultDescription      *string `json:"defaultDescription,omitempty"     validate:"omitempty,max=1000" extensions:"x-nullable"`

--- a/backend/internal/data/repo/repo_items.go
+++ b/backend/internal/data/repo/repo_items.go
@@ -71,7 +71,7 @@ type (
 		ImportRef   string    `json:"-"`
 		ParentID    uuid.UUID `json:"parentId"    extensions:"x-nullable"`
 		Name        string    `json:"name"        validate:"required,min=1,max=255"`
-		Quantity    int       `json:"quantity"`
+		Quantity    int       `json:"quantity"    validate:"min=0"`
 		Description string    `json:"description" validate:"max=1000"`
 		AssetID     AssetID   `json:"-"`
 
@@ -86,7 +86,7 @@ type (
 		AssetID                 AssetID   `json:"assetId"                 swaggertype:"string"`
 		Name                    string    `json:"name"                    validate:"required,min=1,max=255"`
 		Description             string    `json:"description"             validate:"max=1000"`
-		Quantity                int       `json:"quantity"`
+		Quantity                int       `json:"quantity"                validate:"min=0"`
 		Insured                 bool      `json:"insured"`
 		Archived                bool      `json:"archived"`
 		SyncChildItemsLocations bool      `json:"syncChildItemsLocations"`
@@ -123,7 +123,7 @@ type (
 
 	ItemPatch struct {
 		ID         uuid.UUID   `json:"id"`
-		Quantity   *int        `json:"quantity,omitempty" extensions:"x-nullable,x-omitempty"`
+		Quantity   *int        `json:"quantity,omitempty" validate:"omitempty,min=0" extensions:"x-nullable,x-omitempty"`
 		ImportRef  *string     `json:"-,omitempty"        extensions:"x-nullable,x-omitempty"`
 		LocationID uuid.UUID   `json:"locationId"         extensions:"x-nullable,x-omitempty"`
 		TagIDs     []uuid.UUID `json:"tagIds"             extensions:"x-nullable,x-omitempty"`

--- a/frontend/components/Form/TextField.vue
+++ b/frontend/components/Form/TextField.vue
@@ -20,6 +20,7 @@
       :placeholder="placeholder"
       :type="type"
       :required="required"
+      :min="min"
       class="w-full"
     />
   </div>
@@ -43,6 +44,7 @@
       :placeholder="placeholder"
       :type="type"
       :required="required"
+      :min="min"
       class="col-span-3 mt-2 w-full"
     />
   </div>
@@ -88,6 +90,11 @@
     minLength: {
       type: Number,
       default: -1,
+      required: false,
+    },
+    min: {
+      type: Number,
+      default: undefined,
       required: false,
     },
   });

--- a/frontend/pages/item/[id]/index/edit.vue
+++ b/frontend/pages/item/[id]/index/edit.vue
@@ -161,6 +161,7 @@
     type: "number";
     label: string;
     ref: NonNullableNumberKeys<ItemOut> | NonNullableStringKeys<ItemOut>;
+    min?: number;
   };
 
   interface BoolFormField {
@@ -189,6 +190,7 @@
       type: "number",
       label: "items.quantity",
       ref: "quantity",
+      min: 0,
     },
     {
       type: "markdown",
@@ -639,6 +641,7 @@
                   v-model.number="item[field.ref]"
                   type="number"
                   :label="$t(field.label)"
+                  :min="field.min"
                   inline
                 />
                 <FormDatePicker
@@ -800,6 +803,7 @@
                   v-model.number="item[field.ref]"
                   type="number"
                   :label="$t(field.label)"
+                  :min="field.min"
                   inline
                 />
                 <FormDatePicker
@@ -847,6 +851,7 @@
                   v-model.number="item[field.ref]"
                   type="number"
                   :label="$t(field.label)"
+                  :min="field.min"
                   inline
                 />
                 <FormDatePicker
@@ -894,6 +899,7 @@
                   v-model.number="item[field.ref]"
                   type="number"
                   :label="$t(field.label)"
+                  :min="field.min"
                   inline
                 />
                 <FormDatePicker


### PR DESCRIPTION
The increment/decrement buttons on the item view already check for negative values, but the advanced edit form lets you type or scroll below zero freely.

This adds validation on both sides:
- **Frontend:** New `min` prop on `FormTextField`, passed through to the HTML input. Quantity field sets `min=0`.
- **Backend:** `validate:"min=0"` on the `Quantity` field in `ItemCreate`, `ItemUpdate`, and `ItemPatch` structs. The existing `go-playground/validator` pipeline catches it before anything hits the database.

Fixes #1231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Numeric input components accept an optional minimum value and this minimum is applied in item edit forms.

* **Bug Fixes**
  * Quantity inputs now enforce a non-negative minimum (0) across create, update, patch, and template-based item flows to prevent negative quantities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->