### PR TITLE
Add public found-item page for QR scans

### DIFF
--- a/backend/app/api/app.go
+++ b/backend/app/api/app.go
@@ -21,6 +21,7 @@ type app struct {
 	bus                 *eventbus.EventBus
 	authLimiter         *authRateLimiter
 	notifierTestLimiter *simpleRateLimiter
+	publicFoundLimiter  *simpleRateLimiter
 	otel                *otel.Provider
 }
 
@@ -39,6 +40,7 @@ func new(conf *config.Config) *app {
 
 	s.authLimiter = newAuthRateLimiter(s.conf.Auth.RateLimit)
 	s.notifierTestLimiter = newSimpleRateLimiter(10, time.Minute, s.conf.Options.TrustProxy) // 10 requests per minute
+	s.publicFoundLimiter = newSimpleRateLimiter(30, time.Minute, s.conf.Options.TrustProxy)  // 30 requests per minute
 
 	return s
 }

--- a/backend/app/api/handlers/v1/v1_ctrl_public_found.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_public_found.go
@@ -9,10 +9,18 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/hay-kot/httpkit/errchain"
 	"github.com/hay-kot/httpkit/server"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/repo"
 	"github.com/sysadminsmedia/homebox/backend/internal/sys/validate"
 	"github.com/sysadminsmedia/homebox/backend/internal/web/adapters"
 )
+
+func publicFoundRequestError(err error) error {
+	if ent.IsNotFound(err) {
+		return validate.NewRequestError(errors.New("not found"), http.StatusNotFound)
+	}
+	return validate.NewRequestError(err, http.StatusInternalServerError)
+}
 
 // HandlePublicFoundItemGet godoc
 //
@@ -31,7 +39,7 @@ func (ctrl *V1Controller) HandlePublicFoundItemGet() errchain.HandlerFunc {
 
 		out, err := ctrl.repo.Entities.GetPublicFoundByID(r.Context(), ID)
 		if err != nil {
-			return validate.NewRequestError(err, http.StatusNotFound)
+			return publicFoundRequestError(err)
 		}
 
 		return server.JSON(w, http.StatusOK, out)
@@ -59,7 +67,7 @@ func (ctrl *V1Controller) HandlePublicFoundAssetGet() errchain.HandlerFunc {
 
 		out, err := ctrl.repo.Entities.GetPublicFoundByAssetID(r.Context(), repo.AssetID(assetID))
 		if err != nil {
-			return validate.NewRequestError(errors.New("not found"), http.StatusNotFound)
+			return publicFoundRequestError(err)
 		}
 
 		return server.JSON(w, http.StatusOK, out)

--- a/backend/app/api/handlers/v1/v1_ctrl_public_found.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_public_found.go
@@ -1,0 +1,67 @@
+package v1
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/hay-kot/httpkit/errchain"
+	"github.com/hay-kot/httpkit/server"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/repo"
+	"github.com/sysadminsmedia/homebox/backend/internal/sys/validate"
+	"github.com/sysadminsmedia/homebox/backend/internal/web/adapters"
+)
+
+// HandlePublicFoundItemGet godoc
+//
+//	@Summary	Get public found item contact
+//	@Tags		Public
+//	@Produce	json
+//	@Param		id	path		string	true	"Item ID"
+//	@Success	200	{object}	repo.PublicFoundEntity
+//	@Router		/v1/public/found/item/{id} [GET]
+func (ctrl *V1Controller) HandlePublicFoundItemGet() errchain.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		ID, err := adapters.RouteUUID(r, "id")
+		if err != nil {
+			return validate.NewRequestError(err, http.StatusBadRequest)
+		}
+
+		out, err := ctrl.repo.Entities.GetPublicFoundByID(r.Context(), ID)
+		if err != nil {
+			return validate.NewRequestError(err, http.StatusNotFound)
+		}
+
+		return server.JSON(w, http.StatusOK, out)
+	}
+}
+
+// HandlePublicFoundAssetGet godoc
+//
+//	@Summary	Get public found asset contact
+//	@Tags		Public
+//	@Produce	json
+//	@Param		id	path		string	true	"Asset ID"
+//	@Success	200	{object}	repo.PublicFoundEntity
+//	@Router		/v1/public/found/asset/{id} [GET]
+func (ctrl *V1Controller) HandlePublicFoundAssetGet() errchain.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		assetIDParam := strings.ReplaceAll(chi.URLParam(r, "id"), "-", "")
+		assetID, err := strconv.ParseInt(assetIDParam, 10, 64)
+		if err != nil {
+			return validate.NewRequestError(err, http.StatusBadRequest)
+		}
+		if repo.AssetID(assetID).Nil() {
+			return validate.NewRequestError(fmt.Errorf("invalid asset id"), http.StatusBadRequest)
+		}
+
+		out, err := ctrl.repo.Entities.GetPublicFoundByAssetID(r.Context(), repo.AssetID(assetID))
+		if err != nil {
+			return validate.NewRequestError(fmt.Errorf("failed to find asset id"), http.StatusNotFound)
+		}
+
+		return server.JSON(w, http.StatusOK, out)
+	}
+}

--- a/backend/app/api/handlers/v1/v1_ctrl_public_found.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_public_found.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -51,15 +51,15 @@ func (ctrl *V1Controller) HandlePublicFoundAssetGet() errchain.HandlerFunc {
 		assetIDParam := strings.ReplaceAll(chi.URLParam(r, "id"), "-", "")
 		assetID, err := strconv.ParseInt(assetIDParam, 10, 64)
 		if err != nil {
-			return validate.NewRequestError(err, http.StatusBadRequest)
+			return validate.NewRequestError(errors.New("not found"), http.StatusNotFound)
 		}
 		if repo.AssetID(assetID).Nil() {
-			return validate.NewRequestError(fmt.Errorf("invalid asset id"), http.StatusBadRequest)
+			return validate.NewRequestError(errors.New("not found"), http.StatusNotFound)
 		}
 
 		out, err := ctrl.repo.Entities.GetPublicFoundByAssetID(r.Context(), repo.AssetID(assetID))
 		if err != nil {
-			return validate.NewRequestError(fmt.Errorf("failed to find asset id"), http.StatusNotFound)
+			return validate.NewRequestError(errors.New("not found"), http.StatusNotFound)
 		}
 
 		return server.JSON(w, http.StatusOK, out)

--- a/backend/app/api/middleware_ratelimit_test.go
+++ b/backend/app/api/middleware_ratelimit_test.go
@@ -10,7 +10,12 @@ import (
 	"github.com/sysadminsmedia/homebox/backend/internal/sys/config"
 )
 
-const proxyRemoteAddr = "10.0.0.1:1234"
+const (
+	proxyRemoteAddr     = "10.0.0.1:1234"
+	directConnection    = "DirectConnection"
+	proxyXRealIP        = "ProxyXRealIP"
+	rateLimitTestClient = "192.168.1.1"
+)
 
 func TestSimpleRateLimiter(t *testing.T) {
 	type testCase struct {
@@ -21,12 +26,12 @@ func TestSimpleRateLimiter(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name:       "DirectConnection",
+			name:       directConnection,
 			trustProxy: false,
 			setupReq:   func(r *http.Request, ip string) { r.RemoteAddr = ip + ":1234" },
 		},
 		{
-			name:       "ProxyXRealIP",
+			name:       proxyXRealIP,
 			trustProxy: true,
 			setupReq: func(r *http.Request, ip string) {
 				r.RemoteAddr = proxyRemoteAddr // Proxy IP
@@ -48,7 +53,7 @@ func TestSimpleRateLimiter(t *testing.T) {
 			// Create a rate limiter that allows 3 requests per 10 seconds
 			limiter := newSimpleRateLimiter(3, 10*time.Second, tc.trustProxy)
 			t.Cleanup(func() { limiter.Stop() })
-			clientIP := "192.168.1.1"
+			clientIP := rateLimitTestClient
 
 			// Helper to get IP
 			getIP := func(ip string) string {
@@ -96,12 +101,12 @@ func TestSimpleRateLimiterRefill(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name:       "DirectConnection",
+			name:       directConnection,
 			trustProxy: false,
 			setupReq:   func(r *http.Request, ip string) { r.RemoteAddr = ip + ":1234" },
 		},
 		{
-			name:       "ProxyXRealIP",
+			name:       proxyXRealIP,
 			trustProxy: true,
 			setupReq: func(r *http.Request, ip string) {
 				r.RemoteAddr = proxyRemoteAddr // Proxy IP
@@ -115,7 +120,7 @@ func TestSimpleRateLimiterRefill(t *testing.T) {
 			// Create a rate limiter that allows 2 requests per 100ms
 			limiter := newSimpleRateLimiter(2, 100*time.Millisecond, tc.trustProxy)
 			t.Cleanup(func() { limiter.Stop() })
-			clientIP := "192.168.1.1"
+			clientIP := rateLimitTestClient
 
 			// Helper to get IP
 			getIP := func(ip string) string {
@@ -157,12 +162,12 @@ func TestSimpleRateLimiterConcurrent(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name:       "DirectConnection",
+			name:       directConnection,
 			trustProxy: false,
 			setupReq:   func(r *http.Request, ip string) { r.RemoteAddr = ip + ":1234" },
 		},
 		{
-			name:       "ProxyXRealIP",
+			name:       proxyXRealIP,
 			trustProxy: true,
 			setupReq: func(r *http.Request, ip string) {
 				r.RemoteAddr = proxyRemoteAddr // Proxy IP
@@ -175,7 +180,7 @@ func TestSimpleRateLimiterConcurrent(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			limiter := newSimpleRateLimiter(10, time.Second, tc.trustProxy)
 			t.Cleanup(func() { limiter.Stop() })
-			clientIP := "192.168.1.1"
+			clientIP := rateLimitTestClient
 
 			// Helper to get IP
 			getIP := func(ip string) string {
@@ -222,12 +227,12 @@ func TestSimpleRateLimiterCleanup(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name:       "DirectConnection",
+			name:       directConnection,
 			trustProxy: false,
 			setupReq:   func(r *http.Request, ip string) { r.RemoteAddr = ip + ":1234" },
 		},
 		{
-			name:       "ProxyXRealIP",
+			name:       proxyXRealIP,
 			trustProxy: true,
 			setupReq: func(r *http.Request, ip string) {
 				r.RemoteAddr = proxyRemoteAddr // Proxy IP
@@ -250,7 +255,7 @@ func TestSimpleRateLimiterCleanup(t *testing.T) {
 			}
 
 			// Add entries for multiple IPs
-			ips := []string{"192.168.1.1", "192.168.1.2", "192.168.1.3", "192.168.1.4", "192.168.1.5"}
+			ips := []string{rateLimitTestClient, "192.168.1.2", "192.168.1.3", "192.168.1.4", "192.168.1.5"}
 			for _, ip := range ips {
 				limiter.allow(getIP(ip))
 			}
@@ -291,12 +296,12 @@ func TestSimpleRateLimiterCleanupPreservesActive(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name:       "DirectConnection",
+			name:       directConnection,
 			trustProxy: false,
 			setupReq:   func(r *http.Request, ip string) { r.RemoteAddr = ip + ":1234" },
 		},
 		{
-			name:       "ProxyXRealIP",
+			name:       proxyXRealIP,
 			trustProxy: true,
 			setupReq: func(r *http.Request, ip string) {
 				r.RemoteAddr = proxyRemoteAddr // Proxy IP
@@ -317,7 +322,7 @@ func TestSimpleRateLimiterCleanupPreservesActive(t *testing.T) {
 				return limiter.getClientIP(req, limiter.trustProxy)
 			}
 
-			activeIP := "192.168.1.1"
+			activeIP := rateLimitTestClient
 			staleIP := "192.168.1.2"
 
 			// Create a stale entry

--- a/backend/app/api/routes.go
+++ b/backend/app/api/routes.go
@@ -88,8 +88,14 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 
 		r.Post("/users/register", chain.ToHandlerFunc(v1Ctrl.HandleUserRegistration()))
 		r.Post("/users/login", chain.ToHandlerFunc(v1Ctrl.HandleAuthLogin(providers...), a.mwAuthRateLimit))
-		r.Get("/public/found/item/{id}", chain.ToHandlerFunc(v1Ctrl.HandlePublicFoundItemGet()))
-		r.Get("/public/found/asset/{id}", chain.ToHandlerFunc(v1Ctrl.HandlePublicFoundAssetGet()))
+
+		// Public found-item lookups are intentionally unauthenticated so QR labels
+		// can help return lost items. Rate limiting reduces asset-id enumeration.
+		publicFoundMW := []errchain.Middleware{
+			a.publicFoundLimiter.middleware,
+		}
+		r.Get("/public/found/item/{id}", chain.ToHandlerFunc(v1Ctrl.HandlePublicFoundItemGet(), publicFoundMW...))
+		r.Get("/public/found/asset/{id}", chain.ToHandlerFunc(v1Ctrl.HandlePublicFoundAssetGet(), publicFoundMW...))
 
 		if a.conf.OIDC.Enabled {
 			r.Get("/users/login/oidc", chain.ToHandlerFunc(v1Ctrl.HandleOIDCLogin(), a.mwAuthRateLimit))

--- a/backend/app/api/routes.go
+++ b/backend/app/api/routes.go
@@ -88,6 +88,8 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 
 		r.Post("/users/register", chain.ToHandlerFunc(v1Ctrl.HandleUserRegistration()))
 		r.Post("/users/login", chain.ToHandlerFunc(v1Ctrl.HandleAuthLogin(providers...), a.mwAuthRateLimit))
+		r.Get("/public/found/item/{id}", chain.ToHandlerFunc(v1Ctrl.HandlePublicFoundItemGet()))
+		r.Get("/public/found/asset/{id}", chain.ToHandlerFunc(v1Ctrl.HandlePublicFoundAssetGet()))
 
 		if a.conf.OIDC.Enabled {
 			r.Get("/users/login/oidc", chain.ToHandlerFunc(v1Ctrl.HandleOIDCLogin(), a.mwAuthRateLimit))

--- a/backend/internal/core/services/reporting/import.go
+++ b/backend/internal/core/services/reporting/import.go
@@ -40,9 +40,16 @@ func determineSeparator(data []byte) (rune, error) {
 	}
 }
 
-// separatorDetectionBufferSize is the buffer size for reading CSV headers
-// to detect the separator (comma vs tab)
-const separatorDetectionBufferSize = 4096
+const (
+	homeboxFieldHeaderPrefix = "HB.field."
+	homeboxHeaderPrefix      = "HB."
+	homeboxLocationHeader    = "HB.location"
+	homeboxNameHeader        = "HB.name"
+
+	// separatorDetectionBufferSize is the buffer size for reading CSV headers
+	// to detect the separator (comma vs tab)
+	separatorDetectionBufferSize = 4096
+)
 
 // readRawCsv reads a CSV file and returns the raw data as a 2D string array
 // It determines the separator used in the CSV file and returns an error if
@@ -80,16 +87,16 @@ func parseHeaders(headers []string) (hbHeaders map[string]int, fieldHeaders []st
 	hbHeaders = map[string]int{} // initialize map
 
 	for col, h := range headers {
-		if strings.HasPrefix(h, "HB.field.") {
+		if strings.HasPrefix(h, homeboxFieldHeaderPrefix) {
 			fieldHeaders = append(fieldHeaders, h)
 		}
 
-		if strings.HasPrefix(h, "HB.") {
+		if strings.HasPrefix(h, homeboxHeaderPrefix) {
 			hbHeaders[h] = col
 		}
 	}
 
-	required := []string{"HB.location", "HB.name"}
+	required := []string{homeboxLocationHeader, homeboxNameHeader}
 	if !lo.EveryBy(required, func(h string) bool {
 		return lo.HasKey(hbHeaders, h)
 	}) {

--- a/backend/internal/core/services/reporting/io_sheet_test.go
+++ b/backend/internal/core/services/reporting/io_sheet_test.go
@@ -23,6 +23,12 @@ var (
 	customTypesImportCSV []byte
 )
 
+const (
+	fieldHeader1 = "HB.field.1"
+	fieldHeader2 = "HB.field.2"
+	fieldHeader3 = "HB.field.3"
+)
+
 func TestSheet_Read(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -130,27 +136,27 @@ func Test_parseHeaders(t *testing.T) {
 		},
 		{
 			name:       "field headers only",
-			rawHeaders: []string{"HB.location", "HB.name", "HB.field.1", "HB.field.2", "HB.field.3"},
+			rawHeaders: []string{homeboxLocationHeader, homeboxNameHeader, fieldHeader1, fieldHeader2, fieldHeader3},
 			wantHbHeaders: map[string]int{
-				"HB.location": 0,
-				"HB.name":     1,
-				"HB.field.1":  2,
-				"HB.field.2":  3,
-				"HB.field.3":  4,
+				homeboxLocationHeader: 0,
+				homeboxNameHeader:     1,
+				fieldHeader1:          2,
+				fieldHeader2:          3,
+				fieldHeader3:          4,
 			},
-			wantFieldHeaders: []string{"HB.field.1", "HB.field.2", "HB.field.3"},
+			wantFieldHeaders: []string{fieldHeader1, fieldHeader2, fieldHeader3},
 			wantErr:          false,
 		},
 		{
 			name:       "mixed headers",
-			rawHeaders: []string{"Header 1", "HB.name", "Header 2", "HB.field.2", "Header 3", "HB.field.3", "HB.location"},
+			rawHeaders: []string{"Header 1", homeboxNameHeader, "Header 2", fieldHeader2, "Header 3", fieldHeader3, homeboxLocationHeader},
 			wantHbHeaders: map[string]int{
-				"HB.name":     1,
-				"HB.field.2":  3,
-				"HB.field.3":  5,
-				"HB.location": 6,
+				homeboxNameHeader:     1,
+				fieldHeader2:          3,
+				fieldHeader3:          5,
+				homeboxLocationHeader: 6,
 			},
-			wantFieldHeaders: []string{"HB.field.2", "HB.field.3"},
+			wantFieldHeaders: []string{fieldHeader2, fieldHeader3},
 			wantErr:          false,
 		},
 	}

--- a/backend/internal/data/repo/repo_entities.go
+++ b/backend/internal/data/repo/repo_entities.go
@@ -553,7 +553,7 @@ func (r *EntityRepository) GetPublicFoundByAssetID(ctx context.Context, assetID 
 	span.SetAttributes(attribute.Int("entity.matches", len(results)))
 	switch len(results) {
 	case 0:
-		err := fmt.Errorf("asset id not found")
+		err := &ent.NotFoundError{}
 		recordSpanError(span, err)
 		return PublicFoundEntity{}, err
 	case 1:

--- a/backend/internal/data/repo/repo_entities.go
+++ b/backend/internal/data/repo/repo_entities.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/maintenanceentry"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/predicate"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/tag"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/user"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/types"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -220,6 +221,13 @@ type (
 	EntityOutCount struct {
 		EntitySummary
 		ItemCount float64 `json:"itemCount"`
+	}
+
+	PublicFoundEntity struct {
+		AssetID         AssetID `json:"assetId,string"`
+		ContactName     string  `json:"contactName,omitempty"`
+		ContactEmail    string  `json:"contactEmail,omitempty"`
+		MultipleMatches bool    `json:"multipleMatches,omitempty"`
 	}
 )
 
@@ -468,6 +476,98 @@ func (r *EntityRepository) GetOne(ctx context.Context, id uuid.UUID) (EntityOut,
 	out, err := r.getOne(ctx, entity.ID(id))
 	recordSpanError(span, err)
 	return out, err
+}
+
+func withPublicFoundContact(q *ent.EntityQuery) *ent.EntityQuery {
+	return q.WithGroup(func(gq *ent.GroupQuery) {
+		gq.WithUsers(func(uq *ent.UserQuery) {
+			uq.Order(ent.Asc(user.FieldRole), ent.Asc(user.FieldEmail))
+		})
+	})
+}
+
+func mapPublicFoundEntity(e *ent.Entity) (PublicFoundEntity, error) {
+	out := PublicFoundEntity{
+		AssetID: AssetID(e.AssetID),
+	}
+
+	if e.Edges.Group == nil || len(e.Edges.Group.Edges.Users) == 0 {
+		return out, fmt.Errorf("no contact user found for entity")
+	}
+
+	contact := e.Edges.Group.Edges.Users[0]
+	for _, candidate := range e.Edges.Group.Edges.Users {
+		if candidate.Role == user.RoleOwner {
+			contact = candidate
+			break
+		}
+	}
+
+	out.ContactName = contact.Name
+	out.ContactEmail = contact.Email
+	return out, nil
+}
+
+func (r *EntityRepository) GetPublicFoundByID(ctx context.Context, id uuid.UUID) (PublicFoundEntity, error) {
+	ctx, span := entityTracer().Start(ctx, "repo.EntityRepository.GetPublicFoundByID",
+		trace.WithAttributes(attribute.String("entity.id", id.String())))
+	defer span.End()
+
+	result, err := withPublicFoundContact(r.db.Entity.Query()).
+		Where(entity.ID(id)).
+		Only(ctx)
+	if err != nil {
+		recordSpanError(span, err)
+		return PublicFoundEntity{}, err
+	}
+
+	out, err := mapPublicFoundEntity(result)
+	if err != nil {
+		recordSpanError(span, err)
+		return out, err
+	}
+	span.SetAttributes(attribute.Int64("entity.asset_id", int64(out.AssetID)))
+	return out, nil
+}
+
+func (r *EntityRepository) GetPublicFoundByAssetID(ctx context.Context, assetID AssetID) (PublicFoundEntity, error) {
+	ctx, span := entityTracer().Start(ctx, "repo.EntityRepository.GetPublicFoundByAssetID",
+		trace.WithAttributes(attribute.Int64("entity.asset_id", int64(assetID))))
+	defer span.End()
+
+	if assetID.Nil() {
+		err := fmt.Errorf("invalid asset id")
+		recordSpanError(span, err)
+		return PublicFoundEntity{}, err
+	}
+
+	results, err := withPublicFoundContact(r.db.Entity.Query()).
+		Where(entity.AssetID(int64(assetID))).
+		Limit(2).
+		All(ctx)
+	if err != nil {
+		recordSpanError(span, err)
+		return PublicFoundEntity{}, err
+	}
+
+	span.SetAttributes(attribute.Int("entity.matches", len(results)))
+	switch len(results) {
+	case 0:
+		err := fmt.Errorf("asset id not found")
+		recordSpanError(span, err)
+		return PublicFoundEntity{}, err
+	case 1:
+		out, err := mapPublicFoundEntity(results[0])
+		if err != nil {
+			recordSpanError(span, err)
+		}
+		return out, err
+	default:
+		return PublicFoundEntity{
+			AssetID:         assetID,
+			MultipleMatches: true,
+		}, nil
+	}
 }
 
 func (r *EntityRepository) CheckRef(ctx context.Context, gid uuid.UUID, ref string) (bool, error) {

--- a/backend/internal/data/repo/repo_entities_test.go
+++ b/backend/internal/data/repo/repo_entities_test.go
@@ -124,6 +124,74 @@ func TestEntityRepository_GetOne(t *testing.T) {
 	}
 }
 
+func TestEntityRepository_GetPublicFoundByID(t *testing.T) {
+	ctx := context.Background()
+	item := entityFactory()
+	item.AssetID = AssetID(123456)
+
+	created, err := tRepos.Entities.Create(ctx, tGroup.ID, item)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tRepos.Entities.Delete(ctx, created.ID)
+	})
+
+	found, err := tRepos.Entities.GetPublicFoundByID(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, item.AssetID, found.AssetID)
+	assert.Equal(t, tUser.Email, found.ContactEmail)
+	assert.NotEmpty(t, found.ContactName)
+	assert.False(t, found.MultipleMatches)
+}
+
+func TestEntityRepository_GetPublicFoundByAssetIDRequiresUniqueMatch(t *testing.T) {
+	ctx := context.Background()
+	assetID := AssetID(234567)
+
+	first := entityFactory()
+	first.AssetID = assetID
+	firstItem, err := tRepos.Entities.Create(ctx, tGroup.ID, first)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tRepos.Entities.Delete(ctx, firstItem.ID)
+	})
+
+	found, err := tRepos.Entities.GetPublicFoundByAssetID(ctx, assetID)
+	require.NoError(t, err)
+	assert.Equal(t, assetID, found.AssetID)
+	assert.Equal(t, tUser.Email, found.ContactEmail)
+	assert.False(t, found.MultipleMatches)
+
+	otherGroup, err := tRepos.Groups.GroupCreate(ctx, "found-item-ambiguous", uuid.Nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tRepos.Groups.GroupDelete(ctx, otherGroup.ID)
+	})
+
+	otherPassword := "password"
+	_, err = tRepos.Users.Create(ctx, UserCreate{
+		Name:           "Other Owner",
+		Email:          fk.Email(),
+		Password:       &otherPassword,
+		DefaultGroupID: otherGroup.ID,
+		IsOwner:        true,
+	})
+	require.NoError(t, err)
+
+	second := entityFactory()
+	second.AssetID = assetID
+	secondItem, err := tRepos.Entities.Create(ctx, otherGroup.ID, second)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tRepos.Entities.Delete(ctx, secondItem.ID)
+	})
+
+	ambiguous, err := tRepos.Entities.GetPublicFoundByAssetID(ctx, assetID)
+	require.NoError(t, err)
+	assert.Equal(t, assetID, ambiguous.AssetID)
+	assert.True(t, ambiguous.MultipleMatches)
+	assert.Empty(t, ambiguous.ContactEmail)
+}
+
 func TestEntityRepository_GetAll(t *testing.T) {
 	length := 10
 	expected := useEntities(t, length)

--- a/backend/internal/data/repo/repo_items_search_test.go
+++ b/backend/internal/data/repo/repo_items_search_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/sysadminsmedia/homebox/backend/pkgs/textutils"
 )
 
+const accentedElectronica = "electrónica"
+
 func TestEntityRepository_AccentInsensitiveSearch(t *testing.T) {
 	// Test cases for accent-insensitive search
 	testCases := []struct {
@@ -18,22 +20,22 @@ func TestEntityRepository_AccentInsensitiveSearch(t *testing.T) {
 	}{
 		{
 			name:        "Spanish accented item, search without accents",
-			itemName:    "electrónica",
+			itemName:    accentedElectronica,
 			searchQuery: "electronica",
 			shouldMatch: true,
 			description: "Should find 'electrónica' when searching for 'electronica'",
 		},
 		{
 			name:        "Spanish accented item, search with accents",
-			itemName:    "electrónica",
-			searchQuery: "electrónica",
+			itemName:    accentedElectronica,
+			searchQuery: accentedElectronica,
 			shouldMatch: true,
 			description: "Should find 'electrónica' when searching for 'electrónica'",
 		},
 		{
 			name:        "Non-accented item, search with accents",
 			itemName:    "electronica",
-			searchQuery: "electrónica",
+			searchQuery: accentedElectronica,
 			shouldMatch: true,
 			description: "Should find 'electronica' when searching for 'electrónica' (bidirectional search)",
 		},
@@ -186,7 +188,7 @@ func TestNormalizeSearchQueryIntegration(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"electrónica", "electronica"},
+		{accentedElectronica, "electronica"},
 		{"café", "cafe"},
 		{"ELECTRÓNICA", "electronica"},
 		{"Café París", "cafe paris"},

--- a/backend/internal/sys/validate/notifier_url_test.go
+++ b/backend/internal/sys/validate/notifier_url_test.go
@@ -6,6 +6,12 @@ import (
 	"github.com/sysadminsmedia/homebox/backend/internal/sys/config"
 )
 
+const (
+	privateIPv4Webhook = "generic://http://192.168.1.100/webhook"
+	privateIPv4CIDR    = "192.168.1.0/24"
+	ipv6ULAWebhook     = "generic://http://[fd00::1]/webhook"
+)
+
 func TestValidateNotifierURL(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -119,7 +125,7 @@ func TestValidateNotifierURL(t *testing.T) {
 			name: "allow list permits private IP",
 			url:  "generic://http://192.168.1.1/webhook",
 			config: config.NotifierConf{
-				AllowNets:      []string{"192.168.1.0/24"},
+				AllowNets:      []string{privateIPv4CIDR},
 				BlockLocalNets: true,
 			},
 			expectError: false,
@@ -128,7 +134,7 @@ func TestValidateNotifierURL(t *testing.T) {
 			name: "allow list blocks non-matching IP",
 			url:  "generic://http://10.0.0.1/webhook",
 			config: config.NotifierConf{
-				AllowNets: []string{"192.168.1.0/24"},
+				AllowNets: []string{privateIPv4CIDR},
 			},
 			expectError: true,
 		},
@@ -144,7 +150,7 @@ func TestValidateNotifierURL(t *testing.T) {
 			name: "block_nets blocks specific network",
 			url:  "generic://http://192.168.1.1/webhook",
 			config: config.NotifierConf{
-				BlockNets: []string{"192.168.1.0/24"},
+				BlockNets: []string{privateIPv4CIDR},
 			},
 			expectError: true,
 		},
@@ -152,7 +158,7 @@ func TestValidateNotifierURL(t *testing.T) {
 			name: "block_nets allows non-matching network",
 			url:  "generic://http://10.0.0.1/webhook",
 			config: config.NotifierConf{
-				BlockNets: []string{"192.168.1.0/24"},
+				BlockNets: []string{privateIPv4CIDR},
 			},
 			expectError: false,
 		},
@@ -176,8 +182,8 @@ func TestValidateNotifierURL(t *testing.T) {
 			name: "allow_nets takes precedence over block_nets",
 			url:  "generic://http://192.168.1.1/webhook",
 			config: config.NotifierConf{
-				AllowNets: []string{"192.168.1.0/24"},
-				BlockNets: []string{"192.168.1.0/24"},
+				AllowNets: []string{privateIPv4CIDR},
+				BlockNets: []string{privateIPv4CIDR},
 			},
 			expectError: false,
 		},
@@ -200,7 +206,7 @@ func TestValidateNotifierURL(t *testing.T) {
 		},
 		{
 			name: "ipv6_ula_blocked_by_bogon_nets",
-			url:  "generic://http://[fd00::1]/webhook",
+			url:  ipv6ULAWebhook,
 			config: config.NotifierConf{
 				BlockBogonNets: true,
 			},
@@ -208,7 +214,7 @@ func TestValidateNotifierURL(t *testing.T) {
 		},
 		{
 			name: "ipv6_ula_allowed_when_bogon_nets_not_blocked",
-			url:  "generic://http://[fd00::1]/webhook",
+			url:  ipv6ULAWebhook,
 			config: config.NotifierConf{
 				BlockBogonNets: false,
 			},
@@ -216,7 +222,7 @@ func TestValidateNotifierURL(t *testing.T) {
 		},
 		{
 			name: "ipv6_ula_allowed_via_allow_nets",
-			url:  "generic://http://[fd00::1]/webhook",
+			url:  ipv6ULAWebhook,
 			config: config.NotifierConf{
 				AllowNets:      []string{"fd00::/8"},
 				BlockBogonNets: true,
@@ -273,7 +279,7 @@ func TestValidateNotifierURL(t *testing.T) {
 		},
 		{
 			name: "ipv6_ula_blocked_by_local_nets",
-			url:  "generic://http://[fd00::1]/webhook",
+			url:  ipv6ULAWebhook,
 			config: config.NotifierConf{
 				BlockLocalNets: true,
 			},
@@ -281,7 +287,7 @@ func TestValidateNotifierURL(t *testing.T) {
 		},
 		{
 			name: "ipv6_ula_allowed_when_local_nets_not_blocked",
-			url:  "generic://http://[fd00::1]/webhook",
+			url:  ipv6ULAWebhook,
 			config: config.NotifierConf{
 				BlockLocalNets: false,
 			},
@@ -392,11 +398,11 @@ func TestValidateNotifierURL_InvalidCIDR_AllowNets(t *testing.T) {
 	}{
 		{
 			name: "invalid CIDR in AllowNets is skipped",
-			url:  "generic://http://192.168.1.100/webhook",
+			url:  privateIPv4Webhook,
 			config: config.NotifierConf{
 				AllowNets: []string{
-					"invalid-cidr",   // Invalid - should be logged and skipped
-					"192.168.1.0/24", // Valid - should match
+					"invalid-cidr",  // Invalid - should be logged and skipped
+					privateIPv4CIDR, // Valid - should match
 				},
 			},
 			expectError: false,
@@ -404,7 +410,7 @@ func TestValidateNotifierURL_InvalidCIDR_AllowNets(t *testing.T) {
 		},
 		{
 			name: "all CIDRs invalid in AllowNets",
-			url:  "generic://http://192.168.1.100/webhook",
+			url:  privateIPv4Webhook,
 			config: config.NotifierConf{
 				AllowNets: []string{
 					"invalid-cidr-1",
@@ -454,7 +460,7 @@ func TestValidateNotifierURL_InvalidCIDR_BlockNets(t *testing.T) {
 	}{
 		{
 			name: "invalid CIDR in BlockNets is skipped",
-			url:  "generic://http://192.168.1.100/webhook",
+			url:  privateIPv4Webhook,
 			config: config.NotifierConf{
 				BlockNets: []string{
 					"invalid-cidr", // Invalid - should be logged and skipped
@@ -466,11 +472,11 @@ func TestValidateNotifierURL_InvalidCIDR_BlockNets(t *testing.T) {
 		},
 		{
 			name: "invalid CIDR doesn't prevent valid blocking",
-			url:  "generic://http://192.168.1.100/webhook",
+			url:  privateIPv4Webhook,
 			config: config.NotifierConf{
 				BlockNets: []string{
 					"not-a-cidr",
-					"192.168.1.0/24", // Valid - should block
+					privateIPv4CIDR, // Valid - should block
 					"also-invalid",
 				},
 			},
@@ -479,7 +485,7 @@ func TestValidateNotifierURL_InvalidCIDR_BlockNets(t *testing.T) {
 		},
 		{
 			name: "all CIDRs invalid in BlockNets",
-			url:  "generic://http://192.168.1.100/webhook",
+			url:  privateIPv4Webhook,
 			config: config.NotifierConf{
 				BlockNets: []string{
 					"invalid-1",

--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -291,7 +291,12 @@
   import BaseModal from "@/components/App/CreateModal.vue";
   import { Label } from "@/components/ui/label";
   import { Input } from "@/components/ui/input";
-  import type { EntityCreate, EntityTemplateOut, EntityTemplateSummary, EntityOut } from "~~/lib/api/types/data-contracts";
+  import type {
+    EntityCreate,
+    EntityTemplateOut,
+    EntityTemplateSummary,
+    EntityOut,
+  } from "~~/lib/api/types/data-contracts";
   import { useTagStore } from "~/stores/tags";
   import { useLocationStore } from "~~/stores/locations";
   import MdiBarcode from "~icons/mdi/barcode";
@@ -390,7 +395,11 @@
     if (et?.defaultTemplateId && et.defaultTemplate) {
       const { data, error } = await api.templates.get(et.defaultTemplateId);
       if (!error && data) {
-        selectedTemplate.value = { id: data.id, name: data.name, description: data.description } as EntityTemplateSummary;
+        selectedTemplate.value = {
+          id: data.id,
+          name: data.name,
+          description: data.description,
+        } as EntityTemplateSummary;
         templateData.value = data;
         form.quantity = data.defaultQuantity;
         if (data.defaultName) form.name = data.defaultName;
@@ -657,7 +666,7 @@
     } else {
       // Normal item creation without template
       const out: EntityCreate = {
-        parentId: form.parentId || form.location.id as string,
+        parentId: form.parentId || (form.location.id as string),
         name: form.name,
         quantity: form.quantity,
         description: form.description,

--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -292,11 +292,12 @@
   import { Label } from "@/components/ui/label";
   import { Input } from "@/components/ui/input";
   import type {
-    EntityCreate,
     EntityTemplateOut,
     EntityTemplateSummary,
     EntityOut,
+    EntitySummary,
   } from "~~/lib/api/types/data-contracts";
+  import type { EntityCreateBody } from "~~/lib/api/classes/items";
   import { useTagStore } from "~/stores/tags";
   import { useLocationStore } from "~~/stores/locations";
   import MdiBarcode from "~icons/mdi/barcode";
@@ -584,8 +585,11 @@
           parent.value = data;
         }
 
-        if (data.location || data.parent) {
-          const loc = data.location || data.parent;
+        let loc: EntitySummary | null | undefined = data.parent;
+        if ("location" in data) {
+          loc = (data as EntityOut & { location?: EntitySummary | null }).location ?? loc;
+        }
+        if (loc) {
           parentItemLocationId = loc.id;
         }
 
@@ -665,14 +669,16 @@
       data = result.data;
     } else {
       // Normal item creation without template
-      const out: EntityCreate = {
+      const out: EntityCreateBody = {
         parentId: form.parentId || (form.location.id as string),
         name: form.name,
         quantity: form.quantity,
         description: form.description,
         tagIds: form.tags,
-        entityTypeId: selectedEntityType.value?.id,
       };
+      if (selectedEntityType.value) {
+        out.entityTypeId = selectedEntityType.value.id;
+      }
 
       const result = await api.items.create(out);
       error = result.error;

--- a/frontend/components/Location/CreateModal.vue
+++ b/frontend/components/Location/CreateModal.vue
@@ -67,11 +67,7 @@
 
       <template v-if="showAdvanced">
         <TagSelector v-model="form.tags" :tags="tags ?? []" />
-        <FormTextArea
-          v-model="form.notes"
-          label="Notes"
-          :max-length="1000"
-        />
+        <FormTextArea v-model="form.notes" label="Notes" :max-length="1000" />
       </template>
 
       <div class="mt-4 flex flex-row-reverse">
@@ -142,8 +138,8 @@
   import { Label } from "@/components/ui/label";
   import { Input } from "@/components/ui/input";
   import BaseModal from "@/components/App/CreateModal.vue";
-  import type { EntityTypeSummary } from "~~/lib/api/types/data-contracts";
-  import type { EntitySummary } from "~~/lib/api/types/data-contracts";
+  import type { EntityTypeSummary, EntitySummary } from "~~/lib/api/types/data-contracts";
+
   import { AttachmentTypes } from "~~/lib/api/types/non-generated";
   import { useDialog, useDialogHotkey } from "~/components/ui/dialog-provider";
   import { useTagStore } from "~/stores/tags";
@@ -171,8 +167,8 @@
   useDialogHotkey(DialogID.CreateLocation, { code: "Digit3", shift: true });
 
   // Entity type selection
-  const locationTypes = ref<import("~~/lib/api/types/data-contracts").EntityTypeSummary[]>([]);
-  const selectedEntityType = ref<import("~~/lib/api/types/data-contracts").EntityTypeSummary | null>(null);
+  const locationTypes = ref<EntityTypeSummary[]>([]);
+  const selectedEntityType = ref<EntityTypeSummary | null>(null);
   const showEntityTypeSelector = computed(() => locationTypes.value.length > 1);
 
   onMounted(async () => {

--- a/frontend/components/Location/CreateModal.vue
+++ b/frontend/components/Location/CreateModal.vue
@@ -67,7 +67,7 @@
 
       <template v-if="showAdvanced">
         <TagSelector v-model="form.tags" :tags="tags ?? []" />
-        <FormTextArea v-model="form.notes" label="Notes" :max-length="1000" />
+        <FormTextArea v-model="form.notes" :label="$t('components.location.create_modal.notes')" :max-length="1000" />
       </template>
 
       <div class="mt-4 flex flex-row-reverse">
@@ -139,6 +139,7 @@
   import { Input } from "@/components/ui/input";
   import BaseModal from "@/components/App/CreateModal.vue";
   import type { EntityTypeSummary, EntitySummary } from "~~/lib/api/types/data-contracts";
+  import type { EntityCreateBody } from "~~/lib/api/classes/items";
 
   import { AttachmentTypes } from "~~/lib/api/types/non-generated";
   import { useDialog, useDialogHotkey } from "~/components/ui/dialog-provider";
@@ -290,12 +291,18 @@
 
     if (shift?.value) close = false;
 
-    const { data, error } = await api.items.createLocation({
+    const locationRequest: EntityCreateBody = {
       name: form.name,
       description: form.description,
       parentId: form.parent ? form.parent.id : null,
-      entityTypeId: selectedEntityType.value?.id,
-    });
+      quantity: 1,
+      tagIds: form.tags,
+    };
+    if (selectedEntityType.value) {
+      locationRequest.entityTypeId = selectedEntityType.value.id;
+    }
+
+    const { data, error } = await api.items.createLocation(locationRequest);
 
     if (error) {
       loading.value = false;

--- a/frontend/components/Scanner/ARControls.vue
+++ b/frontend/components/Scanner/ARControls.vue
@@ -2,7 +2,13 @@
   <div class="pointer-events-none absolute inset-0 z-20 flex flex-col justify-between">
     <!-- Top bar -->
     <div class="pointer-events-auto flex items-center gap-3 bg-background/60 p-3 backdrop-blur-sm">
-      <Button variant="ghost" size="icon" :aria-label="t('scanner_ar.back')" :title="t('scanner_ar.back')" @click="$emit('back')">
+      <Button
+        variant="ghost"
+        size="icon"
+        :aria-label="t('scanner_ar.back')"
+        :title="t('scanner_ar.back')"
+        @click="$emit('back')"
+      >
         <MdiArrowLeft class="size-5" />
       </Button>
       <span class="text-sm font-semibold text-foreground">{{ t("scanner_ar.title") }}</span>

--- a/frontend/composables/use-api.ts
+++ b/frontend/composables/use-api.ts
@@ -37,7 +37,7 @@ export function useUserApi(): UserClient {
     headers["X-Tenant"] = prefs.value.collectionId;
   }
 
-  const requests = new Requests("", "", headers);
+  const requests = new Requests("", () => authCtx.apiToken || "", headers);
   requests.addResponseInterceptor(logger);
   requests.addResponseInterceptor(async r => {
     if (r.status === 401) {

--- a/frontend/composables/use-auth-context.ts
+++ b/frontend/composables/use-auth-context.ts
@@ -5,6 +5,7 @@ import type { UserClient } from "~~/lib/api/user";
 
 export interface IAuthContext {
   get token(): boolean | null;
+  get apiToken(): string | null;
   get attachmentToken(): string | null;
 
   /**
@@ -41,6 +42,7 @@ class AuthContext implements IAuthContext {
 
   user?: UserOut;
   private _token: CookieRef<string | null>;
+  private _apiToken: string | null = null;
   private _attachmentToken: CookieRef<string | null>;
 
   get token() {
@@ -50,6 +52,10 @@ class AuthContext implements IAuthContext {
 
   get attachmentToken() {
     return this._attachmentToken.value;
+  }
+
+  get apiToken() {
+    return import.meta.client ? this._apiToken : null;
   }
 
   private constructor(token: string, attachmentToken: string) {
@@ -79,6 +85,7 @@ class AuthContext implements IAuthContext {
 
     // Delete the cookies
     this._token.value = null;
+    this._apiToken = null;
     this._attachmentToken.value = null;
     console.log("Session invalidated");
   }
@@ -95,6 +102,7 @@ class AuthContext implements IAuthContext {
         expires: expiresAt,
       });
       this._token.value = "true";
+      this._apiToken = r.data.token;
       this._attachmentToken.value = r.data.attachmentToken;
     }
 

--- a/frontend/composables/use-auth-context.ts
+++ b/frontend/composables/use-auth-context.ts
@@ -88,10 +88,13 @@ class AuthContext implements IAuthContext {
 
     if (!r.error) {
       const expiresAt = new Date(r.data.expiresAt);
-      this._token = useCookie(AuthContext.cookieTokenKey);
+      this._token = useCookie(AuthContext.cookieTokenKey, {
+        expires: expiresAt,
+      });
       this._attachmentToken = useCookie(AuthContext.cookieAttachmentTokenKey, {
         expires: expiresAt,
       });
+      this._token.value = "true";
       this._attachmentToken.value = r.data.attachmentToken;
     }
 

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -6,6 +6,25 @@ import prettier from "eslint-plugin-prettier";
 import { includeIgnoreFile } from "@eslint/compat";
 import { fileURLToPath } from "node:url";
 
+if (!Object.groupBy) {
+  Object.defineProperty(Object, "groupBy", {
+    value(items, callback) {
+      const groups = Object.create(null);
+      let index = 0;
+
+      for (const item of items) {
+        const group = callback(item, index++);
+        const key = typeof group === "symbol" ? group : String(group);
+
+        groups[key] ??= [];
+        groups[key].push(item);
+      }
+
+      return groups;
+    },
+  });
+}
+
 const gitignorePath = fileURLToPath(new URL("../.gitignore", import.meta.url));
 
 export default withNuxt([

--- a/frontend/lib/api/classes/items.ts
+++ b/frontend/lib/api/classes/items.ts
@@ -15,7 +15,7 @@ import type {
 } from "../types/data-contracts";
 import type { AttachmentTypes } from "../types/non-generated";
 import type { MaintenanceFilters } from "./maintenance.ts";
-import type { Requests } from "~~/lib/requests";
+import type { Requests, TResponse } from "~~/lib/requests";
 
 export type ItemsQuery = {
   orderBy?: string;
@@ -193,7 +193,7 @@ export class ItemsApi extends BaseAPI {
     return {
       ...resp,
       data: resp.data?.items ?? [],
-    } as { data: EntitySummary[]; error: any; status: number };
+    } as TResponse<EntitySummary[]>;
   }
 
   getTree(tq: TreeQuery = { withItems: false }) {

--- a/frontend/lib/api/classes/items.ts
+++ b/frontend/lib/api/classes/items.ts
@@ -39,6 +39,8 @@ export type TreeQuery = {
   withItems: boolean;
 };
 
+export type EntityCreateBody = Omit<EntityCreate, "entityTypeId"> & Partial<Pick<EntityCreate, "entityTypeId">>;
+
 export class AttachmentsAPI extends BaseAPI {
   add(id: string, file: File | Blob, filename: string, type: AttachmentTypes | null = null, primary?: boolean) {
     const formData = new FormData();
@@ -115,8 +117,8 @@ export class ItemsApi extends BaseAPI {
     return payload;
   }
 
-  async create(item: EntityCreate) {
-    const payload = await this.http.post<EntityCreate, EntityOut>({ url: route("/entities"), body: item });
+  async create(item: EntityCreateBody) {
+    const payload = await this.http.post<EntityCreateBody, EntityOut>({ url: route("/entities"), body: item });
     return payload;
   }
 
@@ -200,8 +202,8 @@ export class ItemsApi extends BaseAPI {
     return this.http.get<TreeItem[]>({ url: route("/entities/tree", tq) });
   }
 
-  createLocation(body: EntityCreate) {
-    return this.http.post<EntityCreate, EntityOut>({ url: route("/entities"), body });
+  createLocation(body: EntityCreateBody) {
+    return this.http.post<EntityCreateBody, EntityOut>({ url: route("/entities"), body });
   }
 
   getLocation(id: string) {

--- a/frontend/lib/api/public.ts
+++ b/frontend/lib/api/public.ts
@@ -8,9 +8,28 @@ export type StatusResult = {
   message: string;
 };
 
+export type PublicFoundEntity = {
+  assetId: string;
+  contactName?: string;
+  contactEmail?: string;
+  multipleMatches?: boolean;
+};
+
 export class PublicApi extends BaseAPI {
   public status() {
     return this.http.get<APISummary>({ url: route("/status") });
+  }
+
+  public foundItem(id: string) {
+    return this.http.get<PublicFoundEntity>({
+      url: route(`/public/found/item/${id}`),
+    });
+  }
+
+  public foundAsset(id: string) {
+    return this.http.get<PublicFoundEntity>({
+      url: route(`/public/found/asset/${id}`),
+    });
   }
 
   public login(username: string, password: string, stayLoggedIn = false) {
@@ -25,6 +44,9 @@ export class PublicApi extends BaseAPI {
   }
 
   public register(body: UserRegistration) {
-    return this.http.post<UserRegistration, TokenResponse>({ url: route("/users/register"), body });
+    return this.http.post<UserRegistration, TokenResponse>({
+      url: route("/users/register"),
+      body,
+    });
   }
 }

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -302,6 +302,7 @@
             "create_modal": {
                 "location_description": "Location Description",
                 "location_name": "Location Name",
+                "notes": "Notes",
                 "title": "Create Location",
                 "toast": {
                     "already_creating": "Already creating a location",

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -399,6 +399,7 @@
         "contact_owner": "Contact Owner",
         "email_body": "Hi, I found an item with your HomeBox tag. Please let me know how I can return it.",
         "email_subject": "Found HomeBox item {assetId}",
+        "invalid_kind": "This found-item link is not valid.",
         "multiple_matches": "This asset tag matches more than one item on this HomeBox instance, so the owner cannot be shown safely.",
         "not_found": "This item tag could not be matched to a public contact.",
         "owner_name": "Owner: {name}",

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -394,6 +394,17 @@
     "errors": {
         "api_failure": "Backend API call failed: "
     },
+    "found": {
+        "contact_body": "This tag belongs to a HomeBox inventory. You can email the owner to arrange returning it.",
+        "contact_owner": "Contact Owner",
+        "email_body": "Hi, I found an item with your HomeBox tag. Please let me know how I can return it.",
+        "email_subject": "Found HomeBox item {assetId}",
+        "multiple_matches": "This asset tag matches more than one item on this HomeBox instance, so the owner cannot be shown safely.",
+        "not_found": "This item tag could not be matched to a public contact.",
+        "owner_name": "Owner: {name}",
+        "sign_in": "Sign In",
+        "title": "Found an item?"
+    },
     "global": {
         "add": "Add",
         "archived": "Archived",

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -42,6 +42,26 @@
             "entity_types": "Entity Types",
             "tools": "Tools"
         },
+        "entity_types": {
+            "confirm_delete": "Are you sure you want to delete \"{name}\"? Entities using this type will need to be reassigned.",
+            "container": "Container",
+            "create_title": "Create Entity Type",
+            "default_template": "Default template: {name}",
+            "empty": "No entity types defined yet.",
+            "is_location": "Is a container / location type",
+            "title": "Entity Types",
+            "toast": {
+                "create_failed": "Failed to create entity type",
+                "created": "Entity type created",
+                "delete_failed": "Failed to delete entity type. Make sure no entities are using it.",
+                "deleted": "Entity type deleted",
+                "load_failed": "Failed to load entity types",
+                "name_required": "Name is required",
+                "update_failed": "Failed to update entity type",
+                "updated": "Entity type updated"
+            },
+            "update_title": "Update Entity Type"
+        },
         "uses": "Uses"
     },
     "components": {

--- a/frontend/middleware/auth.ts
+++ b/frontend/middleware/auth.ts
@@ -16,6 +16,7 @@ export default defineNuxtRouteMiddleware(async to => {
   const ctx = useAuthContext();
   const api = useUserApi();
   const redirectTo = useState("authRedirect");
+  const currentPath = import.meta.client ? window.location.pathname : to.path;
 
   if (!ctx.isAuthorized()) {
     const foundPath = foundItemPath(to.path);
@@ -23,9 +24,9 @@ export default defineNuxtRouteMiddleware(async to => {
       return navigateTo(foundPath);
     }
 
-    if (to.path !== "/") {
+    if (currentPath !== "/") {
       console.debug("[middleware/auth] isAuthorized returned false, redirecting to /");
-      redirectTo.value = to.path;
+      redirectTo.value = currentPath;
       return navigateTo("/");
     }
   }
@@ -34,9 +35,9 @@ export default defineNuxtRouteMiddleware(async to => {
     console.log("Fetching user data");
     const { data, error } = await api.user.self();
     if (error) {
-      if (to.path !== "/") {
+      if (currentPath !== "/") {
         console.debug("[middleware/user] user is null and fetch failed, redirecting to /");
-        redirectTo.value = to.path;
+        redirectTo.value = currentPath;
         return navigateTo("/");
       }
     }

--- a/frontend/middleware/auth.ts
+++ b/frontend/middleware/auth.ts
@@ -16,7 +16,7 @@ export default defineNuxtRouteMiddleware(async to => {
   const ctx = useAuthContext();
   const api = useUserApi();
   const redirectTo = useState("authRedirect");
-  const currentPath = import.meta.client ? window.location.pathname : to.path;
+  const currentPath = to.path;
 
   if (!ctx.isAuthorized()) {
     const foundPath = foundItemPath(to.path);

--- a/frontend/middleware/auth.ts
+++ b/frontend/middleware/auth.ts
@@ -1,12 +1,31 @@
-export default defineNuxtRouteMiddleware(async () => {
+function foundItemPath(pathname: string) {
+  const itemMatch = pathname.match(/^\/item\/([^/]+)/);
+  if (itemMatch) {
+    return `/found/item/${encodeURIComponent(itemMatch[1]!)}`;
+  }
+
+  const assetMatch = pathname.match(/^\/(?:a|assets)\/([^/]+)/);
+  if (assetMatch) {
+    return `/found/asset/${encodeURIComponent(assetMatch[1]!)}`;
+  }
+
+  return null;
+}
+
+export default defineNuxtRouteMiddleware(async to => {
   const ctx = useAuthContext();
   const api = useUserApi();
   const redirectTo = useState("authRedirect");
 
   if (!ctx.isAuthorized()) {
-    if (window.location.pathname !== "/") {
+    const foundPath = foundItemPath(to.path);
+    if (foundPath) {
+      return navigateTo(foundPath);
+    }
+
+    if (to.path !== "/") {
       console.debug("[middleware/auth] isAuthorized returned false, redirecting to /");
-      redirectTo.value = window.location.pathname;
+      redirectTo.value = to.path;
       return navigateTo("/");
     }
   }
@@ -15,9 +34,9 @@ export default defineNuxtRouteMiddleware(async () => {
     console.log("Fetching user data");
     const { data, error } = await api.user.self();
     if (error) {
-      if (window.location.pathname !== "/") {
+      if (to.path !== "/") {
         console.debug("[middleware/user] user is null and fetch failed, redirecting to /");
-        redirectTo.value = window.location.pathname;
+        redirectTo.value = to.path;
         return navigateTo("/");
       }
     }

--- a/frontend/pages/collection/index/entity-types.vue
+++ b/frontend/pages/collection/index/entity-types.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-  import { useI18n } from "vue-i18n";
   import { toast } from "@/components/ui/sonner";
   import type {
     EntityTypeCreate,
@@ -16,20 +15,13 @@
   import { Badge } from "@/components/ui/badge";
   import { Card } from "@/components/ui/card";
   import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-  import {
-    Dialog,
-    DialogContent,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-  } from "@/components/ui/dialog";
+  import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
   import { useDialog } from "@/components/ui/dialog-provider";
   import { DialogID } from "~/components/ui/dialog-provider/utils";
   import FormTextField from "~/components/Form/TextField.vue";
   import FormCheckbox from "~/components/Form/Checkbox.vue";
   import TemplateSelector from "~/components/Template/Selector.vue";
 
-  const { t } = useI18n();
   const api = useUserApi();
   const confirm = useConfirm();
   const { openDialog, closeDialog } = useDialog();
@@ -98,7 +90,11 @@
     updateForm.icon = et.icon;
     updateForm.isLocation = et.isLocation;
     updateTemplate.value = et.defaultTemplate
-      ? { id: et.defaultTemplate.id, name: et.defaultTemplate.name, description: et.defaultTemplate.description } as EntityTemplateSummary
+      ? ({
+          id: et.defaultTemplate.id,
+          name: et.defaultTemplate.name,
+          description: et.defaultTemplate.description,
+        } as EntityTemplateSummary)
       : null;
     openDialog(DialogID.UpdateEntityType);
   }
@@ -154,13 +150,7 @@
           <DialogTitle>Create Entity Type</DialogTitle>
         </DialogHeader>
         <form class="flex flex-col gap-3" @submit.prevent="create">
-          <FormTextField
-            v-model="createForm.name"
-            :autofocus="true"
-            label="Name"
-            :max-length="255"
-            :min-length="1"
-          />
+          <FormTextField v-model="createForm.name" :autofocus="true" label="Name" :max-length="255" :min-length="1" />
           <FormCheckbox v-model="createForm.isLocation" label="Is a container / location type" />
           <TemplateSelector v-model="createTemplate" />
 
@@ -178,13 +168,7 @@
           <DialogTitle>Update Entity Type</DialogTitle>
         </DialogHeader>
         <form class="flex flex-col gap-3" @submit.prevent="update">
-          <FormTextField
-            v-model="updateForm.name"
-            :autofocus="true"
-            label="Name"
-            :max-length="255"
-            :min-length="1"
-          />
+          <FormTextField v-model="updateForm.name" :autofocus="true" label="Name" :max-length="255" :min-length="1" />
           <FormCheckbox v-model="updateForm.isLocation" label="Is a container / location type" />
           <TemplateSelector v-model="updateTemplate" />
 
@@ -196,7 +180,7 @@
     </Dialog>
 
     <!-- Page Content -->
-    <div class="flex items-center justify-between mb-4">
+    <div class="mb-4 flex items-center justify-between">
       <h3 class="text-lg font-medium">Entity Types</h3>
       <Button size="sm" @click="openDialog(DialogID.CreateEntityType)">
         <MdiPlus class="mr-1 size-4" />
@@ -207,7 +191,9 @@
     <div v-if="entityTypes && entityTypes.length > 0" class="space-y-2">
       <Card v-for="et in entityTypes" :key="et.id" class="p-4">
         <div class="flex items-center gap-3">
-          <div class="flex size-10 shrink-0 items-center justify-center rounded-full bg-secondary text-secondary-foreground">
+          <div
+            class="flex size-10 shrink-0 items-center justify-center rounded-full bg-secondary text-secondary-foreground"
+          >
             <MdiMapMarkerOutline v-if="et.isLocation" class="size-5" />
             <MdiPackageVariantClosed v-else class="size-5" />
           </div>

--- a/frontend/pages/collection/index/entity-types.vue
+++ b/frontend/pages/collection/index/entity-types.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+  import { useI18n } from "vue-i18n";
   import { toast } from "@/components/ui/sonner";
   import type {
     EntityTypeCreate,
@@ -25,15 +26,20 @@
   const api = useUserApi();
   const confirm = useConfirm();
   const { openDialog, closeDialog } = useDialog();
+  const { t } = useI18n();
 
-  const { data: entityTypes, refresh } = useAsyncData("entity-types", async () => {
+  const { data: entityTypes, refresh } = useAsyncData<EntityTypeSummary[]>("entity-types", async () => {
     const { data, error } = await api.entityTypes.getAll();
     if (error) {
-      toast.error("Failed to load entity types");
+      toast.error(t("collection.entity_types.toast.load_failed"));
       return [];
     }
-    return data;
+    return data ?? [];
   });
+
+  function getEntityTypes(): EntityTypeSummary[] {
+    return entityTypes.value ?? [];
+  }
 
   // Create form
   const createForm = reactive({
@@ -52,7 +58,7 @@
 
   async function create() {
     if (!createForm.name.trim()) {
-      toast.error("Name is required");
+      toast.error(t("collection.entity_types.toast.name_required"));
       return;
     }
 
@@ -65,11 +71,11 @@
 
     const { error } = await api.entityTypes.create(payload);
     if (error) {
-      toast.error("Failed to create entity type");
+      toast.error(t("collection.entity_types.toast.create_failed"));
       return;
     }
 
-    toast.success("Entity type created");
+    toast.success(t("collection.entity_types.toast.created"));
     resetCreateForm();
     closeDialog(DialogID.CreateEntityType);
     refresh();
@@ -101,7 +107,7 @@
 
   async function update() {
     if (!updateForm.name.trim()) {
-      toast.error("Name is required");
+      toast.error(t("collection.entity_types.toast.name_required"));
       return;
     }
 
@@ -115,28 +121,26 @@
 
     const { error } = await api.entityTypes.update(updateForm.id, payload);
     if (error) {
-      toast.error("Failed to update entity type");
+      toast.error(t("collection.entity_types.toast.update_failed"));
       return;
     }
 
-    toast.success("Entity type updated");
+    toast.success(t("collection.entity_types.toast.updated"));
     closeDialog(DialogID.UpdateEntityType);
     refresh();
   }
 
   async function deleteEntityType(et: EntityTypeSummary) {
-    const { isCanceled } = await confirm.open(
-      `Are you sure you want to delete "${et.name}"? Entities using this type will need to be reassigned.`
-    );
+    const { isCanceled } = await confirm.open(t("collection.entity_types.confirm_delete", { name: et.name }));
     if (isCanceled) return;
 
     const { error } = await api.entityTypes.delete(et.id);
     if (error) {
-      toast.error("Failed to delete entity type. Make sure no entities are using it.");
+      toast.error(t("collection.entity_types.toast.delete_failed"));
       return;
     }
 
-    toast.success("Entity type deleted");
+    toast.success(t("collection.entity_types.toast.deleted"));
     refresh();
   }
 </script>
@@ -147,15 +151,21 @@
     <Dialog :dialog-id="DialogID.CreateEntityType">
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Create Entity Type</DialogTitle>
+          <DialogTitle>{{ t("collection.entity_types.create_title") }}</DialogTitle>
         </DialogHeader>
         <form class="flex flex-col gap-3" @submit.prevent="create">
-          <FormTextField v-model="createForm.name" :autofocus="true" label="Name" :max-length="255" :min-length="1" />
-          <FormCheckbox v-model="createForm.isLocation" label="Is a container / location type" />
+          <FormTextField
+            v-model="createForm.name"
+            :autofocus="true"
+            :label="t('global.name')"
+            :max-length="255"
+            :min-length="1"
+          />
+          <FormCheckbox v-model="createForm.isLocation" :label="t('collection.entity_types.is_location')" />
           <TemplateSelector v-model="createTemplate" />
 
           <DialogFooter>
-            <Button type="submit">Create</Button>
+            <Button type="submit">{{ t("global.create") }}</Button>
           </DialogFooter>
         </form>
       </DialogContent>
@@ -165,15 +175,21 @@
     <Dialog :dialog-id="DialogID.UpdateEntityType">
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Update Entity Type</DialogTitle>
+          <DialogTitle>{{ t("collection.entity_types.update_title") }}</DialogTitle>
         </DialogHeader>
         <form class="flex flex-col gap-3" @submit.prevent="update">
-          <FormTextField v-model="updateForm.name" :autofocus="true" label="Name" :max-length="255" :min-length="1" />
-          <FormCheckbox v-model="updateForm.isLocation" label="Is a container / location type" />
+          <FormTextField
+            v-model="updateForm.name"
+            :autofocus="true"
+            :label="t('global.name')"
+            :max-length="255"
+            :min-length="1"
+          />
+          <FormCheckbox v-model="updateForm.isLocation" :label="t('collection.entity_types.is_location')" />
           <TemplateSelector v-model="updateTemplate" />
 
           <DialogFooter>
-            <Button type="submit">Update</Button>
+            <Button type="submit">{{ t("global.update") }}</Button>
           </DialogFooter>
         </form>
       </DialogContent>
@@ -181,15 +197,15 @@
 
     <!-- Page Content -->
     <div class="mb-4 flex items-center justify-between">
-      <h3 class="text-lg font-medium">Entity Types</h3>
+      <h3 class="text-lg font-medium">{{ t("collection.entity_types.title") }}</h3>
       <Button size="sm" @click="openDialog(DialogID.CreateEntityType)">
         <MdiPlus class="mr-1 size-4" />
-        Create
+        {{ t("global.create") }}
       </Button>
     </div>
 
-    <div v-if="entityTypes && entityTypes.length > 0" class="space-y-2">
-      <Card v-for="et in entityTypes" :key="et.id" class="p-4">
+    <div v-if="getEntityTypes().length > 0" class="space-y-2">
+      <Card v-for="et in getEntityTypes()" :key="et.id" class="p-4">
         <div class="flex items-center gap-3">
           <div
             class="flex size-10 shrink-0 items-center justify-center rounded-full bg-secondary text-secondary-foreground"
@@ -201,10 +217,12 @@
           <div class="mr-auto min-w-0">
             <div class="flex items-center gap-2">
               <span class="font-medium">{{ et.name }}</span>
-              <Badge v-if="et.isLocation" variant="secondary" class="text-xs">Container</Badge>
+              <Badge v-if="et.isLocation" variant="secondary" class="text-xs">
+                {{ t("collection.entity_types.container") }}
+              </Badge>
             </div>
             <p v-if="et.defaultTemplate" class="text-xs text-muted-foreground">
-              Default template: {{ et.defaultTemplate.name }}
+              {{ t("collection.entity_types.default_template", { name: et.defaultTemplate.name }) }}
             </p>
           </div>
 
@@ -216,7 +234,7 @@
                     <MdiPencil class="size-4" />
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent>Edit</TooltipContent>
+                <TooltipContent>{{ t("global.edit") }}</TooltipContent>
               </Tooltip>
               <Tooltip>
                 <TooltipTrigger as-child>
@@ -224,7 +242,7 @@
                     <MdiDelete class="size-4" />
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent>Delete</TooltipContent>
+                <TooltipContent>{{ t("global.delete") }}</TooltipContent>
               </Tooltip>
             </div>
           </TooltipProvider>
@@ -233,10 +251,10 @@
     </div>
 
     <div v-else class="flex flex-col items-center justify-center py-12 text-center">
-      <p class="mb-4 text-muted-foreground">No entity types defined yet.</p>
+      <p class="mb-4 text-muted-foreground">{{ t("collection.entity_types.empty") }}</p>
       <Button @click="openDialog(DialogID.CreateEntityType)">
         <MdiPlus class="mr-2" />
-        Create Entity Type
+        {{ t("collection.entity_types.create_title") }}
       </Button>
     </div>
   </div>

--- a/frontend/pages/found/[kind]/[id].vue
+++ b/frontend/pages/found/[kind]/[id].vue
@@ -20,19 +20,35 @@
   const id = computed(() => route.params.id as string);
   const isAsset = computed(() => kind.value === "asset");
   const isItem = computed(() => kind.value === "item");
-  const originalPath = computed(() => (isAsset.value ? `/a/${id.value}` : `/item/${id.value}`));
+  const hasInvalidKind = computed(() => !isAsset.value && !isItem.value);
+  const originalPath = computed(() => {
+    if (isAsset.value) {
+      return `/a/${id.value}`;
+    }
+    if (isItem.value) {
+      return `/item/${id.value}`;
+    }
+    return "/";
+  });
 
   useHead({
     title: `HomeBox | ${t("found.title")}`,
   });
 
-  const { data: found, pending } = useAsyncData(`found-${kind.value}-${id.value}`, async () => {
-    if (!isAsset.value && !isItem.value) {
-      return null;
+  const {
+    data: found,
+    pending,
+    error,
+  } = useAsyncData(`found-${kind.value}-${id.value}`, async () => {
+    if (hasInvalidKind.value) {
+      throw createError({
+        statusCode: 404,
+        statusMessage: t("found.invalid_kind"),
+      });
     }
 
-    const { data, error } = isAsset.value ? await api.foundAsset(id.value) : await api.foundItem(id.value);
-    if (error) {
+    const { data, error: apiError } = isAsset.value ? await api.foundAsset(id.value) : await api.foundItem(id.value);
+    if (apiError) {
       return null;
     }
     return data;
@@ -42,6 +58,9 @@
   const hasContactName = computed(() => Boolean(found.value?.contactName));
   const ownerNameText = computed(() => t("found.owner_name", { name: found.value?.contactName ?? "" }));
   const hasMultipleMatches = computed(() => Boolean(found.value?.multipleMatches));
+  const notFoundText = computed(() =>
+    hasInvalidKind.value || error.value ? t("found.invalid_kind") : t("found.not_found")
+  );
 
   const contactHref = computed(() => {
     if (!found.value?.contactEmail) {
@@ -93,6 +112,13 @@
             <p class="flex gap-2">
               <MdiAlertCircle class="mt-0.5 size-5 shrink-0" />
               <span>{{ $t("found.multiple_matches") }}</span>
+            </p>
+          </template>
+
+          <template v-else-if="hasInvalidKind || error">
+            <p class="flex gap-2">
+              <MdiAlertCircle class="mt-0.5 size-5 shrink-0" />
+              <span>{{ notFoundText }}</span>
             </p>
           </template>
 

--- a/frontend/pages/found/[kind]/[id].vue
+++ b/frontend/pages/found/[kind]/[id].vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+  import { useI18n } from "vue-i18n";
+  import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+  import { Button } from "@/components/ui/button";
+  import AppLogo from "~/components/App/Logo.vue";
+  import MdiAlertCircle from "~icons/mdi/alert-circle";
+  import MdiEmail from "~icons/mdi/email";
+  import MdiLogin from "~icons/mdi/login";
+  import MdiPackageVariant from "~icons/mdi/package-variant";
+
+  definePageMeta({
+    layout: "empty",
+  });
+
+  const { t } = useI18n();
+  const route = useRoute();
+  const api = usePublicApi();
+
+  const kind = computed(() => route.params.kind as string);
+  const id = computed(() => route.params.id as string);
+  const isAsset = computed(() => kind.value === "asset");
+  const isItem = computed(() => kind.value === "item");
+  const originalPath = computed(() => (isAsset.value ? `/a/${id.value}` : `/item/${id.value}`));
+
+  useHead({
+    title: `HomeBox | ${t("found.title")}`,
+  });
+
+  const { data: found, pending } = useAsyncData(`found-${kind.value}-${id.value}`, async () => {
+    if (!isAsset.value && !isItem.value) {
+      return null;
+    }
+
+    const { data, error } = isAsset.value ? await api.foundAsset(id.value) : await api.foundItem(id.value);
+    if (error) {
+      return null;
+    }
+    return data;
+  });
+
+  const canContactOwner = computed(() => Boolean(found.value?.contactEmail && !found.value?.multipleMatches));
+
+  const contactHref = computed(() => {
+    if (!found.value?.contactEmail) {
+      return "";
+    }
+
+    const subject = t("found.email_subject", { assetId: found.value.assetId });
+    const body = t("found.email_body");
+    return `mailto:${found.value.contactEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+  });
+
+  function signIn() {
+    const redirectTo = useState("authRedirect");
+    redirectTo.value = originalPath.value;
+    navigateTo("/");
+  }
+</script>
+
+<template>
+  <main class="flex min-h-screen bg-background px-4 py-8 text-foreground">
+    <div class="mx-auto flex w-full max-w-xl flex-col justify-center">
+      <div class="mb-6 flex items-center justify-center gap-2 text-primary">
+        <h1 class="flex items-center text-4xl font-bold">
+          HomeB
+          <AppLogo class="-mb-3 w-10" />
+          x
+        </h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle class="flex items-center gap-3 text-2xl">
+            <MdiPackageVariant class="size-8 text-primary" />
+            {{ $t("found.title") }}
+          </CardTitle>
+        </CardHeader>
+
+        <CardContent class="space-y-4 text-sm text-muted-foreground">
+          <p v-if="pending">{{ $t("global.loading") }}</p>
+
+          <template v-else-if="canContactOwner">
+            <p>{{ $t("found.contact_body") }}</p>
+            <p v-if="found?.contactName">
+              {{ $t("found.owner_name", { name: found.contactName }) }}
+            </p>
+          </template>
+
+          <template v-else-if="found?.multipleMatches">
+            <p class="flex gap-2">
+              <MdiAlertCircle class="mt-0.5 size-5 shrink-0" />
+              <span>{{ $t("found.multiple_matches") }}</span>
+            </p>
+          </template>
+
+          <template v-else>
+            <p class="flex gap-2">
+              <MdiAlertCircle class="mt-0.5 size-5 shrink-0" />
+              <span>{{ $t("found.not_found") }}</span>
+            </p>
+          </template>
+        </CardContent>
+
+        <CardFooter class="flex flex-col gap-2 sm:flex-row">
+          <Button v-if="canContactOwner" as-child class="w-full sm:w-auto">
+            <a :href="contactHref">
+              <MdiEmail />
+              {{ $t("found.contact_owner") }}
+            </a>
+          </Button>
+
+          <Button variant="outline" class="w-full sm:w-auto" @click="signIn">
+            <MdiLogin />
+            {{ $t("found.sign_in") }}
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  </main>
+</template>

--- a/frontend/pages/found/[kind]/[id].vue
+++ b/frontend/pages/found/[kind]/[id].vue
@@ -39,6 +39,9 @@
   });
 
   const canContactOwner = computed(() => Boolean(found.value?.contactEmail && !found.value?.multipleMatches));
+  const hasContactName = computed(() => Boolean(found.value?.contactName));
+  const ownerNameText = computed(() => t("found.owner_name", { name: found.value?.contactName ?? "" }));
+  const hasMultipleMatches = computed(() => Boolean(found.value?.multipleMatches));
 
   const contactHref = computed(() => {
     if (!found.value?.contactEmail) {
@@ -81,12 +84,12 @@
 
           <template v-else-if="canContactOwner">
             <p>{{ $t("found.contact_body") }}</p>
-            <p v-if="found?.contactName">
-              {{ $t("found.owner_name", { name: found.contactName }) }}
+            <p v-if="hasContactName">
+              {{ ownerNameText }}
             </p>
           </template>
 
-          <template v-else-if="found?.multipleMatches">
+          <template v-else-if="hasMultipleMatches">
             <p class="flex gap-2">
               <MdiAlertCircle class="mt-0.5 size-5 shrink-0" />
               <span>{{ $t("found.multiple_matches") }}</span>

--- a/frontend/pages/item/[id]/index/edit.vue
+++ b/frontend/pages/item/[id]/index/edit.vue
@@ -5,7 +5,6 @@
   import type { ItemAttachment, EntityFieldData, EntityOut, EntityUpdate } from "~~/lib/api/types/data-contracts";
   import { AttachmentTypes } from "~~/lib/api/types/non-generated";
   import { useTagStore } from "~/stores/tags";
-  import { useLocationStore } from "~~/stores/locations";
   import MdiLoading from "~icons/mdi/loading";
   import MdiDelete from "~icons/mdi/delete";
   import MdiPencil from "~icons/mdi/pencil";
@@ -45,9 +44,6 @@
   const preferences = useViewPreferences();
 
   const itemId = computed<string>(() => route.params.id as string);
-
-  const locationStore = useLocationStore();
-  const locations = computed(() => locationStore.allLocations);
 
   const tagStore = useTagStore();
   const tags = computed(() => tagStore.tags);

--- a/frontend/pages/location/[id]/index.vue
+++ b/frontend/pages/location/[id]/index.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+  import BaseContainer from "@/components/Base/Container.vue";
+
   definePageMeta({
     middleware: ["auth"],
   });
@@ -9,7 +11,3 @@
     <NuxtPage />
   </BaseContainer>
 </template>
-
-<script lang="ts">
-  import BaseContainer from "@/components/Base/Container.vue";
-</script>

--- a/frontend/pages/location/[id]/index/edit.vue
+++ b/frontend/pages/location/[id]/index/edit.vue
@@ -5,7 +5,6 @@
   import type { ItemAttachment, EntityFieldData, EntityOut, EntityUpdate } from "~~/lib/api/types/data-contracts";
   import { AttachmentTypes } from "~~/lib/api/types/non-generated";
   import { useTagStore } from "~/stores/tags";
-  import { useLocationStore } from "~~/stores/locations";
   import MdiLoading from "~icons/mdi/loading";
   import MdiDelete from "~icons/mdi/delete";
   import MdiPencil from "~icons/mdi/pencil";
@@ -43,9 +42,6 @@
   const preferences = useViewPreferences();
 
   const locationId = computed<string>(() => route.params.id as string);
-
-  const locationStore = useLocationStore();
-  const locations = computed(() => locationStore.allLocations);
 
   const tagStore = useTagStore();
   const tags = computed(() => tagStore.tags);

--- a/frontend/pages/location/[id]/index/index.vue
+++ b/frontend/pages/location/[id]/index/index.vue
@@ -226,8 +226,7 @@
           <button
             v-for="(photo, i) in photos"
             :key="i"
-            class="group relative overflow-hidden rounded-lg border bg-muted"
-            style="aspect-ratio: 1 / 1"
+            class="aspect-square group relative overflow-hidden rounded-lg border bg-muted"
             @click="openImageDialog(photo, location.id)"
           >
             <img

--- a/frontend/pages/location/[id]/index/index.vue
+++ b/frontend/pages/location/[id]/index/index.vue
@@ -4,7 +4,6 @@
   import type { AnyDetail, Details } from "~~/components/global/DetailsSection/types";
   import { filterZeroValues } from "~~/components/global/DetailsSection/types";
   import type { ItemAttachment } from "~~/lib/api/types/data-contracts";
-  import { useLocationStore } from "~~/stores/locations";
   import MdiPackageVariant from "~icons/mdi/package-variant";
   import MdiPlus from "~icons/mdi/plus";
   import MdiPencil from "~icons/mdi/pencil";
@@ -49,7 +48,7 @@
 
   const locationId = computed<string>(() => route.params.id as string);
 
-  const { data: location, refresh } = useAsyncData(locationId.value, async () => {
+  const { data: location } = useAsyncData(locationId.value, async () => {
     const { data, error } = await api.items.getLocation(locationId.value);
     if (error) {
       toast.error(t("locations.toast.failed_load_location"));
@@ -85,8 +84,6 @@
   function goToEdit() {
     navigateTo(`/location/${locationId.value}/edit`);
   }
-
-  const locationStore = useLocationStore();
 
   // Photos
   type Photo = {
@@ -150,7 +147,12 @@
         else acc.attachments.push(attachment);
         return acc;
       },
-      { attachments: [] as ItemAttachment[], warranty: [] as ItemAttachment[], manuals: [] as ItemAttachment[], receipts: [] as ItemAttachment[] }
+      {
+        attachments: [] as ItemAttachment[],
+        warranty: [] as ItemAttachment[],
+        manuals: [] as ItemAttachment[],
+        receipts: [] as ItemAttachment[],
+      }
     );
   });
 
@@ -171,12 +173,12 @@
         type: "markdown",
         text: location.value.notes,
       },
-      ...((location.value.fields || []).map(field => {
+      ...(location.value.fields || []).map(field => {
         return {
           name: field.name,
           text: field.textValue,
         } as AnyDetail;
-      })),
+      }),
     ];
 
     if (!preferences.value.showEmpty) {
@@ -224,7 +226,8 @@
           <button
             v-for="(photo, i) in photos"
             :key="i"
-            class="group relative aspect-square overflow-hidden rounded-lg border bg-muted"
+            class="group relative overflow-hidden rounded-lg border bg-muted"
+            style="aspect-ratio: 1 / 1"
             @click="openImageDialog(photo, location.id)"
           >
             <img


### PR DESCRIPTION
## Summary
- adds unauthenticated public found-item endpoints for item UUID and asset ID QR scans
- redirects signed-out `/item/:id`, `/a/:id`, and `/assets/:id` scans to a public `/found/...` page instead of the login page
- shows the owner contact email only when a QR/asset lookup resolves safely; asset IDs with multiple matches do not expose contact details
- adds repository tests for direct item lookup and ambiguous asset-ID behavior

Fixes #13.

Note: this patch was prepared with AI assistance from the `nexiumbiz-debug` account.

## Testing
- `corepack pnpm exec eslint 'middleware/auth.ts' 'lib/api/public.ts' 'pages/found/[kind]/[id].vue' --ignore-pattern 'components/ui'`
- `node -e "JSON.parse(require('fs').readFileSync('frontend/locales/en.json','utf8')); console.log('en.json ok')"`
- `git diff --cached --check`

Also tried `corepack pnpm exec nuxi typecheck --noEmit`; it still fails on existing unrelated project type errors such as `components/global/LabelMaker.vue`, `components/Item/Card.vue`, `components/Maintenance/ListView.vue`, template pages, and `plugins/i18n.ts`.

Backend Go tests were not run locally because this Windows environment does not have `go`/`gofmt` installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public "found" pages for items/assets with contact-by-email when a single owner is available; handles loading, multiple-match, and not-found states.

* **API**
  * New unauthenticated endpoints to fetch found-item and found-asset data.

* **Middleware**
  * Unauthenticated navigation to item/asset routes redirects to corresponding found pages.

* **Localization**
  * Added English strings for the found flow (titles, errors, email templates).

* **Tests**
  * Added repository tests covering found-item lookup and multiple-match behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sysadminsmedia/homebox/pull/1482)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->