### PR TITLE
fix(api): correct currency endpoint route from /currencies to /currency

### DIFF
--- a/backend/app/api/routes.go
+++ b/backend/app/api/routes.go
@@ -80,7 +80,7 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 			BuildTime: buildTime,
 		})))
 
-		r.Get("/currencies", chain.ToHandlerFunc(v1Ctrl.HandleCurrency()))
+		r.Get("/currency", chain.ToHandlerFunc(v1Ctrl.HandleCurrency()))
 
 		providers := []v1.AuthProvider{
 			providers.NewLocalProvider(a.services.User),

--- a/backend/app/api/routes.go
+++ b/backend/app/api/routes.go
@@ -81,6 +81,8 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 		})))
 
 		r.Get("/currency", chain.ToHandlerFunc(v1Ctrl.HandleCurrency()))
+		// Backward-compatible alias; remove after frontend migration to /currency.
+		r.Get("/currencies", chain.ToHandlerFunc(v1Ctrl.HandleCurrency()))
 
 		providers := []v1.AuthProvider{
 			providers.NewLocalProvider(a.services.User),


### PR DESCRIPTION
Fixes #1469

## Problem

The `/api/v1/currency` endpoint returns 404. The route was registered as `/api/v1/currencies` (plural) but the documentation and swagger annotation specify `/api/v1/currency` (singular).

## Root Cause

In `backend/app/api/routes.go` line 83, the route was incorrectly registered:
```go
r.Get("/currencies", chain.ToHandlerFunc(v1Ctrl.HandleCurrency()))
```

But the swagger annotation in `controller.go` specifies:
```go
// @Router    /v1/currency [GET]
```

## Solution

Changed the route registration from `/currencies` to `/currency` to match the documentation and swagger annotation.

## Changes

- `backend/app/api/routes.go`: Line 83, `/currencies` → `/currency`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * Added a singular currency endpoint for retrieving currency information.
  * Kept the existing plural endpoint as a temporary backward-compatible alias; it is deprecated and will be removed after frontend migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->