### PR TITLE
fix: location create modal shows 'Item Photo' instead of 'Location Photo' (closes #1456)

### DIFF
--- a/frontend/components/Location/CreateModal.vue
+++ b/frontend/components/Location/CreateModal.vue
@@ -36,7 +36,7 @@
       <!-- Photo upload -->
       <div class="flex w-full flex-col gap-1.5">
         <Label for="location-create-photo" class="flex w-full px-1">
-          {{ $t("components.item.create_modal.item_photo") }}
+          {{ $t("components.location.create_modal.location_photo") }}
         </Label>
         <div class="relative inline-block">
           <Button type="button" variant="outline" class="w-full" aria-hidden="true" @click.prevent="">

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -283,6 +283,7 @@
             "create_modal": {
                 "location_description": "Location Description",
                 "location_name": "Location Name",
+                "location_photo": "Location Photo 📷",
                 "title": "Create Location",
                 "toast": {
                     "already_creating": "Already creating a location",


### PR DESCRIPTION
## Summary
Fixes #1456: The location creation modal was displaying "Item Photo 📷" in the photo upload label.

## Problem
`frontend/components/Location/CreateModal.vue` was using the item-specific translation key `components.item.create_modal.item_photo`, causing the label to show item text when creating a location.

## Fix
- Added `location_photo` key to `components.location.create_modal` in `frontend/locales/en.json`
- Updated `Location/CreateModal.vue` to use the location-specific key

## Testing
- Verified the label now shows "Location Photo 📷" in the location creation modal

Closes #1456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated the photo upload label in the location creation modal to display "Location Photo 📷" instead of a generic label, providing clearer, location-specific guidance to users.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sysadminsmedia/homebox/pull/1490)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->