### PR TITLE
feat(frontend): remember previously selected camera

### DIFF
--- a/frontend/components/App/ScannerModal.vue
+++ b/frontend/components/App/ScannerModal.vue
@@ -76,6 +76,8 @@
   const detectedBarcode = ref<string>("");
   const detectedBarcodeType = ref<string>("");
 
+  const LAST_USED_DEVICE_ID_KEY = "homebox:lastUsedDeviceId";
+
   const handleError = (error: unknown) => {
     console.error("Scanner error:", error);
     errorMessage.value = t("scanner.error");
@@ -109,13 +111,21 @@
       sources.value = devices;
 
       if (devices.length > 0) {
-        for (let i = 0; i < devices.length; i++) {
-          if (devices[i]!.label.toLowerCase().includes("back")) {
-            selectedSource.value = devices[i]!.deviceId;
-          }
+        let lastUsedDeviceId: string | null = null;
+        try {
+          lastUsedDeviceId = localStorage.getItem(LAST_USED_DEVICE_ID_KEY);
+        } catch (e) {
+          console.debug("failed to read selected camera", e);
         }
-        if (!selectedSource.value) {
-          selectedSource.value = devices[0]!.deviceId;
+
+        selectedSource.value = devices[0]!.deviceId;
+        for (const device of devices) {
+          if (device.deviceId === lastUsedDeviceId) {
+            selectedSource.value = device.deviceId;
+            break;
+          } else if (device.label.toLowerCase().includes("back")) {
+            selectedSource.value = device.deviceId;
+          }
         }
       } else {
         errorMessage.value = t("scanner.no_sources");
@@ -144,6 +154,12 @@
   watch(selectedSource, async newSource => {
     if (!open.value || !newSource) return;
     codeReader.reset();
+
+    try {
+      localStorage.setItem(LAST_USED_DEVICE_ID_KEY, newSource);
+    } catch (e) {
+      console.warn("failed to persist selected camera", e);
+    }
 
     try {
       await codeReader.decodeFromVideoDevice(newSource, video.value!, (result, err) => {


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

This is a small PR that saves the previously selected camera (device id) in the browser's local storage.

I often use HomeBox on an iPhone, which do have multiple cameras, and I like to scan labels with an ultra wide camera, but each time I start the scanning telephoto camera is selected.

This PR remembers the camera the user picked last time, and it tries to select it.

## Which issue(s) this PR fixes:

This sort of fixes this: #1210

## Testing

I have tested it on my mobile. Tested it without the camera selected (no value in local storage), then switching to my preferred camera, closing the dialog and re-opening it. Then I modified the local storage value to non-existing device id and re-opened the dialog to check that default camera is selected (like it used to work before this change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Scanner now remembers and automatically re-selects your last-used camera across sessions.
  * Changing the camera while the scanner is open saves the new choice for future use, with sensible fallback to available rear/default cameras if the previous device is unavailable.
  * Smoother experience when switching devices or returning to the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->