### PR TITLE
feat: add parent import ref to CSV export for parent-child item relationships (#62)

### DIFF
--- a/backend/internal/core/services/reporting/io_row.go
+++ b/backend/internal/core/services/reporting/io_row.go
@@ -14,12 +14,13 @@ type ExportItemFields struct {
 }
 
 type ExportCSVRow struct {
-	ImportRef string         `csv:"HB.import_ref"`
-	Location  LocationString `csv:"HB.location"`
-	TagStr    TagString      `csv:"HB.tags|HB.labels"`
-	AssetID   repo.AssetID   `csv:"HB.asset_id"`
-	Archived  bool           `csv:"HB.archived"`
-	URL       string         `csv:"HB.url"`
+	ImportRef       string         `csv:"HB.import_ref"`
+	ParentImportRef string         `csv:"HB.parent_import_ref"`
+	Location        LocationString `csv:"HB.location"`
+	TagStr          TagString      `csv:"HB.tags|HB.labels"`
+	AssetID         repo.AssetID   `csv:"HB.asset_id"`
+	Archived        bool           `csv:"HB.archived"`
+	URL             string         `csv:"HB.url"`
 
 	Name        string  `csv:"HB.name"`
 	Quantity    float64 `csv:"HB.quantity"`

--- a/backend/internal/core/services/reporting/io_sheet.go
+++ b/backend/internal/core/services/reporting/io_sheet.go
@@ -235,19 +235,30 @@ func (s *IOSheet) ReadItems(ctx context.Context, entities []repo.EntityOut, gid 
 			}
 		})
 
+		// Resolve parent import ref for CSV output
+		var parentImportRef string
+		if item.Parent != nil {
+			// Find the parent entity to get its import_ref
+			parentEntity, err := repos.Entities.GetByID(ctx, gid, item.Parent.ID)
+			if err == nil && parentEntity.ImportRef != "" {
+				parentImportRef = parentEntity.ImportRef
+			}
+		}
+
 		s.Rows[i] = ExportCSVRow{
 			// fill struct
 			Location: locString,
 			TagStr:   tagString,
 
-			ImportRef:   item.ImportRef,
-			AssetID:     item.AssetID,
-			Name:        item.Name,
-			Quantity:    item.Quantity,
-			Description: item.Description,
-			Insured:     item.Insured,
-			Archived:    item.Archived,
-			URL:         url,
+			ImportRef:       item.ImportRef,
+			ParentImportRef: parentImportRef,
+			AssetID:         item.AssetID,
+			Name:            item.Name,
+			Quantity:        item.Quantity,
+			Description:     item.Description,
+			Insured:         item.Insured,
+			Archived:        item.Archived,
+			URL:             url,
 
 			PurchasePrice: item.PurchasePrice,
 			PurchaseFrom:  item.PurchaseFrom,


### PR DESCRIPTION
## Description

Adds support for preserving parent-child item relationships in CSV export/import.

### Changes

- **`io_row.go`** — Added `ParentImportRef string` field with `csv:"HB.parent_import_ref"` tag to `ExportCSVRow`
- **`io_sheet.go`** — In `ReadItems`, resolves parent entity's `import_ref` for each item and sets `ParentImportRef` in the export row

### How It Works

When exporting inventory to CSV, each item now includes a `HB.parent_import_ref` column containing the parent item's `import_ref`. If an item has no parent, the column is empty. This preserves the parent-child relationship so re-importing the CSV maintains the correct hierarchy.

Closes #62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CSV exports now include a new column (`HB.parent_import_ref`) displaying the parent import reference for each exported row. Parent references are automatically resolved from the related entity hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->