### PR TITLE
feat: Niimbot BLE thermal printer integration

### DIFF
--- a/frontend/components/global/LabelMaker.vue
+++ b/frontend/components/global/LabelMaker.vue
@@ -2,6 +2,7 @@
   import { useI18n } from "vue-i18n";
   import { type QueryValue, route } from "../../lib/api/base/urls";
   import PageQRCode from "./PageQRCode.vue";
+  import NiimbotPrint from "@/components/niimbot/NiimbotPrint.vue";
   import { DialogID } from "@/components/ui/dialog-provider/utils";
   import { toast } from "@/components/ui/sonner";
   import MdiLoading from "~icons/mdi/loading";
@@ -121,6 +122,7 @@
             </Button>
           </ButtonGroup>
         </DialogFooter>
+        <NiimbotPrint :id="id" :type="type" />
       </DialogContent>
     </Dialog>
 

--- a/frontend/components/niimbot/NiimbotPrint.vue
+++ b/frontend/components/niimbot/NiimbotPrint.vue
@@ -1,0 +1,189 @@
+<script setup lang="ts">
+  import { ref, onMounted } from "vue";
+  import { useI18n } from "vue-i18n";
+  import { type QueryValue, route } from "../../lib/api/base/urls";
+  import { toast } from "@/components/ui/sonner";
+  import { Button } from "@/components/ui/button";
+  import { PRESET_TAPE_SIZES, type TapeSize } from "@/composables/use-niimbot";
+  import MdiLoading from "~icons/mdi/loading";
+  import MdiBluetooth from "~icons/mdi/bluetooth";
+  import MdiBluetoothConnect from "~icons/mdi/bluetooth-connect";
+
+  const { t } = useI18n();
+
+  const props = defineProps<{
+    type: string;
+    id: string;
+  }>();
+
+  const {
+    isSupported,
+    connected,
+    deviceName,
+    printing,
+    printProgress,
+    connect,
+    disconnect,
+    printImage,
+    loadSavedTapeSize,
+    saveTapeSize,
+  } = useNiimbot();
+
+  // --- Label variant ---
+  type LabelVariant = "full" | "qr";
+  const labelVariant = ref<LabelVariant>("full");
+
+  // --- Tape size ---
+  const selectedPresetIndex = ref(-1);
+  const customWidth = ref(50);
+  const customHeight = ref(30);
+  const isCustomSize = ref(false);
+
+  onMounted(() => {
+    const saved = loadSavedTapeSize();
+    const presetIdx = PRESET_TAPE_SIZES.findIndex(s => s.width === saved.width && s.height === saved.height);
+    if (presetIdx >= 0) {
+      selectedPresetIndex.value = presetIdx;
+      isCustomSize.value = false;
+    } else {
+      isCustomSize.value = true;
+      customWidth.value = saved.width;
+      customHeight.value = saved.height;
+    }
+  });
+
+  function getCurrentTapeSize(): TapeSize {
+    if (isCustomSize.value) {
+      return {
+        label: `${customWidth.value} × ${customHeight.value} mm`,
+        width: customWidth.value,
+        height: customHeight.value,
+      };
+    }
+    return PRESET_TAPE_SIZES[selectedPresetIndex.value] ?? PRESET_TAPE_SIZES[2];
+  }
+
+  function getLabelImageUrl(): string {
+    const { selectedId } = useCollections();
+    const params: Record<string, QueryValue> = {};
+    if (selectedId.value) {
+      params.tenant = selectedId.value;
+    }
+
+    if (labelVariant.value === "qr") {
+      const pageUrl = `${window.location.origin}${window.location.pathname}`;
+      return route("/qrcode", { data: pageUrl });
+    }
+
+    const validTypes = ["item", "location", "asset"];
+    if (!validTypes.includes(props.type)) {
+      throw new Error(`Unexpected type: ${props.type}`);
+    }
+    return route(`/labelmaker/${props.type}/${props.id}`, params);
+  }
+
+  async function handlePrint() {
+    try {
+      const tapeSize = getCurrentTapeSize();
+      saveTapeSize(tapeSize);
+
+      const url = getLabelImageUrl();
+      await printImage(url, tapeSize);
+      toast.success(t("components.niimbot.print_success"));
+    } catch (e) {
+      console.error("Niimbot: print error", e);
+      const msg = e instanceof Error ? e.message : String(e);
+      toast.error(t("components.niimbot.print_failed", { error: msg }));
+    }
+  }
+
+  async function handleConnect() {
+    try {
+      if (connected.value) {
+        await disconnect();
+      } else {
+        await connect();
+      }
+    } catch (e) {
+      console.error("Niimbot: connection error", e);
+      const msg = e instanceof Error ? e.message : String(e);
+      toast.error(t("components.niimbot.connection_failed", { error: msg }));
+    }
+  }
+
+  function onPresetChange(event: Event) {
+    const value = (event.target as HTMLSelectElement).value;
+    if (value === "custom") {
+      isCustomSize.value = true;
+      selectedPresetIndex.value = -1;
+    } else {
+      isCustomSize.value = false;
+      selectedPresetIndex.value = Number(value);
+    }
+  }
+</script>
+
+<template>
+  <div v-if="isSupported" class="mt-3 flex flex-col gap-3 border-t pt-3">
+    <div class="flex items-center justify-between">
+      <span class="text-sm font-medium">Niimbot</span>
+      <Button size="sm" variant="outline" class="gap-1" @click="handleConnect">
+        <MdiBluetoothConnect v-if="connected" class="text-blue-500" />
+        <MdiBluetooth v-else />
+        {{ connected ? deviceName : $t("components.niimbot.connect") }}
+      </Button>
+    </div>
+
+    <!-- Label variant -->
+    <div class="flex items-center gap-2">
+      <label class="text-sm">{{ $t("components.niimbot.label") }}:</label>
+      <select v-model="labelVariant" class="flex-1 rounded border bg-background px-2 py-1 text-sm">
+        <option value="full">{{ $t("components.niimbot.label_full") }}</option>
+        <option value="qr">{{ $t("components.niimbot.label_qr") }}</option>
+      </select>
+    </div>
+
+    <!-- Tape size -->
+    <div class="flex items-center gap-2">
+      <label class="text-sm">{{ $t("components.niimbot.tape") }}:</label>
+      <select
+        class="flex-1 rounded border bg-background px-2 py-1 text-sm"
+        :value="isCustomSize ? 'custom' : selectedPresetIndex"
+        @change="onPresetChange"
+      >
+        <option v-for="(size, idx) in PRESET_TAPE_SIZES" :key="idx" :value="idx">
+          {{ size.label }}
+        </option>
+        <option value="custom">{{ $t("components.niimbot.custom") }}</option>
+      </select>
+    </div>
+
+    <!-- Custom size inputs -->
+    <div v-if="isCustomSize" class="flex items-center gap-2">
+      <input
+        v-model.number="customWidth"
+        type="number"
+        min="10"
+        max="100"
+        class="w-16 rounded border bg-background px-2 py-1 text-sm"
+        placeholder="W"
+      />
+      <span class="text-sm">x</span>
+      <input
+        v-model.number="customHeight"
+        type="number"
+        min="10"
+        max="200"
+        class="w-16 rounded border bg-background px-2 py-1 text-sm"
+        placeholder="H"
+      />
+      <span class="text-sm text-muted-foreground">mm</span>
+    </div>
+
+    <!-- Print button -->
+    <Button class="w-full gap-2" :disabled="printing" @click="handlePrint">
+      <MdiLoading v-if="printing" class="animate-spin" />
+      {{ printing ? $t("components.niimbot.printing", { progress: printProgress }) : $t("components.niimbot.print") }}
+    </Button>
+  </div>
+</template>

--- a/frontend/composables/use-niimbot.ts
+++ b/frontend/composables/use-niimbot.ts
@@ -1,0 +1,284 @@
+import { ref, computed } from "vue";
+
+// Lazy import to avoid SSR issues with Web Bluetooth
+let niimbluelib: typeof import("@mmote/niimbluelib") | null = null;
+
+async function loadNiimbluelib() {
+  if (!niimbluelib) {
+    try {
+      niimbluelib = await import("@mmote/niimbluelib");
+    } catch (e) {
+      throw new Error("Failed to load @mmote/niimbluelib. Check that the package is installed.");
+    }
+  }
+  return niimbluelib;
+}
+
+export type TapeSize = {
+  label: string;
+  width: number;
+  height: number;
+};
+
+export const PRESET_TAPE_SIZES: TapeSize[] = [
+  { label: "30 × 20 mm", width: 30, height: 20 },
+  { label: "40 × 30 mm", width: 40, height: 30 },
+  { label: "50 × 30 mm", width: 50, height: 30 },
+  { label: "50 × 50 mm", width: 50, height: 50 },
+  { label: "40 × 60 mm", width: 40, height: 60 },
+];
+
+const DPMM = 8; // 203 DPI = 8 dots per mm
+const MIN_TAPE_MM = 10;
+const MAX_TAPE_WIDTH_MM = 100;
+const MAX_TAPE_HEIGHT_MM = 200;
+
+const LS_TAPE_KEY = "niimbot_tape_size";
+
+// Shared state across component instances
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- niimbluelib alpha has no type declarations
+const client = ref<any>(null);
+const deviceName = ref<string | null>(null);
+const connected = ref(false);
+const printing = ref(false);
+const printProgress = ref(0);
+
+export function useNiimbot() {
+  const isSupported = computed(() => typeof navigator !== "undefined" && "bluetooth" in navigator);
+
+  function loadSavedTapeSize(): TapeSize {
+    if (typeof localStorage === "undefined") return PRESET_TAPE_SIZES[2]; // 50x30 default
+    const saved = localStorage.getItem(LS_TAPE_KEY);
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        if (
+          Number.isFinite(parsed.width) &&
+          Number.isFinite(parsed.height) &&
+          parsed.width >= MIN_TAPE_MM &&
+          parsed.width <= MAX_TAPE_WIDTH_MM &&
+          parsed.height >= MIN_TAPE_MM &&
+          parsed.height <= MAX_TAPE_HEIGHT_MM
+        ) {
+          return parsed;
+        }
+        localStorage.removeItem(LS_TAPE_KEY);
+      } catch (e) {
+        console.warn("Niimbot: corrupted tape size in localStorage, resetting", e);
+        localStorage.removeItem(LS_TAPE_KEY);
+      }
+    }
+    return PRESET_TAPE_SIZES[2];
+  }
+
+  function saveTapeSize(size: TapeSize) {
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem(LS_TAPE_KEY, JSON.stringify(size));
+    }
+  }
+
+  async function connect(): Promise<boolean> {
+    const lib = await loadNiimbluelib();
+    const newClient = new lib.NiimbotBluetoothClient();
+
+    newClient.on("disconnect", () => {
+      connected.value = false;
+      deviceName.value = null;
+      client.value = null;
+    });
+
+    newClient.on("printprogress", event => {
+      printProgress.value = event.pagePrintProgress;
+    });
+
+    try {
+      const info = await newClient.connect();
+      client.value = newClient;
+      connected.value = true;
+      deviceName.value = info.deviceName ?? "Niimbot";
+      try {
+        await newClient.fetchPrinterInfo();
+      } catch (infoErr) {
+        console.warn("Niimbot: connected but failed to fetch printer info", infoErr);
+      }
+      return true;
+    } catch (e) {
+      // User cancelled the Bluetooth picker — not an error
+      if (e instanceof DOMException && e.name === "NotFoundError") {
+        return false;
+      }
+      try {
+        await newClient.disconnect();
+      } catch (cleanupErr) {
+        console.warn("Niimbot: cleanup disconnect failed", cleanupErr);
+      }
+      // Real error — throw so caller can show it
+      throw e;
+    }
+  }
+
+  async function disconnect() {
+    if (client.value) {
+      try {
+        await client.value.disconnect();
+      } catch (e) {
+        console.warn("Niimbot: disconnect failed, cleaning up anyway", e);
+      } finally {
+        client.value = null;
+        connected.value = false;
+        deviceName.value = null;
+      }
+    }
+  }
+
+  async function printImage(imageUrl: string, tapeSize: TapeSize): Promise<void> {
+    if (!client.value) {
+      await connect(); // throws on real error, returns false on cancel
+      if (!client.value) return; // user cancelled
+    }
+
+    const lib = await loadNiimbluelib();
+    printing.value = true;
+    printProgress.value = 0;
+
+    // Capture client ref to avoid race condition if BLE disconnects mid-print
+    const c = client.value;
+
+    try {
+      // With printDirection "top" (no rotation):
+      //   canvas width  → cols (across printhead, must be multiple of 8)
+      //   canvas height → rows (feed direction)
+      // Printer does NOT auto-center. Canvas must span full printhead
+      // width, with label content centered within it.
+      if (!Number.isFinite(tapeSize.width) || !Number.isFinite(tapeSize.height)) {
+        throw new Error("Invalid tape dimensions");
+      }
+
+      const meta = c.getModelMetadata?.();
+      const printheadPx = meta?.printheadPixels ?? 384;
+      const labelWidthPx = Math.round(tapeSize.width * DPMM);
+      const labelHeightPx = Math.round(tapeSize.height * DPMM);
+
+      if (labelWidthPx <= 0 || labelHeightPx <= 0) {
+        throw new Error("Tape dimensions must be greater than zero");
+      }
+      if (labelWidthPx > printheadPx) {
+        throw new Error(`Tape width exceeds printhead (${printheadPx / DPMM} mm max)`);
+      }
+
+      // Load and process label image
+      const img = await loadImage(imageUrl);
+
+      // First render label at tape dimensions
+      const labelCanvas = resizeToCanvas(img, labelWidthPx, labelHeightPx);
+      applyThreshold(labelCanvas, 128);
+
+      // Then place centered on printhead-wide canvas
+      const canvas = document.createElement("canvas");
+      canvas.width = printheadPx;
+      canvas.height = labelHeightPx;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) throw new Error("Failed to create canvas context for label rendering");
+      ctx.fillStyle = "white";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      const offsetX = Math.floor((printheadPx - labelWidthPx) / 2);
+      ctx.drawImage(labelCanvas, offsetX, 0);
+
+      // Encode for printer (no rotation for wide labels)
+      const encoded = lib.ImageEncoder.encodeCanvas(canvas, "top");
+
+      // Stop heartbeat during printing (can interfere with protocol)
+      c.stopHeartbeat();
+
+      // Get print task type from printer or fallback to B1
+      const taskType = c.getPrintTaskType?.() ?? "B1";
+      const printTask = c.abstraction.newPrintTask(taskType, {
+        totalPages: 1,
+        labelType: lib.LabelType.WithGaps,
+        density: 3,
+      });
+
+      await printTask.printInit();
+      await printTask.printPage(encoded, 1);
+      await printTask.waitForFinished();
+
+      printProgress.value = 100;
+    } catch (e) {
+      console.error("Niimbot print failed:", e);
+      throw e;
+    } finally {
+      try {
+        await c.abstraction?.printEnd();
+      } catch (endErr) {
+        console.warn("Niimbot: printEnd failed, printer may need power cycle", endErr);
+      }
+      c.startHeartbeat?.();
+      printing.value = false;
+    }
+  }
+
+  return {
+    isSupported,
+    connected,
+    deviceName,
+    printing,
+    printProgress,
+    connect,
+    disconnect,
+    printImage,
+    loadSavedTapeSize,
+    saveTapeSize,
+  };
+}
+
+// --- Helper functions ---
+
+function loadImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error(`Failed to load image: ${url}`));
+    img.src = url;
+  });
+}
+
+function resizeToCanvas(img: HTMLImageElement, targetW: number, targetH: number): HTMLCanvasElement {
+  const canvas = document.createElement("canvas");
+  canvas.width = targetW;
+  canvas.height = targetH;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Failed to create canvas context");
+
+  // White background
+  ctx.fillStyle = "white";
+  ctx.fillRect(0, 0, targetW, targetH);
+
+  // Fit image preserving aspect ratio
+  const scale = Math.min(targetW / img.width, targetH / img.height);
+  const w = img.width * scale;
+  const h = img.height * scale;
+  const x = (targetW - w) / 2;
+  const y = (targetH - h) / 2;
+  ctx.drawImage(img, x, y, w, h);
+
+  return canvas;
+}
+
+function applyThreshold(canvas: HTMLCanvasElement, threshold: number) {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Failed to get canvas context for threshold");
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const data = imageData.data;
+
+  for (let i = 0; i < data.length; i += 4) {
+    const luminance = data[i] * 0.299 + data[i + 1] * 0.587 + data[i + 2] * 0.114;
+    const val = luminance < threshold ? 0 : 255;
+    data[i] = val;
+    data[i + 1] = val;
+    data[i + 2] = val;
+    data[i + 3] = 255;
+  }
+
+  ctx.putImageData(imageData, 0, 0);
+}

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -1,899 +1,912 @@
 {
-    "collection": {
-        "copy_invite": "Copy Invite Link",
-        "create_invite": "Create Invite",
-        "delete_collection": "Delete Collection",
-        "delete_confirm": "Are you sure you want to delete this collection? This action cannot be undone.",
-        "deleted_collection": "Collection deleted.",
-        "expires_at": "Expires",
-        "invite_token": "Token",
-        "invite_token_hidden": "No longer visible",
-        "invite_token_warning": "Invite tokens are only shown once. Copy the link now; you will not be able to view this token again after leaving or refreshing this page.",
-        "invites": "Invites",
-        "invites_delete_confirm": "Are you sure you want to delete this invite?",
-        "leave_collection": "Leave Collection",
-        "leave_confirm": "Are you sure you want to leave this collection?",
-        "left_collection": "You have left the collection.",
-        "manage_collection": "Manage Collection",
-        "members": {
-            "cannot_remove_last": "You cannot remove the last member.",
-            "email": "Email",
-            "empty": "No members in this collection yet.",
-            "member": "Member",
-            "name": "Name",
-            "owner": "Owner",
-            "remove_confirm": "Are you sure you want to remove this member?",
-            "removed": "Member removed",
-            "role": "Role"
-        },
-        "no_collections": {
-            "create": "Create a new collection",
-            "join": "Join an existing collection",
-            "message": "It looks like you're not part of a collection. Create a new collection for your things, or join one you've been invited to.",
-            "title": "No Collections Found"
-        },
-        "no_invites": "No invites",
-        "remaining_uses": "Remaining uses",
-        "tabs": {
-            "invites": "Invites",
-            "members": "Members",
-            "notifiers": "Notifiers",
-            "settings": "Settings",
-            "tools": "Tools"
-        },
-        "uses": "Uses"
+  "collection": {
+    "copy_invite": "Copy Invite Link",
+    "create_invite": "Create Invite",
+    "delete_collection": "Delete Collection",
+    "delete_confirm": "Are you sure you want to delete this collection? This action cannot be undone.",
+    "deleted_collection": "Collection deleted.",
+    "expires_at": "Expires",
+    "invite_token": "Token",
+    "invite_token_hidden": "No longer visible",
+    "invite_token_warning": "Invite tokens are only shown once. Copy the link now; you will not be able to view this token again after leaving or refreshing this page.",
+    "invites": "Invites",
+    "invites_delete_confirm": "Are you sure you want to delete this invite?",
+    "leave_collection": "Leave Collection",
+    "leave_confirm": "Are you sure you want to leave this collection?",
+    "left_collection": "You have left the collection.",
+    "manage_collection": "Manage Collection",
+    "members": {
+      "cannot_remove_last": "You cannot remove the last member.",
+      "email": "Email",
+      "empty": "No members in this collection yet.",
+      "member": "Member",
+      "name": "Name",
+      "owner": "Owner",
+      "remove_confirm": "Are you sure you want to remove this member?",
+      "removed": "Member removed",
+      "role": "Role"
     },
-    "components": {
-        "app": {
-            "create_modal": {
-                "createAndAddAnother": "Use {shiftKey} + {enterKey} to create and add another.",
-                "enter": "Enter",
-                "shift": "Shift"
-            },
-            "import_dialog": {
-                "change_warning": "Behavior for imports with existing import_refs has changed. If an import_ref is present in the CSV file, the \nitem will be updated with the values in the CSV file.",
-                "description": "Import a CSV file containing your items, labels, and locations. See documentation for more information on the \nrequired format.",
-                "title": "Import CSV File",
-                "toast": {
-                    "import_failed": "Import failed. Please try again later.",
-                    "import_success": "Import successful!",
-                    "please_select_file": "Please select a file to import."
-                }
-            },
-            "outdated": {
-                "current_version": "Current Version",
-                "dismiss": "Dismiss",
-                "latest_version": "Latest Version",
-                "new_version_available": "New Version Available",
-                "new_version_available_link": "Click here to view the release notes"
-            }
-        },
-        "collection": {
-            "create_modal": {
-                "name_label": "Collection Name",
-                "title": "Create Collection",
-                "toast": {
-                    "already_creating": "Already creating a collection",
-                    "create_failed": "Failed to create collection",
-                    "create_success": "Collection created",
-                    "please_enter_name": "Please enter a collection name"
-                }
-            },
-            "invite_create_modal": {
-                "toast": {
-                    "invalid_expiry_missing": "Please choose an expiration date and time.",
-                    "invalid_expiry_past": "Expiration date must be in the future.",
-                    "invalid_uses": "Uses must be a number between 1 and 100."
-                }
-            },
-            "join_modal": {
-                "invite_code_label": "Collection Invite Code",
-                "invites_should_look_like": "Invites should look like:",
-                "join": "Join Collection",
-                "no_invite_code_create_one": "No invite code? Create a new collection instead",
-                "title": "Join Collection",
-                "toast": {
-                    "already_joining": "Already joining a collection",
-                    "join_failed": "Failed to join collection",
-                    "join_success": "Collection joined",
-                    "please_enter_valid_join_code": "Please enter a valid collection invite code"
-                }
-            },
-            "selector": {
-                "collection_options": "Collection Options",
-                "create_collection": "Create New Collection",
-                "join_collection": "Join Existing Collection",
-                "no_collection_found": "No collection found",
-                "search_collections": "Search Collections…",
-                "select_collection": "Select Collection",
-                "your_collections": "Your Collections"
-            }
-        },
-        "color_selector": {
-            "clear": "Clear color",
-            "color": "Color",
-            "no_color": "No color",
-            "no_color_selected": "No color selected",
-            "randomize": "Randomize color"
-        },
-        "form": {
-            "password": {
-                "toggle_show": "Toggle Password Show"
-            }
-        },
-        "global": {
-            "copy_text": {
-                "continue": "Continue",
-                "documentation": "documentation",
-                "failed_to_copy": "Failed to copy text to clipboard",
-                "https_required": "because HTTPS is required",
-                "learn_more": "Learn more in our"
-            },
-            "date_time": {
-                "ago": "{0} ago",
-                "days": "days",
-                "hour": "hour",
-                "hours": "hours",
-                "in": "in {0}",
-                "just-now": "just now",
-                "last-month": "last month",
-                "last-week": "last week",
-                "last-year": "last year",
-                "minute": "minute",
-                "minutes": "minutes",
-                "months": "months",
-                "next-month": "next month",
-                "next-week": "next week",
-                "next-year": "next year",
-                "second": "second",
-                "seconds": "seconds",
-                "tomorrow": "tomorrow",
-                "week": "week",
-                "weeks": "weeks",
-                "years": "years",
-                "yesterday": "yesterday"
-            },
-            "label_maker": {
-                "browser_print": "Print from Browser",
-                "confirm_description": "Are you sure you want to print this label?",
-                "download": "Download Label",
-                "print": "Print label",
-                "server_print": "Print on Server",
-                "titles": "Labels",
-                "toast": {
-                    "load_status_failed": "Failed to load status",
-                    "print_failed": "Failed to print label",
-                    "print_success": "Label printed"
-                }
-            },
-            "page_qr_code": {
-                "page_url": "Page URL",
-                "qr_tooltip": "Show QR Code"
-            },
-            "password_score": {
-                "password_strength": "Password Strength"
-            }
-        },
-        "item": {
-            "attachments_list": {
-                "download": "Download",
-                "open_new_tab": "Open in new tab"
-            },
-            "create_modal": {
-                "clear_template": "Clear Template",
-                "delete_photo": "Delete photo",
-                "item_description": "Item Description",
-                "item_name": "Item Name",
-                "item_photo": "Item Photo 📷",
-                "item_quantity": "Item Quantity",
-                "parent_item": "Parent Item",
-                "product_tooltip_input_barcode": "Autofill with a manually provided barcode",
-                "product_tooltip_scan_barcode": "Autofill with a barcode from 📷",
-                "rotate_photo": "Rotate photo",
-                "set_as_primary_photo": "Set as { isPrimary, select, true {non-} false {} other {}}primary photo",
-                "title": "Create Item",
-                "toast": {
-                    "already_creating": "Already creating an item",
-                    "create_failed": "Couldn't create item",
-                    "create_success": "Item created",
-                    "failed_load_parent": "Failed to load parent item - please select manually",
-                    "no_canvas_support": "Your browser doesn't support canvas operations",
-                    "please_select_location": "Please select a location.",
-                    "rotate_failed": "Failed to rotate image: { error }",
-                    "rotate_process_failed": "Failed to process rotated image",
-                    "some_photos_failed": "{count, plural, =0 {No photos to upload.} =1 {1 photo failed to upload.} other {Some photos failed to upload.}}",
-                    "upload_failed": "Failed to upload photo: { photoName }",
-                    "upload_success": "{count, plural, =0 {No photos uploaded.} =1 {Photo uploaded successfully.} other {All photos uploaded successfully.}}",
-                    "uploading_photos": "{count, plural, =0 {No photos to upload} =1 {Uploading 1 photo…} other {Uploading {count} photos…}}"
-                },
-                "upload_photos": "Upload Photos",
-                "uploaded": "Uploaded Photo"
-            },
-            "product_import": {
-                "barcode": "Product's barcode",
-                "db_source": "DB source",
-                "error_exception": "Exception occured while retrieving item barcode: ",
-                "error_invalid_barcode": "Invalid barcode provided",
-                "error_not_found": "No product found with given barcode.",
-                "import_selected": "Import selected",
-                "search_item": "Search product",
-                "title": "Import product"
-            },
-            "selector": {
-                "clear": "Clear Item Selection",
-                "no_results": "No Results Found",
-                "placeholder": "Select…",
-                "search_placeholder": "Type to search…",
-                "searching": "Searching…"
-            },
-            "view": {
-                "change_details": {
-                    "add_tags": "Add Tags",
-                    "failed_to_update_item": "Failed to update item",
-                    "remove_tags": "Remove Tags",
-                    "title": "Change Item Details"
-                },
-                "selectable": {
-                    "card": "Card",
-                    "items": "Items",
-                    "no_items": "No Items to Display",
-                    "select_all": "Select All",
-                    "select_card": "Select Card",
-                    "select_row": "Select Row",
-                    "table": "Table"
-                },
-                "table": {
-                    "dropdown": {
-                        "actions": "Actions",
-                        "change_location": "Change Location",
-                        "change_location_success": "Location Changed",
-                        "change_tags": "Change Tags",
-                        "change_tags_success": "Tags Changed",
-                        "create_maintenance_item": "Create Maintenance Entry for Item",
-                        "create_maintenance_selected": "Create Maintenance Entry for Selected Items",
-                        "create_maintenance_success": "Maintenance Entrys Created",
-                        "delete_confirmation": "Are you sure you want to delete the selected items? This action cannot be undone.",
-                        "delete_item": "Delete Item",
-                        "delete_selected": "Delete Selected Items",
-                        "download_csv": "Download Table as CSV",
-                        "download_json": "Download Table as JSON",
-                        "duplicate_item": "Duplicate Item",
-                        "duplicate_selected": "Duplicate Selected Items",
-                        "error_deleting": "Error Deleting Item",
-                        "error_duplicating": "Error Duplicating Item",
-                        "open_menu": "Open menu",
-                        "open_multi_tab_warning": "For security reasons browsers do not allow multiple tabs to be opened at once by default, to change this please follow the documentation:",
-                        "toggle_expand": "Toggle Expand",
-                        "view_item": "View item",
-                        "view_items": "View items"
-                    },
-                    "headers": "Headers",
-                    "page": "Page",
-                    "quick_actions": "Enable Quick Actions & Selection",
-                    "rows_per_page": "Rows per page",
-                    "selected_rows": "{selected} of {total} rows selected.",
-                    "table_settings": "Table Settings",
-                    "view_item": "View Item"
-                }
-            }
-        },
-        "location": {
-            "create_modal": {
-                "location_description": "Location Description",
-                "location_name": "Location Name",
-                "title": "Create Location",
-                "toast": {
-                    "already_creating": "Already creating a location",
-                    "create_failed": "Couldn't create location",
-                    "create_success": "Location created"
-                }
-            },
-            "selector": {
-                "clear": "Clear Location Selection",
-                "no_location_found": "No location found",
-                "parent_location": "Parent Location",
-                "search_location": "Search Locations",
-                "select_location": "Select a Location"
-            },
-            "tree": {
-                "no_locations": "No locations available. Use the Create button to add a new location."
-            }
-        },
-        "quick_menu": {
-            "no_results": "No results found.",
-            "shortcut_hint": "Use the number keys to quickly select an action."
-        },
-        "search": {
-            "filter": {
-                "search_placeholder": "Search…"
-            }
-        },
-        "tag": {
-            "create_modal": {
-                "tag_color": "Tag Color",
-                "tag_description": "Tag Description",
-                "tag_name": "Tag Name",
-                "title": "Create Tag",
-                "toast": {
-                    "already_creating": "Already creating a tag",
-                    "create_failed": "Couldn't create tag",
-                    "create_success": "Tag created",
-                    "tag_name_too_long": "Tag name must not be longer than 50 characters"
-                }
-            },
-            "selector": {
-                "select_tags": "Select Tags"
-            }
-        },
-        "template": {
-            "apply_template": "Apply a template",
-            "card": {
-                "delete": "Delete template",
-                "duplicate": "Duplicate template",
-                "edit": "Edit template"
-            },
-            "confirm_delete": "Delete this template?",
-            "create_modal": {
-                "title": "Create Template"
-            },
-            "detail": {
-                "default_values": "Default Values",
-                "updated": "Updated"
-            },
-            "edit_modal": {
-                "title": "Edit Template"
-            },
-            "empty_value": "(empty)",
-            "form": {
-                "custom_fields": "Custom Fields",
-                "default_item_values": "Default Item Values",
-                "default_location": "Default Location",
-                "default_value": "Default Value",
-                "field_name": "Field Name",
-                "item_description": "Item Description",
-                "item_name": "Item Name",
-                "lifetime_warranty": "Lifetime Warranty",
-                "location": "Location",
-                "manufacturer": "Manufacturer",
-                "model_number": "Model Number",
-                "no_custom_fields": "No custom fields.",
-                "template_description": "Template Description",
-                "template_name": "Template Name"
-            },
-            "hide_defaults": "Hide defaults",
-            "save_as_template": "Save as Template",
-            "selector": {
-                "clear": "Clear Template Selection",
-                "label": "Template (Optional)",
-                "not_found": "No template found",
-                "search": "Search templates…",
-                "select": "Select template…"
-            },
-            "show_defaults": "Show defaults",
-            "toast": {
-                "applied": "Template \"{name}\" applied",
-                "create_failed": "Failed to create template",
-                "created": "Template created",
-                "delete_failed": "Failed to delete template",
-                "deleted": "Template deleted",
-                "duplicate_failed": "Failed to duplicate template",
-                "duplicated": "Template duplicated as \"{name}\"",
-                "load_failed": "Failed to load template details",
-                "saved_as_template": "Item saved as template \"{name}\"",
-                "update_failed": "Failed to update template",
-                "updated": "Template updated"
-            },
-            "using_template": "Using template: {name}"
+    "no_collections": {
+      "create": "Create a new collection",
+      "join": "Join an existing collection",
+      "message": "It looks like you're not part of a collection. Create a new collection for your things, or join one you've been invited to.",
+      "title": "No Collections Found"
+    },
+    "no_invites": "No invites",
+    "remaining_uses": "Remaining uses",
+    "tabs": {
+      "invites": "Invites",
+      "members": "Members",
+      "notifiers": "Notifiers",
+      "settings": "Settings",
+      "tools": "Tools"
+    },
+    "uses": "Uses"
+  },
+  "components": {
+    "app": {
+      "create_modal": {
+        "createAndAddAnother": "Use {shiftKey} + {enterKey} to create and add another.",
+        "enter": "Enter",
+        "shift": "Shift"
+      },
+      "import_dialog": {
+        "change_warning": "Behavior for imports with existing import_refs has changed. If an import_ref is present in the CSV file, the \nitem will be updated with the values in the CSV file.",
+        "description": "Import a CSV file containing your items, labels, and locations. See documentation for more information on the \nrequired format.",
+        "title": "Import CSV File",
+        "toast": {
+          "import_failed": "Import failed. Please try again later.",
+          "import_success": "Import successful!",
+          "please_select_file": "Please select a file to import."
         }
+      },
+      "outdated": {
+        "current_version": "Current Version",
+        "dismiss": "Dismiss",
+        "latest_version": "Latest Version",
+        "new_version_available": "New Version Available",
+        "new_version_available_link": "Click here to view the release notes"
+      }
     },
-    "errors": {
-        "api_failure": "Backend API call failed: "
+    "collection": {
+      "create_modal": {
+        "name_label": "Collection Name",
+        "title": "Create Collection",
+        "toast": {
+          "already_creating": "Already creating a collection",
+          "create_failed": "Failed to create collection",
+          "create_success": "Collection created",
+          "please_enter_name": "Please enter a collection name"
+        }
+      },
+      "invite_create_modal": {
+        "toast": {
+          "invalid_expiry_missing": "Please choose an expiration date and time.",
+          "invalid_expiry_past": "Expiration date must be in the future.",
+          "invalid_uses": "Uses must be a number between 1 and 100."
+        }
+      },
+      "join_modal": {
+        "invite_code_label": "Collection Invite Code",
+        "invites_should_look_like": "Invites should look like:",
+        "join": "Join Collection",
+        "no_invite_code_create_one": "No invite code? Create a new collection instead",
+        "title": "Join Collection",
+        "toast": {
+          "already_joining": "Already joining a collection",
+          "join_failed": "Failed to join collection",
+          "join_success": "Collection joined",
+          "please_enter_valid_join_code": "Please enter a valid collection invite code"
+        }
+      },
+      "selector": {
+        "collection_options": "Collection Options",
+        "create_collection": "Create New Collection",
+        "join_collection": "Join Existing Collection",
+        "no_collection_found": "No collection found",
+        "search_collections": "Search Collections…",
+        "select_collection": "Select Collection",
+        "your_collections": "Your Collections"
+      }
+    },
+    "color_selector": {
+      "clear": "Clear color",
+      "color": "Color",
+      "no_color": "No color",
+      "no_color_selected": "No color selected",
+      "randomize": "Randomize color"
+    },
+    "form": {
+      "password": {
+        "toggle_show": "Toggle Password Show"
+      }
     },
     "global": {
-        "add": "Add",
-        "archived": "Archived",
-        "build": "Build: { build }",
-        "cancel": "Cancel",
-        "confirm": "Confirm",
-        "create": "Create",
-        "create_and_add": "Create and Add Another",
-        "create_subitem": "Create Subitem",
-        "created": "Created",
-        "delete": "Delete",
-        "delete_confirm": "Are you sure you want to delete this item? ",
-        "demo_instance": "This is a demo instance",
-        "details": "Details",
-        "duplicate": "Duplicate",
-        "edit": "Edit",
-        "email": "Email",
-        "follow_dev": "Follow the Developer",
-        "footer": {
-            "api_link": "'<a href=\"https://homebox.software/en/api/\" target=\"_blank\">'API'</a>'",
-            "version_link": "'<'a href=\"https://github.com/sysadminsmedia/homebox/releases/tag/v{ version }\" target=\"_blank\"'>' Version: { version } Build: { build } '</a>'"
-        },
-        "github": "GitHub Project",
-        "insured": "Insured",
-        "items": "Items",
-        "join_discord": "Join the Discord",
-        "loading": "Loading…",
-        "locations": "Locations",
-        "maintenance": "Maintenance",
-        "name": "Name",
-        "navigate": "Navigate",
-        "no": "No",
-        "password": "Password",
-        "preview": "Preview",
-        "quantity": "Quantity",
-        "read_docs": "Read the Docs",
-        "return_home": "Return Home",
-        "save": "Save",
-        "search": "Search",
-        "sign_out": "Sign Out",
-        "submit": "Submit",
-        "tags": "Tags",
-        "unknown": "Unknown",
-        "update": "Update",
-        "updating": "Updating",
-        "value": "Value",
-        "version": "Version: { version }",
-        "welcome": "Welcome, { username }",
-        "yes": "Yes"
-    },
-    "home": {
-        "quick_statistics": "Quick Statistics",
-        "recently_added": "Recently Added",
-        "storage_locations": "Storage Locations",
-        "tags": "Tags",
-        "total_items": "Total Items",
-        "total_locations": "Total Locations",
-        "total_tags": "Total Tags",
-        "total_value": "Total Value"
-    },
-    "index": {
-        "disabled_registration": "Registration Disabled",
-        "dont_join_group": "Don't want to join a group?",
-        "joining_group": "You're Joining an Existing Group!",
-        "login": "Login",
-        "or": "or",
-        "register": "Register",
-        "remember_me": "Remember Me",
-        "set_email": "What's your email?",
-        "set_name": "What's your name?",
-        "set_password": "Set your password",
-        "tagline": "Track, Organize, and Manage your Things.",
-        "title": "Organize and Tag Your Stuff",
+      "copy_text": {
+        "continue": "Continue",
+        "documentation": "documentation",
+        "failed_to_copy": "Failed to copy text to clipboard",
+        "https_required": "because HTTPS is required",
+        "learn_more": "Learn more in our"
+      },
+      "date_time": {
+        "ago": "{0} ago",
+        "days": "days",
+        "hour": "hour",
+        "hours": "hours",
+        "in": "in {0}",
+        "just-now": "just now",
+        "last-month": "last month",
+        "last-week": "last week",
+        "last-year": "last year",
+        "minute": "minute",
+        "minutes": "minutes",
+        "months": "months",
+        "next-month": "next month",
+        "next-week": "next week",
+        "next-year": "next year",
+        "second": "second",
+        "seconds": "seconds",
+        "tomorrow": "tomorrow",
+        "week": "week",
+        "weeks": "weeks",
+        "years": "years",
+        "yesterday": "yesterday"
+      },
+      "label_maker": {
+        "browser_print": "Print from Browser",
+        "confirm_description": "Are you sure you want to print this label?",
+        "download": "Download Label",
+        "print": "Print label",
+        "server_print": "Print on Server",
+        "titles": "Labels",
         "toast": {
-            "invalid_email": "Invalid email address",
-            "invalid_email_password": "Invalid email or password",
-            "login_success": "Logged in successfully",
-            "oidc_access_denied": "Access denied: Your account does not have the required role/group membership",
-            "oidc_auth_failed": "OIDC authentication failed",
-            "oidc_invalid_response": "Invalid OIDC response received",
-            "oidc_provider_error": "OIDC provider returned an error",
-            "oidc_security_error": "OIDC security error - possible CSRF attack",
-            "oidc_session_expired": "OIDC session has expired",
-            "oidc_token_expired": "OIDC token has expired",
-            "oidc_token_invalid": "OIDC token signature is invalid",
-            "problem_registering": "Problem registering user",
-            "user_registered": "User registered"
+          "load_status_failed": "Failed to load status",
+          "print_failed": "Failed to print label",
+          "print_success": "Label printed"
         }
+      },
+      "page_qr_code": {
+        "page_url": "Page URL",
+        "qr_tooltip": "Show QR Code"
+      },
+      "password_score": {
+        "password_strength": "Password Strength"
+      }
     },
-    "items": {
-        "add": "Add",
-        "advanced": "Advanced",
-        "archived": "Archived",
-        "asset_id": "Asset ID",
-        "associated_with_multiple": "This Asset Id is associated with multiple items",
-        "attachment": "Attachment",
-        "attachments": "Attachments",
-        "changes_persisted_immediately": "Changes to attachments will be saved immediately",
-        "created_at": "Created At",
+    "item": {
+      "attachments_list": {
+        "download": "Download",
+        "open_new_tab": "Open in new tab"
+      },
+      "create_modal": {
+        "clear_template": "Clear Template",
+        "delete_photo": "Delete photo",
+        "item_description": "Item Description",
+        "item_name": "Item Name",
+        "item_photo": "Item Photo 📷",
+        "item_quantity": "Item Quantity",
+        "parent_item": "Parent Item",
+        "product_tooltip_input_barcode": "Autofill with a manually provided barcode",
+        "product_tooltip_scan_barcode": "Autofill with a barcode from 📷",
+        "rotate_photo": "Rotate photo",
+        "set_as_primary_photo": "Set as { isPrimary, select, true {non-} false {} other {}}primary photo",
+        "title": "Create Item",
+        "toast": {
+          "already_creating": "Already creating an item",
+          "create_failed": "Couldn't create item",
+          "create_success": "Item created",
+          "failed_load_parent": "Failed to load parent item - please select manually",
+          "no_canvas_support": "Your browser doesn't support canvas operations",
+          "please_select_location": "Please select a location.",
+          "rotate_failed": "Failed to rotate image: { error }",
+          "rotate_process_failed": "Failed to process rotated image",
+          "some_photos_failed": "{count, plural, =0 {No photos to upload.} =1 {1 photo failed to upload.} other {Some photos failed to upload.}}",
+          "upload_failed": "Failed to upload photo: { photoName }",
+          "upload_success": "{count, plural, =0 {No photos uploaded.} =1 {Photo uploaded successfully.} other {All photos uploaded successfully.}}",
+          "uploading_photos": "{count, plural, =0 {No photos to upload} =1 {Uploading 1 photo…} other {Uploading {count} photos…}}"
+        },
+        "upload_photos": "Upload Photos",
+        "uploaded": "Uploaded Photo"
+      },
+      "product_import": {
+        "barcode": "Product's barcode",
+        "db_source": "DB source",
+        "error_exception": "Exception occured while retrieving item barcode: ",
+        "error_invalid_barcode": "Invalid barcode provided",
+        "error_not_found": "No product found with given barcode.",
+        "import_selected": "Import selected",
+        "search_item": "Search product",
+        "title": "Import product"
+      },
+      "selector": {
+        "clear": "Clear Item Selection",
+        "no_results": "No Results Found",
+        "placeholder": "Select…",
+        "search_placeholder": "Type to search…",
+        "searching": "Searching…"
+      },
+      "view": {
+        "change_details": {
+          "add_tags": "Add Tags",
+          "failed_to_update_item": "Failed to update item",
+          "remove_tags": "Remove Tags",
+          "title": "Change Item Details"
+        },
+        "selectable": {
+          "card": "Card",
+          "items": "Items",
+          "no_items": "No Items to Display",
+          "select_all": "Select All",
+          "select_card": "Select Card",
+          "select_row": "Select Row",
+          "table": "Table"
+        },
+        "table": {
+          "dropdown": {
+            "actions": "Actions",
+            "change_location": "Change Location",
+            "change_location_success": "Location Changed",
+            "change_tags": "Change Tags",
+            "change_tags_success": "Tags Changed",
+            "create_maintenance_item": "Create Maintenance Entry for Item",
+            "create_maintenance_selected": "Create Maintenance Entry for Selected Items",
+            "create_maintenance_success": "Maintenance Entrys Created",
+            "delete_confirmation": "Are you sure you want to delete the selected items? This action cannot be undone.",
+            "delete_item": "Delete Item",
+            "delete_selected": "Delete Selected Items",
+            "download_csv": "Download Table as CSV",
+            "download_json": "Download Table as JSON",
+            "duplicate_item": "Duplicate Item",
+            "duplicate_selected": "Duplicate Selected Items",
+            "error_deleting": "Error Deleting Item",
+            "error_duplicating": "Error Duplicating Item",
+            "open_menu": "Open menu",
+            "open_multi_tab_warning": "For security reasons browsers do not allow multiple tabs to be opened at once by default, to change this please follow the documentation:",
+            "toggle_expand": "Toggle Expand",
+            "view_item": "View item",
+            "view_items": "View items"
+          },
+          "headers": "Headers",
+          "page": "Page",
+          "quick_actions": "Enable Quick Actions & Selection",
+          "rows_per_page": "Rows per page",
+          "selected_rows": "{selected} of {total} rows selected.",
+          "table_settings": "Table Settings",
+          "view_item": "View Item"
+        }
+      }
+    },
+    "location": {
+      "create_modal": {
+        "location_description": "Location Description",
+        "location_name": "Location Name",
+        "title": "Create Location",
+        "toast": {
+          "already_creating": "Already creating a location",
+          "create_failed": "Couldn't create location",
+          "create_success": "Location created"
+        }
+      },
+      "selector": {
+        "clear": "Clear Location Selection",
+        "no_location_found": "No location found",
+        "parent_location": "Parent Location",
+        "search_location": "Search Locations",
+        "select_location": "Select a Location"
+      },
+      "tree": {
+        "no_locations": "No locations available. Use the Create button to add a new location."
+      }
+    },
+    "quick_menu": {
+      "no_results": "No results found.",
+      "shortcut_hint": "Use the number keys to quickly select an action."
+    },
+    "search": {
+      "filter": {
+        "search_placeholder": "Search…"
+      }
+    },
+    "tag": {
+      "create_modal": {
+        "tag_color": "Tag Color",
+        "tag_description": "Tag Description",
+        "tag_name": "Tag Name",
+        "title": "Create Tag",
+        "toast": {
+          "already_creating": "Already creating a tag",
+          "create_failed": "Couldn't create tag",
+          "create_success": "Tag created",
+          "tag_name_too_long": "Tag name must not be longer than 50 characters"
+        }
+      },
+      "selector": {
+        "select_tags": "Select Tags"
+      }
+    },
+    "template": {
+      "apply_template": "Apply a template",
+      "card": {
+        "delete": "Delete template",
+        "duplicate": "Duplicate template",
+        "edit": "Edit template"
+      },
+      "confirm_delete": "Delete this template?",
+      "create_modal": {
+        "title": "Create Template"
+      },
+      "detail": {
+        "default_values": "Default Values",
+        "updated": "Updated"
+      },
+      "edit_modal": {
+        "title": "Edit Template"
+      },
+      "empty_value": "(empty)",
+      "form": {
         "custom_fields": "Custom Fields",
-        "delete_attachment_confirm": "Are you sure you want to delete this attachment?",
-        "delete_item_confirm": "Are you sure you want to delete this item?",
-        "description": "Description",
-        "details": "Details",
-        "drag_and_drop": "Drag and drop files here or click to select files",
-        "duplicate": {
-            "copy_attachments": "Copy Attachments",
-            "copy_custom_fields": "Copy Custom Fields",
-            "copy_maintenance": "Copy Maintenance",
-            "custom_prefix": "Copy Prefix",
-            "enable_custom_prefix": "Enable Custom Prefix",
-            "override_instructions": "Hold shift when clicking the duplicate button to override these settings.",
-            "prefix": "Copy of ",
-            "prefix_instructions": "This prefix will be added to the beginning of the duplicated item's name. Include a space at the end of the prefix to add a space between the prefix and the item name.",
-            "temporary_title": "Temporary Settings",
-            "title": "Duplicate Settings"
-        },
-        "edit": {
-            "edit_attachment_dialog": {
-                "attachment_title": "Attachment Title",
-                "attachment_type": "Attachment Type",
-                "primary_photo": "Primary Photo",
-                "primary_photo_sub": "This option is only available for photos. Only one photo can be primary. If you select this option, the current primary photo, if any will be unselected.",
-                "select_type": "Select a type",
-                "title": "Attachment Edit"
-            },
-            "view_image": "View Image"
-        },
-        "edit_details": "Edit Details",
-        "field": "Field",
-        "field_selector": "Field Selector",
-        "field_value": "Field Value",
-        "first": "First",
-        "include_archive": "Include Archived Items",
-        "insured": "Insured",
-        "invalid_asset_id": "Invalid Asset ID",
-        "last": "Last",
+        "default_item_values": "Default Item Values",
+        "default_location": "Default Location",
+        "default_value": "Default Value",
+        "field_name": "Field Name",
+        "item_description": "Item Description",
+        "item_name": "Item Name",
         "lifetime_warranty": "Lifetime Warranty",
         "location": "Location",
-        "manual": "Manual",
-        "manuals": "Manuals",
         "manufacturer": "Manufacturer",
         "model_number": "Model Number",
-        "name": "Name",
-        "negate_tags": "Negate Selected Tags",
-        "next_page": "Next Page",
-        "no_attachments": "No attachments found",
-        "no_results": "No Items Found",
-        "notes": "Notes",
-        "only_with_photo": "Only items with photo",
-        "only_without_photo": "Only items without photo",
-        "options": "Options",
-        "order_by": "Order By",
-        "pages": "Page { page } of { totalPages }",
-        "parent_item": "Parent Item",
-        "photo": "Photo",
-        "photos": "Photos",
-        "prev_page": "Previous Page",
-        "purchase_date": "Purchase Date",
-        "purchase_details": "Purchase Details",
-        "purchase_price": "Purchase Price",
-        "purchased_from": "Purchased From",
-        "quantity": "Quantity",
-        "query_id": "Querying Asset ID Number: { id }",
-        "receipt": "Receipt",
-        "receipts": "Receipts",
-        "reset_search": "Reset Search",
-        "results": "{ total } Results",
-        "select_field": "Select a field",
-        "select_value": "Select a value",
-        "serial_number": "Serial Number",
-        "show_advanced_view_options": "Show Advanced View Options",
-        "show_empty": "Show Empty",
-        "sold_at": "Sold At",
-        "sold_details": "Sold Details",
-        "sold_price": "Sold Price",
-        "sold_to": "Sold To",
-        "sync_child_locations": "Sync child items' locations",
-        "tip_1": "Location and tag filters use the 'OR' operation. If more than one is selected only one will be\n required for a match.",
-        "tip_2": "Searches prefixed with '#'' will query for a asset ID (example '#000-001')",
-        "tip_3": "Field filters use the 'OR' operation. If more than one is selected only one will be required for a\n match.",
-        "tips": "Tips",
-        "tips_sub": "Search Tips",
-        "toast": {
-            "asset_not_found": "Asset not found",
-            "attachment_deleted": "Attachment deleted",
-            "attachment_updated": "Attachment updated",
-            "attachment_uploaded": "Attachment uploaded",
-            "child_items_location_no_longer_synced": "Child items' locations will no longer be synced with this item.",
-            "child_items_location_synced": "Child items' locations have been synced with this item",
-            "child_location_desync": "Changing location will de-sync it from the parent's location",
-            "error_loading_parent_data": "Something went wrong trying to load parent data",
-            "failed_adjust_quantity": "Failed to adjust quantity",
-            "failed_delete_attachment": "Failed to delete attachment",
-            "failed_delete_item": "Failed to delete item",
-            "failed_duplicate_item": "Failed to duplicate item",
-            "failed_load_asset": "Failed to load asset",
-            "failed_load_item": "Failed to load item",
-            "failed_load_items": "Failed to load items",
-            "failed_save": "Failed to save item",
-            "failed_save_no_location": "Failed to save item: no location selected",
-            "failed_search_items": "Failed to search items",
-            "failed_update_attachment": "Failed to update attachment",
-            "failed_upload_attachment": "Failed to upload attachment",
-            "item_deleted": "Item deleted",
-            "item_saved": "Item saved",
-            "quantity_cannot_negative": "Quantity cannot be negative",
-            "sync_child_location": "Selected parent syncs its children's locations to its own. The location has been updated."
-        },
-        "updated_at": "Updated At",
-        "warranty": "Warranty",
-        "warranty_details": "Warranty Details",
-        "warranty_expires": "Warranty Expires"
+        "no_custom_fields": "No custom fields.",
+        "template_description": "Template Description",
+        "template_name": "Template Name"
+      },
+      "hide_defaults": "Hide defaults",
+      "save_as_template": "Save as Template",
+      "selector": {
+        "clear": "Clear Template Selection",
+        "label": "Template (Optional)",
+        "not_found": "No template found",
+        "search": "Search templates…",
+        "select": "Select template…"
+      },
+      "show_defaults": "Show defaults",
+      "toast": {
+        "applied": "Template \"{name}\" applied",
+        "create_failed": "Failed to create template",
+        "created": "Template created",
+        "delete_failed": "Failed to delete template",
+        "deleted": "Template deleted",
+        "duplicate_failed": "Failed to duplicate template",
+        "duplicated": "Template duplicated as \"{name}\"",
+        "load_failed": "Failed to load template details",
+        "saved_as_template": "Item saved as template \"{name}\"",
+        "update_failed": "Failed to update template",
+        "updated": "Template updated"
+      },
+      "using_template": "Using template: {name}"
     },
-    "languages": {
-        "bs-BA": "Bosnian (Bosnia and Herzegovina)",
-        "ca": "Catalan",
-        "cs-CZ": "Czech",
-        "da-DK": "Danish",
-        "de": "German",
-        "en": "English",
-        "es": "Spanish",
-        "fi-FI": "Finnish",
-        "fr": "French",
-        "hu": "Hungarian",
-        "id-ID": "Indonesian",
-        "it": "Italian",
-        "ja-JP": "Japanese",
-        "ko-KR": "Korean",
-        "lb-LU": "Luxembourgish (Luxembourg)",
-        "lt-LT": "Lithuanian (Lithuania)",
-        "nb-NO": "Norwegian Bokmål",
-        "nl": "Dutch",
-        "pl": "Polish",
-        "pt-BR": "Portuguese (Brazil)",
-        "pt-PT": "Portuguese (Portugal)",
-        "ro-RO": "Romanian",
-        "ru": "Russian",
-        "sk-SK": "Slovak",
-        "sl": "Slovenian",
-        "sq-AL": "Albanian",
-        "sv": "Swedish",
-        "ta-IN": "Tamil",
-        "th-TH": "Thai",
-        "tr": "Turkish",
-        "uk-UA": "Ukrainian",
-        "vi-VN": "Vietnamese",
-        "zh-CN": "Chinese (Simplified)",
-        "zh-HK": "Chinese (Hong Kong)",
-        "zh-MO": "Chinese (Macau)",
-        "zh-TW": "Chinese (Traditional)"
-    },
-    "languages.sr-RS": "Serbian (Serbia)",
-    "locations": {
-        "child_locations": "Child Locations",
-        "collapse_tree": "Collapse Tree",
-        "expand_tree": "Expand Tree",
-        "hide_items": "Hide Items",
-        "location_items_delete_confirm": "Are you sure you want to delete this location and all of its items? This action cannot be undone.",
-        "no_results": "No Locations Found",
-        "show_items": "Show Items",
-        "toast": {
-            "failed_delete_location": "Failed to delete location",
-            "failed_load_location": "Failed to load location",
-            "failed_update_location": "Failed to update location",
-            "location_deleted": "Location deleted",
-            "location_updated": "Location updated"
-        },
-        "update_location": "Update Location"
-    },
-    "maintenance": {
-        "filter": {
-            "both": "Both",
-            "completed": "Completed",
-            "scheduled": "Scheduled"
-        },
-        "list": {
-            "complete": "Complete",
-            "create_first": "Create Your First Entry",
-            "delete": "Delete",
-            "duplicate": "Duplicate",
-            "edit": "Edit",
-            "new": "New"
-        },
-        "modal": {
-            "completed_date": "Completed Date",
-            "cost": "Cost",
-            "delete_confirmation": "Are you sure you want to delete this entry?",
-            "edit_action": "Update",
-            "edit_title": "Edit Entry",
-            "entry_name": "Entry Name",
-            "new_action": "Create",
-            "new_title": "New Entry",
-            "notes": "Notes",
-            "scheduled_date": "Scheduled Date"
-        },
-        "monthly_average": "Monthly Average",
-        "toast": {
-            "failed_to_create": "Failed to create entry",
-            "failed_to_delete": "Failed to delete entry",
-            "failed_to_update": "Failed to update entry"
-        },
-        "total_cost": "Total Cost",
-        "total_entries": "Total Entries"
-    },
-    "menu": {
-        "collection": "Collection",
-        "create_item": "Item / Asset",
-        "create_location": "Location",
-        "create_tag": "Tag",
-        "home": "Home",
-        "locations": "Locations",
-        "maintenance": "Maintenance",
-        "profile": "Profile",
-        "scanner": "Scanner",
-        "search": "Search",
-        "templates": "Templates"
-    },
-    "pages": {
-        "templates": {
-            "no_templates": "No templates yet.",
-            "title": "Templates"
-        }
-    },
-    "profile": {
-        "active": "Active",
-        "change_password": "Change Password",
-        "currency_format": "Currency Format",
-        "current_password": "Current Password",
-        "delete_account": "Delete Account",
-        "delete_account_confirm": "Are you sure you want to delete your account? If you are the last member in your group all your data will be deleted. This action cannot be undone.",
-        "delete_account_sub": "Delete your account and all its associated data. This can not be undone.",
-        "delete_notifier_confirm": "Are you sure you want to delete this notifier?",
-        "display_legacy_header": "{ currentValue, select, true {Disable Legacy Header} false {Enable Legacy Header} other {Not Hit}}",
-        "enabled": "Enabled",
-        "example": "Example",
-        "group_settings": "Group Settings",
-        "group_settings_sub": "Shared Group Settings. You may need to refresh your browser for some settings to apply.",
-        "inactive": "Inactive",
-        "language": "Language",
-        "legacy_image_fit": "{ currentValue, select, true {Disable Legacy Fit: Fit Image with Bars} false {Enable Legacy Fit: Fill Image with Crop} other {Not Hit}}",
-        "moved_notice_body": "Notifiers, invites, and currency settings have been moved to the collection pages.",
-        "moved_notice_description": "These settings are now managed per collection.",
-        "moved_notice_link_invites": "Collection invites",
-        "moved_notice_link_notifiers": "Collection notifiers",
-        "moved_notice_link_settings": "Collection currency settings",
-        "moved_notice_title": "Looking for notifiers, invites, or currency settings?",
-        "new_password": "New Password",
-        "no_notifiers": "No notifiers configured",
-        "no_override": "No override",
-        "notifier_modal": "{ type, select, true {Edit} false {Create} other {Other}} Notifier",
-        "notifiers": "Notifiers",
-        "notifiers_sub": "Get notifications for upcoming maintenance reminders",
-        "override_locale": "Override Date and Currency Language",
-        "test": "Test",
-        "theme_settings": "Theme Settings",
-        "theme_settings_sub": "Theme settings are stored in your browser's local storage. You can change the theme at any time. If you're\n having trouble setting your theme try refreshing your browser.",
-        "toast": {
-            "account_deleted": "Your account has been deleted.",
-            "failed_change_password": "Failed to change password.",
-            "failed_create_notifier": "Failed to create notifier.",
-            "failed_delete_account": "Failed to delete your account.",
-            "failed_delete_notifier": "Failed to delete notifier.",
-            "failed_get_currencies": "Failed to get currencies",
-            "failed_test_notifier": "Failed to test notifier.",
-            "failed_update_group": "Failed to update group",
-            "failed_update_notifier": "Failed to update notifier.",
-            "group_updated": "Group updated",
-            "notifier_test_success": "Notifier test successful.",
-            "password_changed": "Password changed successfully."
-        },
-        "update_group": "Update Group",
-        "update_language": "Update Language",
-        "url": "URL",
-        "user_profile": "User Profile",
-        "user_profile_sub": "Invite users, and manage your account."
-    },
-    "reports": {
-        "label_generator": {
-            "asset_end": "Asset End",
-            "asset_start": "Asset Start",
-            "base_url": "Base URL",
-            "bordered_labels": "Bordered Labels",
-            "generate_page": "Generate Page",
-            "input_placeholder": "Type here",
-            "instruction_1": "The HomeBox Label Generator is a tool to help you print labels for your HomeBox inventory. These are intended to\n be print-ahead labels so you can print many labels and have them ready to apply",
-            "instruction_2": "As such, these labels work by printing a URL QR Code and AssetID information on a label. If you've disabled\n AssetID's in your HomeBox settings, you can still use this tool, but the AssetID's won't reference any item",
-            "instruction_3": "This feature is in early development stages and may change in future releases, if you have feedback please\n provide it in the '<a href=\"https://github.com/sysadminsmedia/homebox/discussions/53\">'GitHub Discussion'</a>'",
-            "label_height": "Label Height",
-            "label_width": "Label Width",
-            "measure_type": "Measure Type",
-            "page_bottom_padding": "Page Bottom Padding",
-            "page_height": "Page Height",
-            "page_left_padding": "Page Left Padding",
-            "page_right_padding": "Page Right Padding",
-            "page_top_padding": "Page Top Padding",
-            "page_width": "Page Width",
-            "print_location_row": "Print Location Row",
-            "qr_code_example": "QR Code Example",
-            "replace_homebox_behavior": "Replace \"HomeBox\" text behavior",
-            "replace_homebox_behavior_always_replace": "Always Replace \"HomeBox\"",
-            "replace_homebox_behavior_item_no_location": "Replace \"HomeBox\" when item has no location",
-            "replace_homebox_behavior_item_no_name": "Replace \"HomeBox\" when item has no name",
-            "replace_homebox_behavior_item_no_name_no_location": "Replace \"HomeBox\" when item has no name and no location",
-            "replace_homebox_behavior_show_homebox": "Show \"HomeBox\"",
-            "replace_homebox_text": "Replacement text",
-            "skip_first_labels": "Skip First Labels",
-            "tip_1": "The defaults here are setup for the\n '<a href=\"https://www.avery.com/templates/5260\">'Avery 5260 label sheets'</a>'. If you're using a different sheet,\n you'll need to adjust the settings to match your sheet.",
-            "tip_2": "If you're customizing your sheet the dimensions are in inches. When building the 5260 sheet, I found that the\n dimensions used in their template, did not match what was needed to print within the boxes.\n '<b>'Be prepared for some trial and error.'</b>'",
-            "tip_3": "When printing be sure to:\n '<ol><li>'Set the margins to 0 or None'</li><li>'Set the scaling to 100%'</li><li>'Disable double-sided printing'</li><li>'Print a test page before printing multiple pages'</li></ol>'",
-            "tips": "Tips",
-            "title": "Label Generator",
-            "toast": {
-                "page_too_small_card": "Page size is too small for the card size"
-            }
-        }
-    },
-    "scanner": {
-        "barcode_detected_message": "product barcode detected",
-        "barcode_fetch_data": "Fetch product data",
-        "error": "An error occurred while scanning",
-        "invalid_url": "Invalid barcode URL",
-        "no_sources": "No video sources available",
-        "permission_denied": "Camera permission denied, please allow access to the camera in your browser settings",
-        "select_video_source": "Pick a video source",
-        "title": "Scanner",
-        "unsupported": "Media Stream API is not supported without HTTPS"
-    },
-    "tags": {
-        "no_results": "No Tags Found",
-        "tag_delete_confirm": "Are you sure you want to delete this tag? This action cannot be undone.",
-        "toast": {
-            "failed_delete_tag": "Failed to delete tag",
-            "failed_load_tag": "Failed to load tag",
-            "failed_update_tag": "Failed to update tag",
-            "tag_deleted": "Tag deleted",
-            "tag_updated": "Tag updated"
-        },
-        "update_tag": "Update Tag"
-    },
-    "tools": {
-        "actions": "Inventory Actions",
-        "actions_set": {
-            "create_missing_thumbnails": "Create Missing Thumbnails",
-            "create_missing_thumbnails_button": "Create Thumbnails",
-            "create_missing_thumbnails_confirm": "Are you sure you want to create missing thumbnails? This can take a while and cannot be paused.",
-            "create_missing_thumbnails_sub": "Creates thumbnails for all attachments that are supported by the current configuration. This is useful for attachments that were uploaded prior to the v0.20.0 release of Homebox. This will not overwrite existing thumbnails, only create new ones for attachments that do not have a thumbnail. Please note that the thumbnails are created in the background and may take a while to complete.",
-            "ensure_ids": "Ensure Asset IDs",
-            "ensure_ids_button": "Ensure Asset IDs",
-            "ensure_ids_confirm": "Are you sure you want to ensure all assets have an ID? This can take a while and cannot be undone.",
-            "ensure_ids_sub": "Ensures that all items in your inventory have a valid asset_id field. This is done by finding the highest current asset_id field in the database and applying the next value to each item that has an unset asset_id field. This is done in order of the created_at field.",
-            "ensure_import_refs": "Ensure Import Refs",
-            "ensure_import_refs_button": "Ensure Import Refs",
-            "ensure_import_refs_sub": "Ensures that all items in your inventory have a valid import_ref field. This is done by randomly generating a 8 character string for each item that has an unset import_ref field.",
-            "set_primary_photo": "Set Primary Photo",
-            "set_primary_photo_button": "Set Primary Photo",
-            "set_primary_photo_confirm": "Are you sure you want to set primary photos? This can take a while and cannot be undone.",
-            "set_primary_photo_sub": "In version v0.10.0 of Homebox, the primary image field was added to attachments of type photo. This action will set the primary image field to the first image in the attachments array in the database, if it is not already set. '<a class=\"link\" href=\"https://github.com/hay-kot/homebox/pull/576\">'See GitHub PR #576'</a>'",
-            "wipe_inventory": "Wipe Inventory",
-            "wipe_inventory_button": "Wipe Inventory",
-            "wipe_inventory_confirm": "Are you sure you want to wipe your entire inventory? This will delete all items and cannot be undone.",
-            "wipe_inventory_locations": "Also wipe all locations",
-            "wipe_inventory_maintenance": "Also wipe all maintenance records",
-            "wipe_inventory_note": "Note: Only group owners can perform this action.",
-            "wipe_inventory_sub": "Permanently deletes all items in your inventory. This action is irreversible and will remove all item data including attachments and photos.",
-            "wipe_inventory_tags": "Also wipe all tags",
-            "zero_datetimes": "Zero Item Date Times",
-            "zero_datetimes_button": "Zero Item Date Times",
-            "zero_datetimes_confirm": "Are you sure you want to reset all date and time values? This can take a while and cannot be undone.",
-            "zero_datetimes_sub": "Resets the time value for all date time fields in your inventory to the beginning of the date. This is to fix a bug that was introduced early on in the development of the site that caused the time value to be stored with the time which caused issues with date fields displaying accurate values. '<a class=\"link\" href=\"https://github.com/hay-kot/homebox/issues/236\" target=\"_blank\">'See Github Issue #236 for more details.'</a>'"
-        },
-        "actions_sub": "Apply Actions to your inventory in bulk. These are irreversible actions. '<b>'Be careful.'</b>'",
-        "demo_mode_error": {
-            "wipe_inventory": "Inventory, tags, locations and maintenance records cannot be wiped whilst Homebox is in demo mode. Please ensure that you are not in demo mode and try again."
-        },
-        "import_export": "Import/Export",
-        "import_export_set": {
-            "export": "Export Inventory",
-            "export_button": "Export Inventory",
-            "export_sub": "Exports the standard CSV format for Homebox. This will export all items in your inventory.",
-            "import": "Import Inventory",
-            "import_button": "Import Inventory",
-            "import_ref_confirm": "Are you sure you want to ensure all assets have an import_ref? This can take a while and cannot be undone.",
-            "import_sub": "Imports the standard CSV format for Homebox. Without an '<code>'HB.import_ref'</code>' column, this will '<b>'not'</b>' overwrite any existing items in your inventory, only add new items. Rows with an '<code>'HB.import_ref'</code>' column are merged into existing items with the same import_ref, if one exists."
-        },
-        "import_export_sub": "Import and export your inventory to and from a CSV file. This is useful for migrating your inventory to a new instance of Homebox.",
-        "reports": "Reports",
-        "reports_set": {
-            "asset_labels": "Asset ID Labels",
-            "asset_labels_button": "Label Generator",
-            "asset_labels_sub": "Generates a printable PDF of labels for a range of Asset ID. These are not specific to your inventory so you are able to print labels ahead of time and apply them to your inventory when you receive them.",
-            "bill_of_materials": "Bill of Materials",
-            "bill_of_materials_button": "Generate BOM",
-            "bill_of_materials_sub": "Generates a CSV (Comma Separated Values) file that can be imported into a spreadsheet program. This is a summary of your inventory with basic item and pricing information."
-        },
-        "reports_sub": "Generate different reports for your inventory.",
-        "toast": {
-            "asset_success": "{ results } assets have been updated.",
-            "failed_create_missing_thumbnails": "Failed to create missing thumbnails.",
-            "failed_ensure_ids": "Failed to ensure asset IDs.",
-            "failed_ensure_import_refs": "Failed to ensure import refs.",
-            "failed_set_primary_photos": "Failed to set primary photos.",
-            "failed_wipe_inventory": "Failed to wipe inventory.",
-            "failed_zero_datetimes": "Failed to reset date and time values.",
-            "wipe_inventory_success": "Successfully wiped inventory. { results } items deleted."
-        }
+    "niimbot": {
+      "connect": "Connect",
+      "label": "Label",
+      "label_full": "Full (QR + name)",
+      "label_qr": "QR code only",
+      "tape": "Tape",
+      "custom": "Custom...",
+      "print": "Print to Niimbot",
+      "printing": "Printing {progress}%",
+      "print_success": "Label sent to printer",
+      "print_failed": "Print failed: {error}",
+      "connection_failed": "Connection failed: {error}"
     }
+  },
+  "errors": {
+    "api_failure": "Backend API call failed: "
+  },
+  "global": {
+    "add": "Add",
+    "archived": "Archived",
+    "build": "Build: { build }",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "create": "Create",
+    "create_and_add": "Create and Add Another",
+    "create_subitem": "Create Subitem",
+    "created": "Created",
+    "delete": "Delete",
+    "delete_confirm": "Are you sure you want to delete this item? ",
+    "demo_instance": "This is a demo instance",
+    "details": "Details",
+    "duplicate": "Duplicate",
+    "edit": "Edit",
+    "email": "Email",
+    "follow_dev": "Follow the Developer",
+    "footer": {
+      "api_link": "'<a href=\"https://homebox.software/en/api/\" target=\"_blank\">'API'</a>'",
+      "version_link": "'<'a href=\"https://github.com/sysadminsmedia/homebox/releases/tag/v{ version }\" target=\"_blank\"'>' Version: { version } Build: { build } '</a>'"
+    },
+    "github": "GitHub Project",
+    "insured": "Insured",
+    "items": "Items",
+    "join_discord": "Join the Discord",
+    "loading": "Loading…",
+    "locations": "Locations",
+    "maintenance": "Maintenance",
+    "name": "Name",
+    "navigate": "Navigate",
+    "no": "No",
+    "password": "Password",
+    "preview": "Preview",
+    "quantity": "Quantity",
+    "read_docs": "Read the Docs",
+    "return_home": "Return Home",
+    "save": "Save",
+    "search": "Search",
+    "sign_out": "Sign Out",
+    "submit": "Submit",
+    "tags": "Tags",
+    "unknown": "Unknown",
+    "update": "Update",
+    "updating": "Updating",
+    "value": "Value",
+    "version": "Version: { version }",
+    "welcome": "Welcome, { username }",
+    "yes": "Yes"
+  },
+  "home": {
+    "quick_statistics": "Quick Statistics",
+    "recently_added": "Recently Added",
+    "storage_locations": "Storage Locations",
+    "tags": "Tags",
+    "total_items": "Total Items",
+    "total_locations": "Total Locations",
+    "total_tags": "Total Tags",
+    "total_value": "Total Value"
+  },
+  "index": {
+    "disabled_registration": "Registration Disabled",
+    "dont_join_group": "Don't want to join a group?",
+    "joining_group": "You're Joining an Existing Group!",
+    "login": "Login",
+    "or": "or",
+    "register": "Register",
+    "remember_me": "Remember Me",
+    "set_email": "What's your email?",
+    "set_name": "What's your name?",
+    "set_password": "Set your password",
+    "tagline": "Track, Organize, and Manage your Things.",
+    "title": "Organize and Tag Your Stuff",
+    "toast": {
+      "invalid_email": "Invalid email address",
+      "invalid_email_password": "Invalid email or password",
+      "login_success": "Logged in successfully",
+      "oidc_access_denied": "Access denied: Your account does not have the required role/group membership",
+      "oidc_auth_failed": "OIDC authentication failed",
+      "oidc_invalid_response": "Invalid OIDC response received",
+      "oidc_provider_error": "OIDC provider returned an error",
+      "oidc_security_error": "OIDC security error - possible CSRF attack",
+      "oidc_session_expired": "OIDC session has expired",
+      "oidc_token_expired": "OIDC token has expired",
+      "oidc_token_invalid": "OIDC token signature is invalid",
+      "problem_registering": "Problem registering user",
+      "user_registered": "User registered"
+    }
+  },
+  "items": {
+    "add": "Add",
+    "advanced": "Advanced",
+    "archived": "Archived",
+    "asset_id": "Asset ID",
+    "associated_with_multiple": "This Asset Id is associated with multiple items",
+    "attachment": "Attachment",
+    "attachments": "Attachments",
+    "changes_persisted_immediately": "Changes to attachments will be saved immediately",
+    "created_at": "Created At",
+    "custom_fields": "Custom Fields",
+    "delete_attachment_confirm": "Are you sure you want to delete this attachment?",
+    "delete_item_confirm": "Are you sure you want to delete this item?",
+    "description": "Description",
+    "details": "Details",
+    "drag_and_drop": "Drag and drop files here or click to select files",
+    "duplicate": {
+      "copy_attachments": "Copy Attachments",
+      "copy_custom_fields": "Copy Custom Fields",
+      "copy_maintenance": "Copy Maintenance",
+      "custom_prefix": "Copy Prefix",
+      "enable_custom_prefix": "Enable Custom Prefix",
+      "override_instructions": "Hold shift when clicking the duplicate button to override these settings.",
+      "prefix": "Copy of ",
+      "prefix_instructions": "This prefix will be added to the beginning of the duplicated item's name. Include a space at the end of the prefix to add a space between the prefix and the item name.",
+      "temporary_title": "Temporary Settings",
+      "title": "Duplicate Settings"
+    },
+    "edit": {
+      "edit_attachment_dialog": {
+        "attachment_title": "Attachment Title",
+        "attachment_type": "Attachment Type",
+        "primary_photo": "Primary Photo",
+        "primary_photo_sub": "This option is only available for photos. Only one photo can be primary. If you select this option, the current primary photo, if any will be unselected.",
+        "select_type": "Select a type",
+        "title": "Attachment Edit"
+      },
+      "view_image": "View Image"
+    },
+    "edit_details": "Edit Details",
+    "field": "Field",
+    "field_selector": "Field Selector",
+    "field_value": "Field Value",
+    "first": "First",
+    "include_archive": "Include Archived Items",
+    "insured": "Insured",
+    "invalid_asset_id": "Invalid Asset ID",
+    "last": "Last",
+    "lifetime_warranty": "Lifetime Warranty",
+    "location": "Location",
+    "manual": "Manual",
+    "manuals": "Manuals",
+    "manufacturer": "Manufacturer",
+    "model_number": "Model Number",
+    "name": "Name",
+    "negate_tags": "Negate Selected Tags",
+    "next_page": "Next Page",
+    "no_attachments": "No attachments found",
+    "no_results": "No Items Found",
+    "notes": "Notes",
+    "only_with_photo": "Only items with photo",
+    "only_without_photo": "Only items without photo",
+    "options": "Options",
+    "order_by": "Order By",
+    "pages": "Page { page } of { totalPages }",
+    "parent_item": "Parent Item",
+    "photo": "Photo",
+    "photos": "Photos",
+    "prev_page": "Previous Page",
+    "purchase_date": "Purchase Date",
+    "purchase_details": "Purchase Details",
+    "purchase_price": "Purchase Price",
+    "purchased_from": "Purchased From",
+    "quantity": "Quantity",
+    "query_id": "Querying Asset ID Number: { id }",
+    "receipt": "Receipt",
+    "receipts": "Receipts",
+    "reset_search": "Reset Search",
+    "results": "{ total } Results",
+    "select_field": "Select a field",
+    "select_value": "Select a value",
+    "serial_number": "Serial Number",
+    "show_advanced_view_options": "Show Advanced View Options",
+    "show_empty": "Show Empty",
+    "sold_at": "Sold At",
+    "sold_details": "Sold Details",
+    "sold_price": "Sold Price",
+    "sold_to": "Sold To",
+    "sync_child_locations": "Sync child items' locations",
+    "tip_1": "Location and tag filters use the 'OR' operation. If more than one is selected only one will be\n required for a match.",
+    "tip_2": "Searches prefixed with '#'' will query for a asset ID (example '#000-001')",
+    "tip_3": "Field filters use the 'OR' operation. If more than one is selected only one will be required for a\n match.",
+    "tips": "Tips",
+    "tips_sub": "Search Tips",
+    "toast": {
+      "asset_not_found": "Asset not found",
+      "attachment_deleted": "Attachment deleted",
+      "attachment_updated": "Attachment updated",
+      "attachment_uploaded": "Attachment uploaded",
+      "child_items_location_no_longer_synced": "Child items' locations will no longer be synced with this item.",
+      "child_items_location_synced": "Child items' locations have been synced with this item",
+      "child_location_desync": "Changing location will de-sync it from the parent's location",
+      "error_loading_parent_data": "Something went wrong trying to load parent data",
+      "failed_adjust_quantity": "Failed to adjust quantity",
+      "failed_delete_attachment": "Failed to delete attachment",
+      "failed_delete_item": "Failed to delete item",
+      "failed_duplicate_item": "Failed to duplicate item",
+      "failed_load_asset": "Failed to load asset",
+      "failed_load_item": "Failed to load item",
+      "failed_load_items": "Failed to load items",
+      "failed_save": "Failed to save item",
+      "failed_save_no_location": "Failed to save item: no location selected",
+      "failed_search_items": "Failed to search items",
+      "failed_update_attachment": "Failed to update attachment",
+      "failed_upload_attachment": "Failed to upload attachment",
+      "item_deleted": "Item deleted",
+      "item_saved": "Item saved",
+      "quantity_cannot_negative": "Quantity cannot be negative",
+      "sync_child_location": "Selected parent syncs its children's locations to its own. The location has been updated."
+    },
+    "updated_at": "Updated At",
+    "warranty": "Warranty",
+    "warranty_details": "Warranty Details",
+    "warranty_expires": "Warranty Expires"
+  },
+  "languages": {
+    "bs-BA": "Bosnian (Bosnia and Herzegovina)",
+    "ca": "Catalan",
+    "cs-CZ": "Czech",
+    "da-DK": "Danish",
+    "de": "German",
+    "en": "English",
+    "es": "Spanish",
+    "fi-FI": "Finnish",
+    "fr": "French",
+    "hu": "Hungarian",
+    "id-ID": "Indonesian",
+    "it": "Italian",
+    "ja-JP": "Japanese",
+    "ko-KR": "Korean",
+    "lb-LU": "Luxembourgish (Luxembourg)",
+    "lt-LT": "Lithuanian (Lithuania)",
+    "nb-NO": "Norwegian Bokmål",
+    "nl": "Dutch",
+    "pl": "Polish",
+    "pt-BR": "Portuguese (Brazil)",
+    "pt-PT": "Portuguese (Portugal)",
+    "ro-RO": "Romanian",
+    "ru": "Russian",
+    "sk-SK": "Slovak",
+    "sl": "Slovenian",
+    "sq-AL": "Albanian",
+    "sv": "Swedish",
+    "ta-IN": "Tamil",
+    "th-TH": "Thai",
+    "tr": "Turkish",
+    "uk-UA": "Ukrainian",
+    "vi-VN": "Vietnamese",
+    "zh-CN": "Chinese (Simplified)",
+    "zh-HK": "Chinese (Hong Kong)",
+    "zh-MO": "Chinese (Macau)",
+    "zh-TW": "Chinese (Traditional)"
+  },
+  "languages.sr-RS": "Serbian (Serbia)",
+  "locations": {
+    "child_locations": "Child Locations",
+    "collapse_tree": "Collapse Tree",
+    "expand_tree": "Expand Tree",
+    "hide_items": "Hide Items",
+    "location_items_delete_confirm": "Are you sure you want to delete this location and all of its items? This action cannot be undone.",
+    "no_results": "No Locations Found",
+    "show_items": "Show Items",
+    "toast": {
+      "failed_delete_location": "Failed to delete location",
+      "failed_load_location": "Failed to load location",
+      "failed_update_location": "Failed to update location",
+      "location_deleted": "Location deleted",
+      "location_updated": "Location updated"
+    },
+    "update_location": "Update Location"
+  },
+  "maintenance": {
+    "filter": {
+      "both": "Both",
+      "completed": "Completed",
+      "scheduled": "Scheduled"
+    },
+    "list": {
+      "complete": "Complete",
+      "create_first": "Create Your First Entry",
+      "delete": "Delete",
+      "duplicate": "Duplicate",
+      "edit": "Edit",
+      "new": "New"
+    },
+    "modal": {
+      "completed_date": "Completed Date",
+      "cost": "Cost",
+      "delete_confirmation": "Are you sure you want to delete this entry?",
+      "edit_action": "Update",
+      "edit_title": "Edit Entry",
+      "entry_name": "Entry Name",
+      "new_action": "Create",
+      "new_title": "New Entry",
+      "notes": "Notes",
+      "scheduled_date": "Scheduled Date"
+    },
+    "monthly_average": "Monthly Average",
+    "toast": {
+      "failed_to_create": "Failed to create entry",
+      "failed_to_delete": "Failed to delete entry",
+      "failed_to_update": "Failed to update entry"
+    },
+    "total_cost": "Total Cost",
+    "total_entries": "Total Entries"
+  },
+  "menu": {
+    "collection": "Collection",
+    "create_item": "Item / Asset",
+    "create_location": "Location",
+    "create_tag": "Tag",
+    "home": "Home",
+    "locations": "Locations",
+    "maintenance": "Maintenance",
+    "profile": "Profile",
+    "scanner": "Scanner",
+    "search": "Search",
+    "templates": "Templates"
+  },
+  "pages": {
+    "templates": {
+      "no_templates": "No templates yet.",
+      "title": "Templates"
+    }
+  },
+  "profile": {
+    "active": "Active",
+    "change_password": "Change Password",
+    "currency_format": "Currency Format",
+    "current_password": "Current Password",
+    "delete_account": "Delete Account",
+    "delete_account_confirm": "Are you sure you want to delete your account? If you are the last member in your group all your data will be deleted. This action cannot be undone.",
+    "delete_account_sub": "Delete your account and all its associated data. This can not be undone.",
+    "delete_notifier_confirm": "Are you sure you want to delete this notifier?",
+    "display_legacy_header": "{ currentValue, select, true {Disable Legacy Header} false {Enable Legacy Header} other {Not Hit}}",
+    "enabled": "Enabled",
+    "example": "Example",
+    "group_settings": "Group Settings",
+    "group_settings_sub": "Shared Group Settings. You may need to refresh your browser for some settings to apply.",
+    "inactive": "Inactive",
+    "language": "Language",
+    "legacy_image_fit": "{ currentValue, select, true {Disable Legacy Fit: Fit Image with Bars} false {Enable Legacy Fit: Fill Image with Crop} other {Not Hit}}",
+    "moved_notice_body": "Notifiers, invites, and currency settings have been moved to the collection pages.",
+    "moved_notice_description": "These settings are now managed per collection.",
+    "moved_notice_link_invites": "Collection invites",
+    "moved_notice_link_notifiers": "Collection notifiers",
+    "moved_notice_link_settings": "Collection currency settings",
+    "moved_notice_title": "Looking for notifiers, invites, or currency settings?",
+    "new_password": "New Password",
+    "no_notifiers": "No notifiers configured",
+    "no_override": "No override",
+    "notifier_modal": "{ type, select, true {Edit} false {Create} other {Other}} Notifier",
+    "notifiers": "Notifiers",
+    "notifiers_sub": "Get notifications for upcoming maintenance reminders",
+    "override_locale": "Override Date and Currency Language",
+    "test": "Test",
+    "theme_settings": "Theme Settings",
+    "theme_settings_sub": "Theme settings are stored in your browser's local storage. You can change the theme at any time. If you're\n having trouble setting your theme try refreshing your browser.",
+    "toast": {
+      "account_deleted": "Your account has been deleted.",
+      "failed_change_password": "Failed to change password.",
+      "failed_create_notifier": "Failed to create notifier.",
+      "failed_delete_account": "Failed to delete your account.",
+      "failed_delete_notifier": "Failed to delete notifier.",
+      "failed_get_currencies": "Failed to get currencies",
+      "failed_test_notifier": "Failed to test notifier.",
+      "failed_update_group": "Failed to update group",
+      "failed_update_notifier": "Failed to update notifier.",
+      "group_updated": "Group updated",
+      "notifier_test_success": "Notifier test successful.",
+      "password_changed": "Password changed successfully."
+    },
+    "update_group": "Update Group",
+    "update_language": "Update Language",
+    "url": "URL",
+    "user_profile": "User Profile",
+    "user_profile_sub": "Invite users, and manage your account."
+  },
+  "reports": {
+    "label_generator": {
+      "asset_end": "Asset End",
+      "asset_start": "Asset Start",
+      "base_url": "Base URL",
+      "bordered_labels": "Bordered Labels",
+      "generate_page": "Generate Page",
+      "input_placeholder": "Type here",
+      "instruction_1": "The HomeBox Label Generator is a tool to help you print labels for your HomeBox inventory. These are intended to\n be print-ahead labels so you can print many labels and have them ready to apply",
+      "instruction_2": "As such, these labels work by printing a URL QR Code and AssetID information on a label. If you've disabled\n AssetID's in your HomeBox settings, you can still use this tool, but the AssetID's won't reference any item",
+      "instruction_3": "This feature is in early development stages and may change in future releases, if you have feedback please\n provide it in the '<a href=\"https://github.com/sysadminsmedia/homebox/discussions/53\">'GitHub Discussion'</a>'",
+      "label_height": "Label Height",
+      "label_width": "Label Width",
+      "measure_type": "Measure Type",
+      "page_bottom_padding": "Page Bottom Padding",
+      "page_height": "Page Height",
+      "page_left_padding": "Page Left Padding",
+      "page_right_padding": "Page Right Padding",
+      "page_top_padding": "Page Top Padding",
+      "page_width": "Page Width",
+      "print_location_row": "Print Location Row",
+      "qr_code_example": "QR Code Example",
+      "replace_homebox_behavior": "Replace \"HomeBox\" text behavior",
+      "replace_homebox_behavior_always_replace": "Always Replace \"HomeBox\"",
+      "replace_homebox_behavior_item_no_location": "Replace \"HomeBox\" when item has no location",
+      "replace_homebox_behavior_item_no_name": "Replace \"HomeBox\" when item has no name",
+      "replace_homebox_behavior_item_no_name_no_location": "Replace \"HomeBox\" when item has no name and no location",
+      "replace_homebox_behavior_show_homebox": "Show \"HomeBox\"",
+      "replace_homebox_text": "Replacement text",
+      "skip_first_labels": "Skip First Labels",
+      "tip_1": "The defaults here are setup for the\n '<a href=\"https://www.avery.com/templates/5260\">'Avery 5260 label sheets'</a>'. If you're using a different sheet,\n you'll need to adjust the settings to match your sheet.",
+      "tip_2": "If you're customizing your sheet the dimensions are in inches. When building the 5260 sheet, I found that the\n dimensions used in their template, did not match what was needed to print within the boxes.\n '<b>'Be prepared for some trial and error.'</b>'",
+      "tip_3": "When printing be sure to:\n '<ol><li>'Set the margins to 0 or None'</li><li>'Set the scaling to 100%'</li><li>'Disable double-sided printing'</li><li>'Print a test page before printing multiple pages'</li></ol>'",
+      "tips": "Tips",
+      "title": "Label Generator",
+      "toast": {
+        "page_too_small_card": "Page size is too small for the card size"
+      }
+    }
+  },
+  "scanner": {
+    "barcode_detected_message": "product barcode detected",
+    "barcode_fetch_data": "Fetch product data",
+    "error": "An error occurred while scanning",
+    "invalid_url": "Invalid barcode URL",
+    "no_sources": "No video sources available",
+    "permission_denied": "Camera permission denied, please allow access to the camera in your browser settings",
+    "select_video_source": "Pick a video source",
+    "title": "Scanner",
+    "unsupported": "Media Stream API is not supported without HTTPS"
+  },
+  "tags": {
+    "no_results": "No Tags Found",
+    "tag_delete_confirm": "Are you sure you want to delete this tag? This action cannot be undone.",
+    "toast": {
+      "failed_delete_tag": "Failed to delete tag",
+      "failed_load_tag": "Failed to load tag",
+      "failed_update_tag": "Failed to update tag",
+      "tag_deleted": "Tag deleted",
+      "tag_updated": "Tag updated"
+    },
+    "update_tag": "Update Tag"
+  },
+  "tools": {
+    "actions": "Inventory Actions",
+    "actions_set": {
+      "create_missing_thumbnails": "Create Missing Thumbnails",
+      "create_missing_thumbnails_button": "Create Thumbnails",
+      "create_missing_thumbnails_confirm": "Are you sure you want to create missing thumbnails? This can take a while and cannot be paused.",
+      "create_missing_thumbnails_sub": "Creates thumbnails for all attachments that are supported by the current configuration. This is useful for attachments that were uploaded prior to the v0.20.0 release of Homebox. This will not overwrite existing thumbnails, only create new ones for attachments that do not have a thumbnail. Please note that the thumbnails are created in the background and may take a while to complete.",
+      "ensure_ids": "Ensure Asset IDs",
+      "ensure_ids_button": "Ensure Asset IDs",
+      "ensure_ids_confirm": "Are you sure you want to ensure all assets have an ID? This can take a while and cannot be undone.",
+      "ensure_ids_sub": "Ensures that all items in your inventory have a valid asset_id field. This is done by finding the highest current asset_id field in the database and applying the next value to each item that has an unset asset_id field. This is done in order of the created_at field.",
+      "ensure_import_refs": "Ensure Import Refs",
+      "ensure_import_refs_button": "Ensure Import Refs",
+      "ensure_import_refs_sub": "Ensures that all items in your inventory have a valid import_ref field. This is done by randomly generating a 8 character string for each item that has an unset import_ref field.",
+      "set_primary_photo": "Set Primary Photo",
+      "set_primary_photo_button": "Set Primary Photo",
+      "set_primary_photo_confirm": "Are you sure you want to set primary photos? This can take a while and cannot be undone.",
+      "set_primary_photo_sub": "In version v0.10.0 of Homebox, the primary image field was added to attachments of type photo. This action will set the primary image field to the first image in the attachments array in the database, if it is not already set. '<a class=\"link\" href=\"https://github.com/hay-kot/homebox/pull/576\">'See GitHub PR #576'</a>'",
+      "wipe_inventory": "Wipe Inventory",
+      "wipe_inventory_button": "Wipe Inventory",
+      "wipe_inventory_confirm": "Are you sure you want to wipe your entire inventory? This will delete all items and cannot be undone.",
+      "wipe_inventory_locations": "Also wipe all locations",
+      "wipe_inventory_maintenance": "Also wipe all maintenance records",
+      "wipe_inventory_note": "Note: Only group owners can perform this action.",
+      "wipe_inventory_sub": "Permanently deletes all items in your inventory. This action is irreversible and will remove all item data including attachments and photos.",
+      "wipe_inventory_tags": "Also wipe all tags",
+      "zero_datetimes": "Zero Item Date Times",
+      "zero_datetimes_button": "Zero Item Date Times",
+      "zero_datetimes_confirm": "Are you sure you want to reset all date and time values? This can take a while and cannot be undone.",
+      "zero_datetimes_sub": "Resets the time value for all date time fields in your inventory to the beginning of the date. This is to fix a bug that was introduced early on in the development of the site that caused the time value to be stored with the time which caused issues with date fields displaying accurate values. '<a class=\"link\" href=\"https://github.com/hay-kot/homebox/issues/236\" target=\"_blank\">'See Github Issue #236 for more details.'</a>'"
+    },
+    "actions_sub": "Apply Actions to your inventory in bulk. These are irreversible actions. '<b>'Be careful.'</b>'",
+    "demo_mode_error": {
+      "wipe_inventory": "Inventory, tags, locations and maintenance records cannot be wiped whilst Homebox is in demo mode. Please ensure that you are not in demo mode and try again."
+    },
+    "import_export": "Import/Export",
+    "import_export_set": {
+      "export": "Export Inventory",
+      "export_button": "Export Inventory",
+      "export_sub": "Exports the standard CSV format for Homebox. This will export all items in your inventory.",
+      "import": "Import Inventory",
+      "import_button": "Import Inventory",
+      "import_ref_confirm": "Are you sure you want to ensure all assets have an import_ref? This can take a while and cannot be undone.",
+      "import_sub": "Imports the standard CSV format for Homebox. Without an '<code>'HB.import_ref'</code>' column, this will '<b>'not'</b>' overwrite any existing items in your inventory, only add new items. Rows with an '<code>'HB.import_ref'</code>' column are merged into existing items with the same import_ref, if one exists."
+    },
+    "import_export_sub": "Import and export your inventory to and from a CSV file. This is useful for migrating your inventory to a new instance of Homebox.",
+    "reports": "Reports",
+    "reports_set": {
+      "asset_labels": "Asset ID Labels",
+      "asset_labels_button": "Label Generator",
+      "asset_labels_sub": "Generates a printable PDF of labels for a range of Asset ID. These are not specific to your inventory so you are able to print labels ahead of time and apply them to your inventory when you receive them.",
+      "bill_of_materials": "Bill of Materials",
+      "bill_of_materials_button": "Generate BOM",
+      "bill_of_materials_sub": "Generates a CSV (Comma Separated Values) file that can be imported into a spreadsheet program. This is a summary of your inventory with basic item and pricing information."
+    },
+    "reports_sub": "Generate different reports for your inventory.",
+    "toast": {
+      "asset_success": "{ results } assets have been updated.",
+      "failed_create_missing_thumbnails": "Failed to create missing thumbnails.",
+      "failed_ensure_ids": "Failed to ensure asset IDs.",
+      "failed_ensure_import_refs": "Failed to ensure import refs.",
+      "failed_set_primary_photos": "Failed to set primary photos.",
+      "failed_wipe_inventory": "Failed to wipe inventory.",
+      "failed_zero_datetimes": "Failed to reset date and time values.",
+      "wipe_inventory_success": "Successfully wiped inventory. { results } items deleted."
+    }
+  }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "vue-tsc": "3.0.6"
   },
   "dependencies": {
+    "@mmote/niimbluelib": "0.0.1-alpha.36",
     "@mdit/plugin-img-size": "^0.22.5",
     "@nuxtjs/color-mode": "^3.5.2",
     "@nuxtjs/tailwindcss": "^6.14.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@mdit/plugin-img-size':
         specifier: ^0.22.5
         version: 0.22.5(markdown-it@14.1.1)
+      '@mmote/niimbluelib':
+        specifier: 0.0.1-alpha.36
+        version: 0.0.1-alpha.36
       '@nuxtjs/color-mode':
         specifier: ^3.5.2
         version: 3.5.2(magicast@0.5.2)
@@ -769,6 +772,14 @@ packages:
       commander:
         optional: true
 
+  '@capacitor-community/bluetooth-le@7.3.2':
+    resolution: {integrity: sha512-7dgtglFXGmyS849XtIZ62iA997aE3yqNsq7XsC8yjR8dqe/agh852+nW1Zk/8QlG58dPu/K5fxVzlWZvZFb80g==}
+    peerDependencies:
+      '@capacitor/core': '>=7.0.0'
+
+  '@capacitor/core@7.6.0':
+    resolution: {integrity: sha512-K6LEvgxW6Nd6uNWHj3U512hUtB4kln71TvVgdvwJRFMLySpUrWwb/A8Q7c3QGogvPvgOjN1U65onkyRTihPGwA==}
+
   '@clack/core@1.0.1':
     resolution: {integrity: sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==}
 
@@ -1214,6 +1225,9 @@ packages:
     peerDependenciesMeta:
       markdown-it:
         optional: true
+
+  '@mmote/niimbluelib@0.0.1-alpha.36':
+    resolution: {integrity: sha512-ZJOllxaZkL4K47uZCotUzwsG2l9Q1IyC3CZ2PZ7pt/67mH63TeV/o2h2VODJGDjA+jQmT8p+JmPVV/v3nIbtWA==}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -2861,6 +2875,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  async-mutex@0.5.0:
+    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
+
   async-sema@3.1.1:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
 
@@ -3782,6 +3799,9 @@ packages:
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
@@ -7366,6 +7386,15 @@ snapshots:
       cac: 6.7.14
       citty: 0.2.1
 
+  '@capacitor-community/bluetooth-le@7.3.2(@capacitor/core@7.6.0)':
+    dependencies:
+      '@capacitor/core': 7.6.0
+      '@types/web-bluetooth': 0.0.20
+
+  '@capacitor/core@7.6.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@clack/core@1.0.1':
     dependencies:
       picocolors: 1.1.1
@@ -7803,6 +7832,14 @@ snapshots:
       '@types/markdown-it': 14.1.2
     optionalDependencies:
       markdown-it: 14.1.1
+
+  '@mmote/niimbluelib@0.0.1-alpha.36':
+    dependencies:
+      '@capacitor-community/bluetooth-le': 7.3.2(@capacitor/core@7.6.0)
+      '@capacitor/core': 7.6.0
+      async-mutex: 0.5.0
+      crc-32: 1.2.2
+      eventemitter3: 5.0.4
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -9720,6 +9757,10 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  async-mutex@0.5.0:
+    dependencies:
+      tslib: 2.8.1
+
   async-sema@3.1.1: {}
 
   async@3.2.6: {}
@@ -10711,6 +10752,8 @@ snapshots:
   event-target-shim@5.0.1: {}
 
   eventemitter3@4.0.7: {}
+
+  eventemitter3@5.0.4: {}
 
   events-universal@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds one-click label printing to Niimbot thermal printers (B1, B21, etc.) via Web Bluetooth API
- Prints both full labels (QR + name) and QR-only directly from the existing label dialog
- Tape size selector with 5 presets + custom dimensions, saved to localStorage

## Motivation

Printing QR labels from Homebox to a thermal printer currently requires ~15 manual steps: copy link, generate QR in another app, save image, open printer app, configure, print. This integration reduces it to one click.

## Implementation

**New files (all Niimbot code is isolated):**
- `composables/use-niimbot.ts` — BLE connection management, image processing pipeline, print protocol
- `components/niimbot/NiimbotPrint.vue` — UI component with tape size selector and print button

**Minimal changes to existing files:**
- `components/global/LabelMaker.vue` — 2 lines added (import + `<NiimbotPrint>` component)
- `package.json` — 1 dependency (`@mmote/niimbluelib`)
- `Dockerfile` — `nuxt prepare` before build (needed for `.nuxt/tsconfig.json` generation)

**Print pipeline:**
```
Homebox API → fetch PNG → resize to tape → threshold to 1-bit
→ center on printhead-wide canvas → encode → BLE print
```

**Key technical details:**
- 203 DPI (8 dots/mm), `printDirection: "top"` for wide labels
- Printer does not auto-center — canvas padded to full printhead width (384px for B1)
- Heartbeat stopped during print to avoid protocol interference
- Component auto-hides via `v-if="isSupported"` in browsers without Web Bluetooth

## Browser support

Web Bluetooth API — Chrome, Edge, Opera only. The component is completely hidden in unsupported browsers (Firefox, Safari, iOS). Requires HTTPS or localhost.

## Screenshots

The Niimbot section appears below the existing label controls in the print dialog:
- Bluetooth connect/disconnect button with device name
- Label variant selector (Full / QR only)
- Tape size selector with presets and custom option
- Print button with progress indicator

![telegram-cloud-photo-size-2-5319245455285754340-y](https://github.com/user-attachments/assets/83406d65-3503-4873-8060-3e7ea276e1b8)

## Test plan

- [ ] Open label dialog in Chrome — Niimbot section visible
- [ ] Open label dialog in Firefox — Niimbot section hidden
- [ ] Connect to Niimbot printer via Bluetooth
- [ ] Print full label — QR + name centered on tape
- [ ] Print QR-only label
- [ ] Switch tape sizes, verify persistence across page reloads
- [ ] Verify no regressions in existing label functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Niimbot Bluetooth label printer support: connect/disconnect, device name display, real-time print progress, success/error toasts.
  * Integrated print UI in the label dialog with Full/QR variants, tape size presets, custom width/height, and saved tape-size persistence.

* **Localization**
  * Large expansion of locale strings, including niimbot labels, tape/print messages, and many reorganized UI sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->