### PR TITLE
fix: print label uses wrong tenant on mobile

### DIFF
--- a/frontend/components/global/LabelMaker.vue
+++ b/frontend/components/global/LabelMaker.vue
@@ -78,11 +78,11 @@
   }
 
   function getLabelUrl(print: boolean): string {
-    const { selectedId } = useCollections();
+    const prefs = useViewPreferences();
     const params: Record<string, QueryValue> = { print };
 
-    if (selectedId.value) {
-      params.tenant = selectedId.value;
+    if (prefs.value.collectionId) {
+      params.tenant = prefs.value.collectionId;
     }
 
     if (props.type === "item" || props.type === "entity") {


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

On mobile, opening **Print Label** on an item from a non-default collection rendered the label for a different item - the item that happened to share the same `assetId` in the **default** collection. Switching the mobile browser to "desktop mode" worked around it; on desktop it always worked.

### Root cause

`LabelMaker.vue#getLabelUrl` read the active tenant from `useCollections().selectedId` and appended it as a `?tenant=` query param. `selectedId` is a module-level ref that is only populated when `Collection/Selector.vue` runs `useCollections().load()` in its `onMounted` hook.

The Selector lives inside the layout's `<Sidebar>`. On desktop the sidebar is a regular always-mounted `<div>`. On mobile (`components/ui/sidebar/Sidebar.vue` lines 29–43) it's rendered inside a `<Sheet>` (Reka UI `DialogPortal` / `DialogContent`), which is **conditionally rendered** - its slot is not mounted until the user opens the hamburger menu. Until that happens, `selectedId.value` is `null`, so:

1. The label URL is built without `?tenant=…`.
2. The backend's `mwTenant` middleware falls back to `user.DefaultGroupID`.
3. `HandleGetAssetLabel` calls `QueryByAssetID(auth, defaultGroupID, assetID)`. Because asset ids are tenant-scoped sequential numbers (e.g. `000-001`), the lookup happily returns a **different** item with the same id from the default collection.

This also explains the "no network request on mobile" symptom: with the tenant param missing, the URL on mobile is byte-identical to the cached URL from a previous visit to the default collection's matching asset id, so the browser serves it from cache without firing a request. On desktop the URL includes a unique tenant uuid, so it never collides with the cache.

### Fix

- `frontend/components/global/LabelMaker.vue` - read the active tenant from `useViewPreferences().value.collectionId` instead of `useCollections().selectedId`. Preferences are persisted via `useLocalStorage` and updated by `useCollections.set()` / `load()` whenever the user switches collection, so they don't depend on the Selector ever being mounted.

This is the same fix [@tonyaellie](https://github.com/tonyaellie) applied to attachment URLs in `lib/api/base/base-api.ts` in [`24e79952`](https://github.com/sysadminsmedia/homebox/commit/24e79952) ("fix: use prefs instead of use collection for attachments"). `LabelMaker.vue` was missed by that earlier pass.

## Which issue(s) this PR fixes:

none

## Special notes:

I audited every consumer of `useCollections()`. Two other files have the same root cause but a different user-visible symptom - both early-return when `selectedCollection.value` is null:

- `frontend/pages/collection/index.vue` (members page) - `loadMembers()` (line 90), `isActionDisabled` (line 87), `handleLeaveCollection` (line 123).
- `frontend/pages/collection/index/settings.vue` - `loadSettings()` (line 34), `save()` (line 94).

If a user deep-links / bookmarks `/collection/members` or `/collection/settings` on mobile and lands on it without ever opening the sidebar, they'll see an empty members list or a "Select a collection" empty state. Opening and closing the sidebar mounts the Selector once, populates `selectedId`, and the page works. The underlying API calls would actually succeed because `base-api.ts` already reads from prefs.

Two ways to fix these, both reasonable - happy to do either as a follow-up:

1. **Local fix**, mirroring this PR: switch the `selectedCollection.value` checks/reads in those two files to use `prefs.value.collectionId` (and re-derive the collection from `collections.value` when the display name is needed).
2. **Layout-level fix**: call `void useCollections().load()` once in `layouts/default.vue`'s `onMounted`. `load()` already self-guards against duplicate / concurrent calls (see `use-collections.ts:22-25`), so this is safe and would populate `selectedId` for every authenticated page, fixing the latent collection-page issue and any future component that reads `selectedId` directly.

A couple of other call sites build `/qrcode?data=…` URLs without a tenant param (`components/global/PageQRCode.vue`, `pages/reports/label-generator.vue`), but the `/qrcode` endpoint just renders the supplied `data` string into a QR image, so the rendered output doesn't depend on the active tenant - no visible bug there.

## Testing

- [ ] In a multi-collection account with asset id `000-001` present in two collections, open the non-default collection's `000-001` item on a mobile viewport (or hard-reload mobile after clearing cache so the previous bad cache entry is gone).
- [ ] Click **Print Label**. Confirm DevTools → Network shows a fresh request to `/api/v1/labelmaker/asset/000-001?print=false&tenant=<non-default-uuid>` and the rendered image shows the correct item's name and parent location.
- [ ] Repeat on desktop - no regression.
- [ ] Test an item without an `assetId` (LabelMaker is invoked with `type="item"` / `id=item.id`) and a location detail page (`type="location"`) to confirm the other branches of `getLabelUrl()` still work.

---

Disclaimer: I have written this MR with the help of Claude Code