### PR TITLE
fix: improve password manager support for auth forms

### DIFF
--- a/frontend/components/Form/Password.vue
+++ b/frontend/components/Form/Password.vue
@@ -1,6 +1,12 @@
 <template>
-  <div class="relative">
-    <FormTextField v-model="value" :placeholder="localizedPlaceholder" :label="localizedLabel" :type="inputType" />
+  <div class="relative" :class="wrapperClass()">
+    <FormTextField
+      v-bind="fieldAttrs()"
+      v-model="value"
+      :placeholder="localizedPlaceholder"
+      :label="localizedLabel"
+      :type="inputType"
+    />
     <TooltipProvider :delay-duration="0">
       <Tooltip>
         <TooltipTrigger as-child>
@@ -24,6 +30,12 @@
   import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
   import FormTextField from "@/components/Form/TextField.vue";
 
+  defineOptions({
+    inheritAttrs: false,
+  });
+
+  const attrs = useAttrs();
+
   const { t } = useI18n();
   type Props = {
     modelValue: string;
@@ -41,6 +53,15 @@
   const inputType = computed(() => {
     return hide.value ? "password" : "text";
   });
+
+  function wrapperClass() {
+    return attrs.class;
+  }
+
+  function fieldAttrs() {
+    const { class: _class, ...rest } = attrs;
+    return rest;
+  }
 
   const value = useVModel(props, "modelValue");
 </script>

--- a/frontend/components/Form/TextField.vue
+++ b/frontend/components/Form/TextField.vue
@@ -5,12 +5,10 @@
       <span class="grow" />
       <span
         :class="{
-          'text-destructive':
-            typeof value === 'string' &&
-            ((maxLength !== -1 && value.length > maxLength) || (minLength !== -1 && value.length < minLength)),
+          'text-destructive': hasLengthError,
         }"
       >
-        {{ typeof value === "string" && (maxLength !== -1 || minLength !== -1) ? `${value.length}/${maxLength}` : "" }}
+        {{ characterCountText }}
       </span>
     </Label>
     <Input
@@ -30,6 +28,7 @@
       :passwordrules="passwordrules"
       :required="required"
       class="w-full"
+      @input="markDirty"
     />
   </div>
   <div v-else v-bind="wrapperAttrs()" class="sm:grid sm:grid-cols-4 sm:items-start sm:gap-4" :class="wrapperClass()">
@@ -38,17 +37,16 @@
       <span class="grow" />
       <span
         :class="{
-          'text-destructive':
-            typeof value === 'string' &&
-            ((maxLength !== -1 && value.length > maxLength) || (minLength !== -1 && value.length < minLength)),
+          'text-destructive': hasLengthError,
         }"
       >
-        {{ typeof value === "string" && (maxLength !== -1 || minLength !== -1) ? `${value.length}/${maxLength}` : "" }}
+        {{ characterCountText }}
       </span>
     </Label>
     <Input
       v-bind="inputAttrs()"
       :id="fieldId"
+      ref="input"
       v-model="value"
       :name="name"
       :placeholder="placeholder"
@@ -62,11 +60,13 @@
       :passwordrules="passwordrules"
       :required="required"
       class="col-span-3 mt-2 w-full"
+      @input="markDirty"
     />
   </div>
 </template>
 
 <script lang="ts" setup>
+  import { useI18n } from "vue-i18n";
   import { Label } from "~/components/ui/label";
   import { Input } from "~/components/ui/input";
 
@@ -145,6 +145,8 @@
     },
   });
 
+  const { t } = useI18n();
+
   const generatedId = useId();
   const fieldId = computed(() => props.id ?? generatedId);
 
@@ -174,4 +176,37 @@
   );
 
   const value = useVModel(props, "modelValue");
+  const isDirty = ref(false);
+
+  function markDirty() {
+    isDirty.value = true;
+  }
+
+  const hasLengthError = computed(() => {
+    if (typeof value.value !== "string" || !isDirty.value) {
+      return false;
+    }
+
+    return (
+      (props.maxLength !== -1 && value.value.length > props.maxLength) ||
+      (props.minLength !== -1 && value.value.length < props.minLength)
+    );
+  });
+
+  const characterCountText = computed(() => {
+    if (typeof value.value !== "string") {
+      return "";
+    }
+
+    if (props.maxLength !== -1) {
+      const minText = props.minLength !== -1 ? ` (${t("components.form.min_length", { min: props.minLength })})` : "";
+      return `${value.value.length}/${props.maxLength}${minText}`;
+    }
+
+    if (props.minLength !== -1) {
+      return `${value.value.length} (${t("components.form.min_length", { min: props.minLength })})`;
+    }
+
+    return "";
+  });
 </script>

--- a/frontend/components/Form/TextField.vue
+++ b/frontend/components/Form/TextField.vue
@@ -1,6 +1,6 @@
 <template>
-  <div v-if="!inline" class="flex w-full flex-col gap-1.5">
-    <Label :for="id" class="flex w-full px-1">
+  <div v-if="!inline" v-bind="wrapperAttrs()" class="flex w-full flex-col gap-1.5" :class="wrapperClass()">
+    <Label :for="fieldId" class="flex w-full px-1">
       <span> {{ label }} </span>
       <span class="grow" />
       <span
@@ -14,20 +14,26 @@
       </span>
     </Label>
     <Input
-      :id="id"
+      v-bind="inputAttrs()"
+      :id="fieldId"
       ref="input"
       v-model="value"
+      :name="name"
       :placeholder="placeholder"
       :type="type"
+      :autocomplete="autocomplete"
       :min="min"
       :max="max"
       :step="step"
+      :minlength="minLength !== -1 ? minLength : undefined"
+      :maxlength="maxLength !== -1 ? maxLength : undefined"
+      :passwordrules="passwordrules"
       :required="required"
       class="w-full"
     />
   </div>
-  <div v-else class="sm:grid sm:grid-cols-4 sm:items-start sm:gap-4">
-    <Label class="flex w-full px-1 py-2" :for="id">
+  <div v-else v-bind="wrapperAttrs()" class="sm:grid sm:grid-cols-4 sm:items-start sm:gap-4" :class="wrapperClass()">
+    <Label class="flex w-full px-1 py-2" :for="fieldId">
       <span> {{ label }} </span>
       <span class="grow" />
       <span
@@ -41,13 +47,19 @@
       </span>
     </Label>
     <Input
-      :id="id"
+      v-bind="inputAttrs()"
+      :id="fieldId"
       v-model="value"
+      :name="name"
       :placeholder="placeholder"
       :type="type"
+      :autocomplete="autocomplete"
       :min="min"
       :max="max"
       :step="step"
+      :minlength="minLength !== -1 ? minLength : undefined"
+      :maxlength="maxLength !== -1 ? maxLength : undefined"
+      :passwordrules="passwordrules"
       :required="required"
       class="col-span-3 mt-2 w-full"
     />
@@ -57,7 +69,18 @@
 <script lang="ts" setup>
   import { Label } from "~/components/ui/label";
   import { Input } from "~/components/ui/input";
+
+  defineOptions({
+    inheritAttrs: false,
+  });
+
+  const attrs = useAttrs();
+
   const props = defineProps({
+    id: {
+      type: String,
+      default: undefined,
+    },
     label: {
       type: String,
       default: "",
@@ -73,6 +96,18 @@
     type: {
       type: String,
       default: "text",
+    },
+    name: {
+      type: String,
+      default: undefined,
+    },
+    autocomplete: {
+      type: String,
+      default: undefined,
+    },
+    passwordrules: {
+      type: String,
+      default: undefined,
     },
     triggerFocus: {
       type: Boolean,
@@ -110,7 +145,22 @@
     },
   });
 
-  const id = useId();
+  const generatedId = useId();
+  const fieldId = computed(() => props.id ?? generatedId);
+
+  function wrapperClass() {
+    return attrs.class;
+  }
+
+  function wrapperAttrs() {
+    const testId = attrs["data-testid"];
+    return testId ? { "data-testid": testId } : {};
+  }
+
+  function inputAttrs() {
+    const { class: _class, "data-testid": _testId, ...rest } = attrs;
+    return rest;
+  }
 
   const input = ref<HTMLElement | null>(null);
 

--- a/frontend/lib/passwords/index.test.ts
+++ b/frontend/lib/passwords/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { scorePassword } from ".";
+import { PASSWORD_MIN_LENGTH, scorePassword } from ".";
 
 describe("scorePassword tests", () => {
   test("flagged words should return negative number", () => {
@@ -15,7 +15,7 @@ describe("scorePassword tests", () => {
   });
 
   test("should return 0 for strings less than 6", () => {
-    expect(scorePassword("12345")).toBe(0);
+    expect(scorePassword("1".repeat(PASSWORD_MIN_LENGTH - 1))).toBe(0);
   });
 
   test("should return positive number for long string", () => {

--- a/frontend/lib/passwords/index.ts
+++ b/frontend/lib/passwords/index.ts
@@ -1,5 +1,8 @@
 const flaggedWords = ["password", "homebox", "admin", "qwerty", "login"];
 
+export const PASSWORD_MIN_LENGTH = 6;
+export const PASSWORD_RULES = `minlength: ${PASSWORD_MIN_LENGTH};`;
+
 /**
  * scorePassword returns a score for a given password between 0 and 100.
  * if a password contains a flagged word, it returns 0.
@@ -10,7 +13,7 @@ export function scorePassword(pass: string): number {
   let score = 0;
   if (!pass) return score;
 
-  if (pass.length < 6) return score;
+  if (pass.length < PASSWORD_MIN_LENGTH) return score;
 
   // Check for flagged words
   for (const word of flaggedWords) {

--- a/frontend/locales/de.json
+++ b/frontend/locales/de.json
@@ -119,7 +119,8 @@
         "form": {
             "password": {
                 "toggle_show": "Passwort anzeigen"
-            }
+            },
+            "min_length": "mind. {min}"
         },
         "global": {
             "copy_text": {

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -120,7 +120,8 @@
         "form": {
             "password": {
                 "toggle_show": "Toggle Password Show"
-            }
+            },
+            "min_length": "min {min}"
         },
         "global": {
             "copy_text": {

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -19,6 +19,7 @@
   import FormPassword from "~/components/Form/Password.vue";
   import FormCheckbox from "~/components/Form/Checkbox.vue";
   import PasswordScore from "~/components/global/PasswordScore.vue";
+  import { PASSWORD_MIN_LENGTH, PASSWORD_RULES } from "~/lib/passwords";
 
   const { t } = useI18n();
 
@@ -304,7 +305,7 @@
       <div class="grid min-h-[50vh] p-6 sm:place-items-center">
         <div>
           <Transition name="slide-fade">
-            <form v-if="registerForm" @submit.prevent="registerUser">
+            <form v-if="registerForm" id="register-form" name="register" method="post" @submit.prevent="registerUser">
               <Card class="md:w-[500px]">
                 <CardHeader>
                   <CardTitle class="flex items-center gap-2">
@@ -313,15 +314,42 @@
                   </CardTitle>
                 </CardHeader>
                 <CardContent class="flex flex-col gap-2">
-                  <FormTextField v-model="email" :label="$t('index.set_email')" data-testid="email-input" />
-                  <FormTextField v-model="username" :label="$t('index.set_name')" data-testid="name-input" />
+                  <FormTextField
+                    id="register-email"
+                    v-model="email"
+                    :label="$t('index.set_email')"
+                    type="email"
+                    name="email"
+                    autocomplete="username"
+                    :required="true"
+                    data-testid="email-input"
+                  />
+                  <FormTextField
+                    id="register-name"
+                    v-model="username"
+                    :label="$t('index.set_name')"
+                    name="name"
+                    autocomplete="name"
+                    :required="true"
+                    data-testid="name-input"
+                  />
                   <div v-if="!(groupToken == '')" class="pb-1 pt-4 text-center">
                     <p>{{ $t("index.joining_group") }}</p>
                     <button type="button" class="text-xs underline" @click="groupToken = ''">
                       {{ $t("index.dont_join_group") }}
                     </button>
                   </div>
-                  <FormPassword v-model="password" :label="$t('index.set_password')" data-testid="password-input" />
+                  <FormPassword
+                    id="register-password"
+                    v-model="password"
+                    :label="$t('index.set_password')"
+                    name="new-password"
+                    autocomplete="new-password"
+                    :min-length="PASSWORD_MIN_LENGTH"
+                    :passwordrules="PASSWORD_RULES"
+                    :required="true"
+                    data-testid="password-input"
+                  />
                   <PasswordScore v-model:valid="canRegister" :password="password" />
                 </CardContent>
                 <CardFooter>
@@ -337,7 +365,7 @@
                 </CardFooter>
               </Card>
             </form>
-            <form v-else @submit.prevent="login">
+            <form v-else id="login-form" name="login" method="post" @submit.prevent="login">
               <Card class="md:w-[500px]">
                 <CardHeader>
                   <CardTitle class="flex items-center gap-2">
@@ -357,8 +385,22 @@
                       <b>{{ $t("global.password") }}</b> demo
                     </p>
                   </template>
-                  <FormTextField v-model="email" :label="$t('global.email')" />
-                  <FormPassword v-model="loginPassword" :label="$t('global.password')" />
+                  <FormTextField
+                    id="login-username"
+                    v-model="email"
+                    :label="$t('global.email')"
+                    name="username"
+                    autocomplete="username"
+                    :required="true"
+                  />
+                  <FormPassword
+                    id="login-password"
+                    v-model="loginPassword"
+                    :label="$t('global.password')"
+                    name="password"
+                    autocomplete="current-password"
+                    :required="true"
+                  />
                   <div class="max-w-[140px]">
                     <FormCheckbox v-model="remember" :label="$t('index.remember_me')" />
                   </div>

--- a/frontend/pages/profile.vue
+++ b/frontend/pages/profile.vue
@@ -19,6 +19,7 @@
   import BaseSectionHeader from "@/components/Base/SectionHeader.vue";
   import DetailsSection from "@/components/global/DetailsSection/DetailsSection.vue";
   import PasswordScore from "~/components/global/PasswordScore.vue";
+  import { PASSWORD_MIN_LENGTH, PASSWORD_RULES } from "~/lib/passwords";
 
   const { t } = useI18n();
 
@@ -85,6 +86,7 @@
   async function changePassword() {
     passwordChange.loading = true;
     if (!passwordChange.isValid) {
+      passwordChange.loading = false;
       return;
     }
 
@@ -124,16 +126,30 @@
           <DialogTitle> {{ $t("profile.change_password") }} </DialogTitle>
         </DialogHeader>
 
-        <FormPassword
-          v-model="passwordChange.current"
-          :label="$t('profile.current_password')"
-          placeholder=""
-          class="mb-2"
-        />
-        <FormPassword v-model="passwordChange.new" :label="$t('profile.new_password')" placeholder="" />
-        <PasswordScore v-model:valid="passwordChange.isValid" :password="passwordChange.new" />
+        <form id="change-password-form" name="change-password" method="post" @submit.prevent="changePassword">
+          <FormPassword
+            id="current-password"
+            v-model="passwordChange.current"
+            :label="$t('profile.current_password')"
+            name="current-password"
+            autocomplete="current-password"
+            placeholder=""
+            :required="true"
+            class="mb-2"
+          />
+          <FormPassword
+            id="new-password"
+            v-model="passwordChange.new"
+            :label="$t('profile.new_password')"
+            name="new-password"
+            autocomplete="new-password"
+            placeholder=""
+            :min-length="PASSWORD_MIN_LENGTH"
+            :passwordrules="PASSWORD_RULES"
+            :required="true"
+          />
+          <PasswordScore v-model:valid="passwordChange.isValid" :password="passwordChange.new" />
 
-        <form @submit.prevent="changePassword">
           <DialogFooter>
             <Button :disabled="!passwordChange.isValid || passwordChange.loading" type="submit">
               <MdiLoading v-if="passwordChange.loading" class="animate-spin" />


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

I noticed that 1Password was not able to autofill my Homebox login details at all. That meant I had to copy and paste my login details manually, which is both less convenient and less secure than letting the password manager fill them directly.

This PR updates the auth-related forms so password managers can correctly recognize the login, registration, and change-password fields. With the added form metadata and autocomplete hints, password managers can now autofill existing login passwords and offer/save generated passwords in the right places.

The change follows standard form semantics and autocomplete conventions documented by 1Password's compatible website guidance, but the implementation is not 1Password-specific. It uses the generic markup that browsers and password managers rely on.

Changes include:

- Pass common input attributes through the shared `FormTextField` and `FormPassword` components.
- Add stable `id`, `name`, `method`, `required`, and autocomplete metadata to the login and registration forms.
- Mark login passwords with `autocomplete="current-password"` and generated/new passwords with `autocomplete="new-password"`.
- Add password-manager metadata to the change-password form while keeping the standard current-password/new-password structure.
- Add shared password policy constants for the frontend minimum length and `passwordrules` hint.
- Preserve `data-testid` on the `FormTextField` wrapper while forwarding other fallthrough attrs to the underlying input.

Separate small fixes included because they were exposed while adding the new metadata:

- Fix the shared `FormTextField` counter for min-only fields. Previously a field with only `minLength` displayed confusing output like `6/-1`; it now shows `6 (min 6)`.
- Clear the change-password loading state when submission is blocked by invalid password strength.

## Which issue(s) this PR fixes:

N/A — no linked issue.

## Special notes for your reviewer:

Please review this as a general password-manager compatibility improvement rather than a 1Password-specific integration. The implementation follows 1Password's published guidance because it documents the standard form markup and autocomplete patterns that browsers and password managers use.

The change-password form intentionally avoids speculative extras such as a hidden username field or a confirmation password field because manual testing using a locally deployed instance did not show that they improved 1Password's update prompt behavior.

No Playwright/e2e coverage is included because the behavior depends on browser/password-manager heuristics and is better validated by hand with a real password manager.

## Testing

- `pnpm exec eslint lib/passwords/index.ts lib/passwords/index.test.ts pages/index.vue pages/profile.vue --max-warnings=0`
- `vitest run lib/passwords/index.test.ts`
- `pnpm --dir frontend run build`
- `git diff --check upstream/main...HEAD`
- `timeout 15m codex review --base upstream/main` — no discrete, actionable regressions found.
- Manual testing using a locally deployed instance with 1Password: login and registration password-manager behavior works locally.
- Manual smoke test: registration password field shows the minimum-length counter as `6 (min 6)` instead of `6/-1`.

## AI Disclosure

Code drafted with an AI coding assistant, reviewed and modified by hand before submission. No automated browser tests were added; testing by hand with a real password manager was completed locally before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a stuck loading state when password-change form validation fails.

* **New Features**
  * Password fields now enforce the configured minimum length and password-strength rules.
  * Forms and form fields include explicit HTML form attributes, improved accessibility with consistent ids/labels, and better browser autocomplete behavior.
  * Added a localized message for minimum-password-length validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->