### PR TITLE
Add UPC to database and add a search, and duplicate scan flow when UPC is scanned 

### DIFF
--- a/backend/internal/data/repo/repo_entities.go
+++ b/backend/internal/data/repo/repo_entities.go
@@ -93,6 +93,7 @@ type (
 		Name         string    `json:"name"         validate:"required,min=1,max=255"`
 		Quantity     float64   `json:"quantity"`
 		Description  string    `json:"description"  validate:"max=1000"`
+		UPC          string    `json:"upc"          validate:"max=64"`
 		AssetID      AssetID   `json:"-"`
 		EntityTypeID uuid.UUID `json:"entityTypeId"`
 
@@ -116,6 +117,7 @@ type (
 		TagIDs []uuid.UUID `json:"tagIds"`
 
 		// Identifications
+		UPC          string `json:"upc"          validate:"max=64"`
 		SerialNumber string `json:"serialNumber"`
 		ModelNumber  string `json:"modelNumber"`
 		Manufacturer string `json:"manufacturer"`
@@ -156,6 +158,7 @@ type (
 		AssetID     AssetID   `json:"assetId,string"`
 		Name        string    `json:"name"`
 		Description string    `json:"description"`
+		UPC         string    `json:"upc"`
 		Quantity    float64   `json:"quantity"`
 		Insured     bool      `json:"insured"`
 		Archived    bool      `json:"archived"`
@@ -187,6 +190,7 @@ type (
 		SyncChildEntityLocations bool `json:"syncChildEntityLocations"`
 
 		SerialNumber string `json:"serialNumber"`
+		UPC          string `json:"upc"`
 		ModelNumber  string `json:"modelNumber"`
 		Manufacturer string `json:"manufacturer"`
 
@@ -258,6 +262,7 @@ func mapEntitySummary(e *ent.Entity) EntitySummary {
 		AssetID:       AssetID(e.AssetID),
 		Name:          e.Name,
 		Description:   e.Description,
+		UPC:           e.ImportRef,
 		ImportRef:     e.ImportRef,
 		Quantity:      e.Quantity,
 		CreatedAt:     e.CreatedAt,
@@ -336,6 +341,7 @@ func mapEntityOut(e *ent.Entity) EntityOut {
 		SyncChildEntityLocations: e.SyncChildEntityLocations,
 
 		// Identification
+		UPC:          e.ImportRef,
 		SerialNumber: e.SerialNumber,
 		ModelNumber:  e.ModelNumber,
 		Manufacturer: e.Manufacturer,
@@ -587,6 +593,7 @@ func (r *EntityRepository) QueryByGroup(ctx context.Context, gid uuid.UUID, q En
 			entity.Or(
 				entity.NameContainsFold(q.Search),
 				entity.DescriptionContainsFold(q.Search),
+				entity.ImportRefContainsFold(q.Search),
 				entity.SerialNumberContainsFold(q.Search),
 				entity.ModelNumberContainsFold(q.Search),
 				entity.ManufacturerContainsFold(q.Search),
@@ -993,8 +1000,13 @@ func (r *EntityRepository) Create(ctx context.Context, gid uuid.UUID, data Entit
 		return EntityOut{}, err
 	}
 
+	importRef := data.ImportRef
+	if data.UPC != "" {
+		importRef = data.UPC
+	}
+
 	q := r.db.Entity.Create().
-		SetImportRef(data.ImportRef).
+		SetImportRef(importRef).
 		SetName(data.Name).
 		SetQuantity(data.Quantity).
 		SetDescription(data.Description).
@@ -1425,6 +1437,7 @@ func (r *EntityRepository) UpdateByGroup(ctx context.Context, gid uuid.UUID, dat
 	q := r.db.Entity.Update().Where(entity.ID(data.ID), entity.HasGroupWith(group.ID(gid))).
 		SetName(data.Name).
 		SetDescription(data.Description).
+		SetImportRef(data.UPC).
 		SetSerialNumber(data.SerialNumber).
 		SetModelNumber(data.ModelNumber).
 		SetManufacturer(data.Manufacturer).
@@ -2113,6 +2126,7 @@ func (r *EntityRepository) Duplicate(ctx context.Context, gid, id uuid.UUID, opt
 		SetQuantity(originalEntity.Quantity).
 		SetGroupID(gid).
 		SetAssetID(int64(nextAssetID)).
+		SetImportRef(originalEntity.ImportRef).
 		SetSerialNumber(originalEntity.SerialNumber).
 		SetModelNumber(originalEntity.ModelNumber).
 		SetManufacturer(originalEntity.Manufacturer).

--- a/frontend/components/Item/BarcodeModal.vue
+++ b/frontend/components/Item/BarcodeModal.vue
@@ -6,6 +6,21 @@
       </DialogHeader>
 
       <div
+        v-if="existingItems.length > 0"
+        class="flex flex-col gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-4 text-amber-700 dark:text-amber-300"
+        role="alert"
+      >
+        <span class="text-sm font-medium">
+          Found {{ existingItems.length }} existing item(s) with UPC {{ barcode }}.
+        </span>
+        <div class="flex flex-wrap gap-2">
+          <Button v-for="existing in existingItems" :key="existing.id" size="sm" variant="outline" @click="navigateToItem(existing.id)">
+            Open {{ existing.name }}
+          </Button>
+        </div>
+      </div>
+
+      <div
         v-if="errorMessage"
         class="flex items-center gap-2 rounded-md border border-destructive bg-destructive/10 p-4 text-destructive"
         role="alert"
@@ -112,7 +127,7 @@
   import { useI18n } from "vue-i18n";
   import { DialogID } from "@/components/ui/dialog-provider/utils";
   import { Button } from "~/components/ui/button";
-  import type { BarcodeProduct } from "~~/lib/api/types/data-contracts";
+  import type { BarcodeProduct, EntitySummary } from "~~/lib/api/types/data-contracts";
   import { useDialog } from "~/components/ui/dialog-provider";
   import MdiAlertCircleOutline from "~icons/mdi/alert-circle-outline";
   import MdiBarcode from "~icons/mdi/barcode";
@@ -129,6 +144,7 @@
   const searching = ref(false);
   const barcode = ref<string>("");
   const products = ref<BarcodeProduct[] | null>(null);
+  const existingItems = ref<EntitySummary[]>([]);
   const selectedRow = ref(-1);
   const errorMessage = ref<string | null>(null);
 
@@ -159,6 +175,7 @@
       selectedRow.value = -1;
       searching.value = false;
       errorMessage.value = null;
+      existingItems.value = [];
 
       if (params?.barcode) {
         // Reset if the barcode is different
@@ -196,6 +213,7 @@
 
   async function retrieveProductInfo(barcode: string) {
     errorMessage.value = null;
+    existingItems.value = [];
 
     if (!barcode || barcode.trim().length === 0 || !/^[0-9]+$/.test(barcode)) {
       errorMessage.value = t("components.item.product_import.error_invalid_barcode");
@@ -207,6 +225,11 @@
     searching.value = true;
 
     try {
+      const existingResult = await api.items.getAll({ q: barcode.trim(), page: 1, pageSize: 10 });
+      if (!existingResult.error && existingResult.data?.items) {
+        existingItems.value = existingResult.data.items.filter(item => item.upc === barcode.trim());
+      }
+
       const result = await api.products.searchFromBarcode(barcode.trim());
       if (result.error) {
         errorMessage.value = t("errors.api_failure") + result.error;
@@ -224,6 +247,10 @@
     } finally {
       searching.value = false;
     }
+  }
+
+  function navigateToItem(itemId: string) {
+    navigateTo(`/item/${itemId}`);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -419,6 +419,7 @@
     parentId: null,
     name: "",
     quantity: 1,
+    upc: "",
     description: "",
     color: "",
     tags: [] as string[],
@@ -602,6 +603,7 @@
       if (params?.product) {
         form.name = params.product.item.name;
         form.description = params.product.item.description;
+        form.upc = params.product.barcode;
 
         if (params.product.imageURL) {
           form.photos.push({
@@ -660,6 +662,7 @@
         parentId: form.parentId || form.location.id as string,
         name: form.name,
         quantity: form.quantity,
+        upc: form.upc,
         description: form.description,
         tagIds: form.tags,
         entityTypeId: selectedEntityType.value?.id,
@@ -705,6 +708,7 @@
 
     form.name = "";
     form.quantity = 1;
+    form.upc = "";
     form.description = "";
     form.color = "";
     form.photos = [];

--- a/frontend/lib/api/types/data-contracts.ts
+++ b/frontend/lib/api/types/data-contracts.ts
@@ -594,6 +594,7 @@ export interface EntityCreate {
   name: string;
   parentId?: string | null;
   quantity: number;
+  upc: string;
   /** Edges */
   tagIds: string[];
 }
@@ -651,6 +652,7 @@ export interface EntityOut {
   soldNotes: string;
   soldPrice: number;
   soldTo: string;
+  upc: string;
   syncChildEntityLocations: boolean;
   tags: TagSummary[];
   thumbnailId?: string | null;
@@ -691,6 +693,7 @@ export interface EntitySummary {
   parent?: EntitySummary | null;
   purchasePrice: number;
   quantity: number;
+  upc: string;
   /** Sale details */
   soldDate: Date | string;
   tags: TagSummary[];
@@ -858,6 +861,7 @@ export interface EntityUpdate {
   purchaseFrom: string;
   purchasePrice?: number | null;
   quantity: number;
+  upc: string;
   /** Identifications */
   serialNumber: string;
   /** Sold */

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -569,6 +569,7 @@
         "select_field": "Select a field",
         "select_value": "Select a value",
         "serial_number": "Serial Number",
+        "upc": "UPC",
         "show_advanced_view_options": "Show Advanced View Options",
         "show_empty": "Show Empty",
         "sold_at": "Sold At",

--- a/frontend/pages/item/[id]/index/edit.vue
+++ b/frontend/pages/item/[id]/index/edit.vue
@@ -190,6 +190,12 @@
     },
     {
       type: "text",
+      label: "items.upc",
+      ref: "upc",
+      maxLength: 64,
+    },
+    {
+      type: "text",
       label: "items.serial_number",
       ref: "serialNumber",
       maxLength: 255,


### PR DESCRIPTION
Motivation

    Allow UPC/barcode to be stored and used when importing products so scanned barcodes can prefill items and detect duplicates.
    Make UPC searchable so users can find items by barcode from the main item search flow.
    Surface UPC in the UI (create modal, edit form and import modal) to improve scanning/import UX.

Description

    Added upc to the entity API types and DTOs used by the frontend (EntityCreate, EntityUpdate, EntityOut, EntitySummary) so UPC is part of the API contract and form payloads.
    Wired product import flow so the barcode returned from product lookup is placed into the item create payload and persisted (backend maps UPC into the existing import_ref storage field to avoid ent codegen changes in this rollout).
    Extended repository search to include UPC (implemented via ImportRefContainsFold where UPC is stored) so searching by barcode will find matching items.
    Added duplicate-detection UI in the Barcode/Product Import modal that queries existing items for the scanned UPC and shows quick “Open” buttons for matches before importing a new item.
    Exposed UPC in the item create modal and item edit form and added an English locale key for the items.upc label.

Testing

    Attempted to run backend repository tests with go test ./internal/data/repo -run TestNormalizeSearchQueryIntegration, but execution did not complete in this environment (test run/timeouts and go generate failed due to external network/module fetch restrictions), so the full automated test suite was not completed.
    Verified repository changes were committed successfully (git commit completed) and performed local inspections of modified TypeScript and Vue files to ensure the new upc fields are passed through create/update flows and rendered in the UI.
    Manual smoke checks in code: ensured product import modal now queries api.items.getAll and filters by upc to display existing items (no runtime test harness was executed here).
<img width="1135" height="535" alt="image" src="https://github.com/user-attachments/assets/6ba30063-f666-4035-91cd-f23ad085aa8b" />

<img width="1238" height="785" alt="image" src="https://github.com/user-attachments/assets/3de83638-174b-4df1-bb3d-8e077947d198" />
