### PR TITLE
feat(integrations): add Paperless-ngx external attachment integration

### DIFF
--- a/backend/app/api/handlers/v1/v1_ctrl_integration_proxy.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_integration_proxy.go
@@ -1,0 +1,128 @@
+package v1
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/hay-kot/httpkit/errchain"
+	"github.com/rs/zerolog/log"
+	"github.com/sysadminsmedia/homebox/backend/internal/core/services"
+	"github.com/sysadminsmedia/homebox/backend/internal/sys/validate"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// validIntegrationName restricts integration names to safe lower-case identifiers,
+// preventing settings-key injection (e.g. "../../evil").
+var validIntegrationName = regexp.MustCompile(`^[a-z][a-z0-9_-]{0,31}$`)
+
+// HandleIntegrationProxy godoc
+//
+//	@Summary	Integration Reverse Proxy
+//	@Description	Proxies a single GET request to the configured external integration.
+//				The integration's credentials (base URL + API token) are read from
+//				user settings ({name}_url / {name}_token) and never exposed to the
+//				frontend.  This single generic endpoint replaces all per-integration
+//				proxy handlers: adding a new integration only requires a Vue component
+//				and a settings entry — no new Go code.
+//	@Tags		Integrations
+//	@Produce	*/*
+//	@Param		name	path	string	true	"Integration name, e.g. paperless"
+//	@Param		path	query	string	true	"Relative API path on the upstream service, must start with /"
+//	@Success	200
+//	@Failure	400	{object}	validate.ErrorResponse
+//	@Failure	502	{object}	validate.ErrorResponse
+//	@Router		/v1/integrations/{name}/proxy [GET]
+//	@Security	Bearer
+func (ctrl *V1Controller) HandleIntegrationProxy() errchain.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		spanCtx, span := startEntityCtrlSpan(r.Context(), "controller.V1.HandleIntegrationProxy")
+		defer span.End()
+
+		name := chi.URLParam(r, "name")
+		if !validIntegrationName.MatchString(name) {
+			return validate.NewRequestError(fmt.Errorf("invalid integration name"), http.StatusBadRequest)
+		}
+
+		rawPath := r.URL.Query().Get("path")
+		if rawPath == "" {
+			return validate.NewRequestError(fmt.Errorf("path query parameter is required"), http.StatusBadRequest)
+		}
+		if !strings.HasPrefix(rawPath, "/") || strings.Contains(rawPath, "://") {
+			return validate.NewRequestError(fmt.Errorf("path must be a relative path starting with /"), http.StatusBadRequest)
+		}
+
+		// Normalise to prevent directory traversal while preserving trailing slash
+		// (many REST APIs treat /foo/1/ and /foo/1 differently).
+		cleanPath := path.Clean(rawPath)
+		if !strings.HasPrefix(cleanPath, "/") {
+			return validate.NewRequestError(fmt.Errorf("invalid path after normalisation"), http.StatusBadRequest)
+		}
+		if strings.HasSuffix(rawPath, "/") && !strings.HasSuffix(cleanPath, "/") {
+			cleanPath += "/"
+		}
+
+		span.SetAttributes(
+			attribute.String("integration.name", name),
+			attribute.String("integration.path", cleanPath),
+		)
+
+		ctx := services.NewContext(spanCtx)
+		settings, svcErr := ctrl.svc.User.GetSettings(ctx.Context, services.UseUserCtx(ctx.Context).ID)
+		if svcErr != nil {
+			return validate.NewRequestError(svcErr, http.StatusInternalServerError)
+		}
+
+		baseURL, _ := settings[name+"_url"].(string)
+		if baseURL == "" {
+			return validate.NewRequestError(
+				fmt.Errorf("%s_url not configured – add it in Settings", name),
+				http.StatusBadRequest,
+			)
+		}
+
+		token, _ := settings[name+"_token"].(string)
+		if token == "" {
+			return validate.NewRequestError(
+				fmt.Errorf("%s_token not configured – add it in Settings", name),
+				http.StatusBadRequest,
+			)
+		}
+
+		upstream := strings.TrimRight(baseURL, "/") + cleanPath
+
+		req, err := http.NewRequest(http.MethodGet, upstream, nil)
+		if err != nil {
+			return validate.NewRequestError(err, http.StatusBadRequest)
+		}
+		req.Header.Set("Authorization", "Token "+token)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			log.Err(err).Str("integration", name).Str("upstream", upstream).Msg("integration proxy: upstream request failed")
+			return validate.NewRequestError(err, http.StatusBadGateway)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode == http.StatusNotFound {
+			return validate.NewRequestError(fmt.Errorf("resource not found at upstream"), http.StatusNotFound)
+		}
+		if resp.StatusCode >= 400 {
+			return validate.NewRequestError(
+				fmt.Errorf("upstream returned %d", resp.StatusCode),
+				http.StatusBadGateway,
+			)
+		}
+
+		if ct := resp.Header.Get("Content-Type"); ct != "" {
+			w.Header().Set("Content-Type", ct)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.Copy(w, resp.Body)
+		return nil
+	}
+}

--- a/backend/app/api/routes.go
+++ b/backend/app/api/routes.go
@@ -207,6 +207,9 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 		r.Delete("/notifiers/{id}", chain.ToHandlerFunc(v1Ctrl.HandleDeleteNotifier(), userMW...))
 		r.Post("/notifiers/test", chain.ToHandlerFunc(v1Ctrl.HandlerNotifierTest(), append(userMW, a.notifierTestLimiter.middleware)...))
 
+		// Integration proxy endpoints
+		r.Get("/integrations/{name}/proxy", chain.ToHandlerFunc(v1Ctrl.HandleIntegrationProxy(), userMW...))
+
 		// Asset-Like endpoints
 		assetMW := []errchain.Middleware{
 			a.mwAuthToken,

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -135,12 +135,6 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/clipperhouse/displaywidth v0.6.2 h1:ZDpTkFfpHOKte4RG5O/BOyf3ysnvFswpyYrV7z2uAKo=
-github.com/clipperhouse/displaywidth v0.6.2/go.mod h1:R+kHuzaYWFkTm7xoMmK1lFydbci4X2CicfbGstSGg0o=
-github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=
-github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
-github.com/clipperhouse/uax29/v2 v2.3.0 h1:SNdx9DVUqMoBuBoW3iLOj4FQv3dN5mDtuqwuhIGpJy4=
-github.com/clipperhouse/uax29/v2 v2.3.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
@@ -338,8 +332,6 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.21 h1:xYae+lCNBP7QuW4PUnNG61ffM4hVIfm+zUzDuSzYLGs=
 github.com/mattn/go-isatty v0.0.21/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
-github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
-github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/mattn/go-sqlite3 v1.14.34 h1:3NtcvcUnFBPsuRcno8pUtupspG/GM+9nZ88zgJcp6Zk=
 github.com/mattn/go-sqlite3 v1.14.34/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=
@@ -362,14 +354,6 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/olahol/melody v1.4.0 h1:Pa5SdeZL/zXPi1tJuMAPDbl4n3gQOThSL6G1p4qZ4SI=
 github.com/olahol/melody v1.4.0/go.mod h1:GgkTl6Y7yWj/HtfD48Q5vLKPVoZOH+Qqgfa7CvJgJM4=
-github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=
-github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6/go.mod h1:rEKTHC9roVVicUIfZK7DYrdIoM0EOr8mK1Hj5s3JjH0=
-github.com/olekukonko/errors v1.1.0 h1:RNuGIh15QdDenh+hNvKrJkmxxjV4hcS50Db478Ou5sM=
-github.com/olekukonko/errors v1.1.0/go.mod h1:ppzxA5jBKcO1vIpCXQ9ZqgDh8iwODz6OXIGKU8r5m4Y=
-github.com/olekukonko/ll v0.1.4-0.20260115111900-9e59c2286df0 h1:jrYnow5+hy3WRDCBypUFvVKNSPPCdqgSXIE9eJDD8LM=
-github.com/olekukonko/ll v0.1.4-0.20260115111900-9e59c2286df0/go.mod h1:b52bVQRRPObe+yyBl0TxNfhesL0nedD4Cht0/zx55Ew=
-github.com/olekukonko/tablewriter v1.1.3 h1:VSHhghXxrP0JHl+0NnKid7WoEmd9/urKRJLysb70nnA=
-github.com/olekukonko/tablewriter v1.1.3/go.mod h1:9VU0knjhmMkXjnMKrZ3+L2JhhtsQ/L38BbL3CRNE8tM=
 github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
 github.com/onsi/ginkgo/v2 v2.9.2/go.mod h1:WHcJJG2dIlcCqVfBAwUCrJxSPFb6v4azBwgxeMeDuts=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
@@ -413,10 +397,6 @@ github.com/shirou/gopsutil/v4 v4.26.3 h1:2ESdQt90yU3oXF/CdOlRCJxrP+Am1aBYubTMTfx
 github.com/shirou/gopsutil/v4 v4.26.3/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
-github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
-github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/backend/internal/core/services/service_items_attachments_external_test.go
+++ b/backend/internal/core/services/service_items_attachments_external_test.go
@@ -30,103 +30,154 @@ func newExternalLinkEntity(t *testing.T) repo.EntityOut {
 	return entity
 }
 
-func TestEntityService_AttachmentAddExternalLink_DefaultType(t *testing.T) {
+// knownSources lists every registered external-link source type together with a
+// representative external ID. To add or remove a service integration from the
+// test matrix, update this slice only — all table-driven tests pick up the
+// change automatically.
+var knownSources = []struct {
+	sourceType string
+	externalID string
+}{
+	{"paperless", "42"},
+	{"immich", "1df4f848-dead-beef-cafe-123456789abc"},
+	{"link", "https://example.com/doc"},
+}
+
+// TestEntityService_AttachmentAddExternalLink_SourceTypes verifies that every
+// known source type is accepted and that the stored mimeType and path match the
+// contract defined by repo.MimeTypeForSourceType.
+func TestEntityService_AttachmentAddExternalLink_SourceTypes(t *testing.T) {
+	svc := &EntityService{repo: tRepos}
+
+	for _, src := range knownSources {
+		t.Run(src.sourceType, func(t *testing.T) {
+			entity := newExternalLinkEntity(t)
+
+			expectedMime, ok := repo.MimeTypeForSourceType(src.sourceType)
+			require.True(t, ok, "knownSources entry %q has no registered mime type", src.sourceType)
+
+			out, err := svc.AttachmentAddExternalLink(tCtx, entity.ID, src.sourceType, src.externalID, "Test Doc", attachment.TypeAttachment)
+			require.NoError(t, err)
+			require.NotEmpty(t, out.Attachments)
+
+			var found bool
+			for _, att := range out.Attachments {
+				if att.Path == src.externalID {
+					found = true
+					assert.Equal(t, expectedMime, att.MimeType)
+					assert.Equal(t, "Test Doc", att.Title)
+					assert.Equal(t, string(attachment.TypeAttachment), att.Type)
+				}
+			}
+			assert.True(t, found, "expected attachment with path %q in entity output", src.externalID)
+		})
+	}
+}
+
+// TestEntityService_AttachmentAddExternalLink_AttachmentTypes verifies that all
+// attachment type variants (Manual, Warranty, Receipt) are stored correctly.
+// The source-type matrix is already covered by
+// TestEntityService_AttachmentAddExternalLink_SourceTypes, so a single
+// representative source type is sufficient here.
+func TestEntityService_AttachmentAddExternalLink_AttachmentTypes(t *testing.T) {
+	src := knownSources[0]
+	expectedMime, _ := repo.MimeTypeForSourceType(src.sourceType)
+
+	cases := []struct {
+		attType attachment.Type
+		title   string
+	}{
+		{attachment.TypeManual, "Manual"},
+		{attachment.TypeWarranty, "Warranty"},
+		{attachment.TypeReceipt, "Receipt"},
+	}
+
+	svc := &EntityService{repo: tRepos}
+
+	for _, tc := range cases {
+		t.Run(string(tc.attType), func(t *testing.T) {
+			entity := newExternalLinkEntity(t)
+
+			out, err := svc.AttachmentAddExternalLink(tCtx, entity.ID, src.sourceType, src.externalID, tc.title, tc.attType)
+			require.NoError(t, err)
+
+			var found bool
+			for _, att := range out.Attachments {
+				if att.Path == src.externalID {
+					found = true
+					assert.Equal(t, string(tc.attType), att.Type)
+					assert.Equal(t, expectedMime, att.MimeType)
+				}
+			}
+			assert.True(t, found)
+		})
+	}
+}
+
+// TestEntityService_AttachmentAddExternalLink_MultipleAttachments verifies that
+// multiple external-link attachments (one per registered source type) can coexist
+// on a single entity.
+func TestEntityService_AttachmentAddExternalLink_MultipleAttachments(t *testing.T) {
 	svc := &EntityService{repo: tRepos}
 	entity := newExternalLinkEntity(t)
 
-	out, err := svc.AttachmentAddExternalLink(tCtx, entity.ID, "link", "https://example.com/doc/42", "Example Doc", "")
+	for _, src := range knownSources {
+		_, err := svc.AttachmentAddExternalLink(tCtx, entity.ID, src.sourceType, src.externalID, src.sourceType+" doc", attachment.TypeAttachment)
+		require.NoError(t, err, "failed for source type %q", src.sourceType)
+	}
+
+	latest, err := svc.repo.Entities.GetOneByGroup(tCtx, tCtx.GID, entity.ID)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(latest.Attachments), len(knownSources))
+}
+
+// TestEntityService_AttachmentAddExternalLink_NoBlobStorage verifies that
+// adding an external-link attachment does not trigger any blob-storage
+// operations (which would fail without a real storage backend).
+func TestEntityService_AttachmentAddExternalLink_NoBlobStorage(t *testing.T) {
+	svc := &EntityService{repo: tRepos}
+	entity := newExternalLinkEntity(t)
+	src := knownSources[0]
+
+	out, err := svc.AttachmentAddExternalLink(tCtx, entity.ID, src.sourceType, src.externalID, "No Blob Doc", attachment.TypeAttachment)
 	require.NoError(t, err)
 	require.NotEmpty(t, out.Attachments)
-
-	var found bool
-	for _, att := range out.Attachments {
-		if att.Path == "https://example.com/doc/42" {
-			found = true
-			assert.Equal(t, repo.MimeTypeLinkURL, att.MimeType)
-			assert.Equal(t, "Example Doc", att.Title)
-			assert.Equal(t, string(attachment.TypeAttachment), att.Type)
-		}
-	}
-	assert.True(t, found)
 }
 
-func TestEntityService_AttachmentAddExternalLink_ManualType(t *testing.T) {
-	svc := &EntityService{repo: tRepos}
-	entity := newExternalLinkEntity(t)
-
-	out, err := svc.AttachmentAddExternalLink(tCtx, entity.ID, "link", "https://example.com/manual", "Manual", attachment.TypeManual)
-	require.NoError(t, err)
-
-	var found bool
-	for _, att := range out.Attachments {
-		if att.Path == "https://example.com/manual" {
-			found = true
-			assert.Equal(t, string(attachment.TypeManual), att.Type)
-		}
-	}
-	assert.True(t, found)
-}
-
-func TestEntityService_AttachmentAddExternalLink_WarrantyType(t *testing.T) {
-	svc := &EntityService{repo: tRepos}
-	entity := newExternalLinkEntity(t)
-
-	out, err := svc.AttachmentAddExternalLink(tCtx, entity.ID, "link", "https://example.com/warranty", "Warranty", attachment.TypeWarranty)
-	require.NoError(t, err)
-
-	var found bool
-	for _, att := range out.Attachments {
-		if att.Path == "https://example.com/warranty" {
-			found = true
-			assert.Equal(t, string(attachment.TypeWarranty), att.Type)
-		}
-	}
-	assert.True(t, found)
-}
-
-func TestEntityService_AttachmentAddExternalLink_ReceiptType(t *testing.T) {
-	svc := &EntityService{repo: tRepos}
-	entity := newExternalLinkEntity(t)
-
-	out, err := svc.AttachmentAddExternalLink(tCtx, entity.ID, "link", "https://example.com/receipt", "Receipt", attachment.TypeReceipt)
-	require.NoError(t, err)
-
-	var found bool
-	for _, att := range out.Attachments {
-		if att.Path == "https://example.com/receipt" {
-			found = true
-			assert.Equal(t, string(attachment.TypeReceipt), att.Type)
-		}
-	}
-	assert.True(t, found)
-}
-
+// TestEntityService_AttachmentAddExternalLink_InvalidEntity verifies that
+// using a non-existent entity ID returns an error.
 func TestEntityService_AttachmentAddExternalLink_InvalidEntity(t *testing.T) {
 	svc := &EntityService{repo: tRepos}
+	src := knownSources[0]
 
-	_, err := svc.AttachmentAddExternalLink(tCtx, uuid.New(), "link", "https://example.com/missing", "Missing", attachment.TypeAttachment)
+	_, err := svc.AttachmentAddExternalLink(tCtx, uuid.New(), src.sourceType, src.externalID, "Missing", attachment.TypeAttachment)
 	assert.Error(t, err)
 }
 
+// TestEntityService_AttachmentAddExternalLink_UnknownSourceType verifies that
+// an unregistered source type is rejected before any DB write.
 func TestEntityService_AttachmentAddExternalLink_UnknownSourceType(t *testing.T) {
 	svc := &EntityService{repo: tRepos}
 	entity := newExternalLinkEntity(t)
 
-	_, err := svc.AttachmentAddExternalLink(tCtx, entity.ID, "paperless", "42", "Paperless", attachment.TypeAttachment)
+	_, err := svc.AttachmentAddExternalLink(tCtx, entity.ID, "unknown-source", "42", "Unknown", attachment.TypeAttachment)
 	assert.Error(t, err)
 }
 
+// TestEntityService_AttachmentDelete_ExternalLink verifies that an external-link
+// attachment can be deleted and is no longer retrievable afterwards.
 func TestEntityService_AttachmentDelete_ExternalLink(t *testing.T) {
 	svc := &EntityService{repo: tRepos}
 	entity := newExternalLinkEntity(t)
+	src := knownSources[0]
 
-	out, err := svc.AttachmentAddExternalLink(tCtx, entity.ID, "link", "https://example.com/delete", "Delete Me", attachment.TypeAttachment)
+	out, err := svc.AttachmentAddExternalLink(tCtx, entity.ID, src.sourceType, src.externalID, "Delete Me", attachment.TypeAttachment)
 	require.NoError(t, err)
 	require.NotEmpty(t, out.Attachments)
 
 	var createdID uuid.UUID
 	for _, att := range out.Attachments {
-		if att.Path == "https://example.com/delete" {
+		if att.Path == src.externalID {
 			createdID = att.ID
 			break
 		}

--- a/backend/internal/data/repo/repo_item_attachments.go
+++ b/backend/internal/data/repo/repo_item_attachments.go
@@ -84,16 +84,32 @@ type (
 	}
 )
 
+// MimeTypeLinkURL is the MIME type for generic HTTP/HTTPS URL links.
 const MimeTypeLinkURL = "link/url"
+
+// MimeTypePaperlessDocument is the MIME type for Paperless-ngx document links.
+const MimeTypePaperlessDocument = "paperless/document"
+
+// MimeTypeImmichAsset is the MIME type for Immich asset links.
+const MimeTypeImmichAsset = "immich/asset"
 
 var externalLinkMimeTypes = []string{
 	MimeTypeLinkURL,
+	MimeTypePaperlessDocument,
+	MimeTypeImmichAsset,
 }
 
+// MimeTypeForSourceType maps a user-facing integration source-type name (e.g. "paperless")
+// to the internal MIME discriminator stored in the attachments table.
+// Returns ("", false) for unknown source types.
 func MimeTypeForSourceType(sourceType string) (string, bool) {
 	switch sourceType {
 	case "link":
 		return MimeTypeLinkURL, true
+	case "paperless":
+		return MimeTypePaperlessDocument, true
+	case "immich":
+		return MimeTypeImmichAsset, true
 	default:
 		return "", false
 	}

--- a/backend/internal/data/repo/repo_item_attachments_test.go
+++ b/backend/internal/data/repo/repo_item_attachments_test.go
@@ -16,10 +16,22 @@ import (
 )
 
 func TestMimeTypeForSourceType(t *testing.T) {
+	// Test "link" source type
 	mime, ok := MimeTypeForSourceType("link")
 	assert.True(t, ok)
 	assert.Equal(t, MimeTypeLinkURL, mime)
 
+	// Test "paperless" source type
+	mime, ok = MimeTypeForSourceType("paperless")
+	assert.True(t, ok)
+	assert.Equal(t, MimeTypePaperlessDocument, mime)
+
+	// Test "immich" source type
+	mime, ok = MimeTypeForSourceType("immich")
+	assert.True(t, ok)
+	assert.Equal(t, MimeTypeImmichAsset, mime)
+
+	// Test unknown source type
 	mime, ok = MimeTypeForSourceType("unknown")
 	assert.False(t, ok)
 	assert.Empty(t, mime)
@@ -138,44 +150,103 @@ func TestAttachmentRepo_Delete(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestAttachmentRepo_CreateExternalLink(t *testing.T) {
-	ctx := context.Background()
-	entity := useEntities(t, 1)[0]
-
-	att, err := tRepos.Attachments.CreateExternalLink(
-		ctx,
-		entity.ID,
-		"https://example.com/manual",
-		"Example Manual",
-		MimeTypeLinkURL,
-		attachment.TypeManual,
-	)
-	require.NoError(t, err)
-	require.NotNil(t, att)
-
-	t.Cleanup(func() {
-		_ = tRepos.Attachments.Delete(ctx, tGroup.ID, att.ID)
-	})
-
-	assert.Equal(t, "https://example.com/manual", att.Path)
-	assert.Equal(t, "Example Manual", att.Title)
-	assert.Equal(t, MimeTypeLinkURL, att.MimeType)
-	assert.Equal(t, attachment.TypeManual, att.Type)
-	assert.False(t, att.Primary)
+// externalLinkMimeTypeCases covers every registered external-link MIME type.
+// Adding a new integration only requires a new entry here — all table-driven
+// tests below pick it up automatically.
+var externalLinkMimeTypeCases = []struct {
+	mimeType   string
+	externalID string
+}{
+	{MimeTypeLinkURL, "https://example.com/doc"},
+	{MimeTypePaperlessDocument, "42"},
+	{MimeTypeImmichAsset, "1df4f848-dead-beef-cafe-123456789abc"},
 }
 
+// TestAttachmentRepo_CreateExternalLink_PerMimeType verifies that path, title,
+// and mimeType are stored and returned verbatim for every known external-link
+// MIME type.
+func TestAttachmentRepo_CreateExternalLink_PerMimeType(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range externalLinkMimeTypeCases {
+		t.Run(tc.mimeType, func(t *testing.T) {
+			entity := useEntities(t, 1)[0]
+
+			att, err := tRepos.Attachments.CreateExternalLink(ctx, entity.ID, tc.externalID, "Test Doc", tc.mimeType, attachment.TypeAttachment)
+			require.NoError(t, err)
+			require.NotNil(t, att)
+
+			t.Cleanup(func() { _ = tRepos.Attachments.Delete(ctx, tGroup.ID, att.ID) })
+
+			assert.Equal(t, tc.externalID, att.Path)
+			assert.Equal(t, "Test Doc", att.Title)
+			assert.Equal(t, tc.mimeType, att.MimeType)
+			assert.Equal(t, attachment.TypeAttachment, att.Type)
+			assert.False(t, att.Primary)
+		})
+	}
+}
+
+// TestAttachmentRepo_CreateExternalLink_AttachmentTypes verifies that all
+// attachment type variants are stored correctly. A single representative MIME
+// type is sufficient since the MIME type coverage is handled above.
+func TestAttachmentRepo_CreateExternalLink_AttachmentTypes(t *testing.T) {
+	ctx := context.Background()
+	mimeType := externalLinkMimeTypeCases[0].mimeType
+	externalID := externalLinkMimeTypeCases[0].externalID
+
+	types := []attachment.Type{
+		attachment.TypeAttachment,
+		attachment.TypeManual,
+		attachment.TypeWarranty,
+		attachment.TypeReceipt,
+	}
+
+	for _, typ := range types {
+		t.Run(string(typ), func(t *testing.T) {
+			entity := useEntities(t, 1)[0]
+
+			att, err := tRepos.Attachments.CreateExternalLink(ctx, entity.ID, externalID, "Doc", mimeType, typ)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = tRepos.Attachments.Delete(ctx, tGroup.ID, att.ID) })
+
+			assert.Equal(t, typ, att.Type)
+			assert.Equal(t, mimeType, att.MimeType)
+		})
+	}
+}
+
+// TestAttachmentRepo_CreateExternalLink_EmptyTypeDefaultsToAttachment verifies
+// that passing an empty attachment type string results in TypeAttachment.
+func TestAttachmentRepo_CreateExternalLink_EmptyTypeDefaultsToAttachment(t *testing.T) {
+	ctx := context.Background()
+	tc := externalLinkMimeTypeCases[0]
+	entity := useEntities(t, 1)[0]
+
+	att, err := tRepos.Attachments.CreateExternalLink(ctx, entity.ID, tc.externalID, "Test", tc.mimeType, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tRepos.Attachments.Delete(ctx, tGroup.ID, att.ID) })
+
+	assert.Equal(t, attachment.TypeAttachment, att.Type)
+}
+
+// TestAttachmentRepo_CreateExternalLink_InvalidEntityID verifies that using a
+// non-existent entity ID returns an error.
+func TestAttachmentRepo_CreateExternalLink_InvalidEntityID(t *testing.T) {
+	tc := externalLinkMimeTypeCases[0]
+
+	_, err := tRepos.Attachments.CreateExternalLink(context.Background(), uuid.New(), tc.externalID, "Orphan", tc.mimeType, attachment.TypeAttachment)
+	assert.Error(t, err)
+}
+
+// TestAttachmentRepo_DeleteExternalLink verifies that a created external-link
+// attachment can be deleted and is no longer retrievable.
 func TestAttachmentRepo_DeleteExternalLink(t *testing.T) {
 	ctx := context.Background()
 	entity := useEntities(t, 1)[0]
+	tc := externalLinkMimeTypeCases[0]
 
-	att, err := tRepos.Attachments.CreateExternalLink(
-		ctx,
-		entity.ID,
-		"https://example.com/receipt",
-		"Example Receipt",
-		MimeTypeLinkURL,
-		attachment.TypeReceipt,
-	)
+	att, err := tRepos.Attachments.CreateExternalLink(ctx, entity.ID, tc.externalID, "Delete Me", tc.mimeType, attachment.TypeAttachment)
 	require.NoError(t, err)
 
 	err = tRepos.Attachments.Delete(ctx, tGroup.ID, att.ID)
@@ -185,24 +256,22 @@ func TestAttachmentRepo_DeleteExternalLink(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestAttachmentRepo_DeleteExternalLink_DoesNotRequireBlobStorage verifies that
+// deleting an external-link attachment does not attempt blob-storage I/O.
 func TestAttachmentRepo_DeleteExternalLink_DoesNotRequireBlobStorage(t *testing.T) {
 	ctx := context.Background()
-
 	repos := New(tClient, tbus, config.Storage{PrefixPath: "/", ConnString: "mem://"}, "mem://{{ .Topic }}", config.Thumbnail{Enabled: false})
 	entity := useEntities(t, 1)[0]
+	tc := externalLinkMimeTypeCases[0]
 
-	att, err := repos.Attachments.CreateExternalLink(
-		ctx,
-		entity.ID,
-		"https://example.com/no-blob",
-		"No Blob",
-		MimeTypeLinkURL,
-		attachment.TypeAttachment,
-	)
+	att, err := repos.Attachments.CreateExternalLink(ctx, entity.ID, tc.externalID, "No Blob", tc.mimeType, attachment.TypeAttachment)
 	require.NoError(t, err)
 
 	err = repos.Attachments.Delete(ctx, tGroup.ID, att.ID)
 	require.NoError(t, err)
+
+	_, err = tRepos.Attachments.Get(ctx, tGroup.ID, att.ID)
+	assert.Error(t, err)
 }
 
 func TestAttachmentRepo_EnsureSinglePrimaryAttachment(t *testing.T) {

--- a/frontend/components/Item/AttachmentsList.vue
+++ b/frontend/components/Item/AttachmentsList.vue
@@ -1,68 +1,181 @@
 <template>
   <ul role="list" class="divide-y rounded-md border">
-    <li
-      v-for="attachment in attachments"
-      :key="attachment.id"
-      class="flex items-center justify-between py-3 pl-3 pr-4 text-sm"
-    >
-      <template v-if="isExternalURLAttachment(attachment)">
-        <div class="flex w-0 flex-1 items-center">
-          <MdiLinkVariant class="size-5 shrink-0 text-gray-400" aria-hidden="true" />
-          <a
-            class="ml-2 w-0 flex-1 truncate text-primary underline"
-            :href="attachment.path"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {{ attachment.title }}
-          </a>
+    <li v-for="attachment in displayAttachments" :key="attachment.id" class="py-3 pl-3 pr-4 text-sm">
+      <!-- ================================================================ -->
+      <!-- Paperless document                                               -->
+      <!-- ================================================================ -->
+      <template v-if="attachment.mimeType === MIME_PAPERLESS">
+        <!-- Unconfigured: URL removed — render as plain unlinkable attachment, no service hints -->
+        <div v-if="!paperlessConfigured" class="flex items-center">
+          <MdiPaperclip class="size-5 shrink-0 text-gray-400" aria-hidden="true" />
+          <span class="ml-2 truncate">{{ attachment.title }}</span>
         </div>
-        <div class="ml-4 flex shrink-0 gap-2">
-          <TooltipProvider :delay-duration="0">
-            <Tooltip>
-              <TooltipTrigger as-child>
-                <a
-                  :class="buttonVariants({ size: 'icon' })"
-                  :href="attachment.path"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <MdiOpenInNew />
-                </a>
-              </TooltipTrigger>
-              <TooltipContent> {{ $t("components.item.attachments_list.open_new_tab") }} </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+
+        <!-- Configured: rich card with loading / ok / stale / error states -->
+        <div v-else class="flex w-full gap-3">
+          <!-- Thumbnail area -->
+          <div class="shrink-0">
+            <div
+              v-if="attachState(attachment) === 'loading' && !paperlessThumbUrls[attachment.path]"
+              class="flex size-14 items-center justify-center rounded border bg-muted"
+            >
+              <MdiLoading class="size-7 animate-spin text-muted-foreground" aria-hidden="true" />
+            </div>
+            <img
+              v-else-if="paperlessThumbUrls[attachment.path]"
+              :src="paperlessThumbUrls[attachment.path]"
+              class="size-14 rounded object-cover shadow"
+              alt=""
+            />
+            <div v-else class="flex size-14 items-center justify-center rounded border bg-muted">
+              <MdiFileDocument class="size-7 text-blue-500" aria-hidden="true" />
+            </div>
+          </div>
+
+          <!-- Content area -->
+          <div class="min-w-0 flex-1 space-y-1">
+            <p class="truncate font-medium leading-tight">
+              {{ paperlessDoc(attachment)?.title || attachment.title }}
+            </p>
+
+            <p
+              v-if="paperlessDoc(attachment)?.correspondent || paperlessDoc(attachment)?.document_type"
+              class="flex items-center gap-1.5 text-xs text-muted-foreground"
+            >
+              <MdiAccountOutline v-if="paperlessDoc(attachment)?.correspondent" class="size-3.5 shrink-0" />
+              <span v-if="paperlessDoc(attachment)?.correspondent" class="truncate">
+                {{ paperlessDoc(attachment)?.correspondent?.name }}
+              </span>
+              <span
+                v-if="paperlessDoc(attachment)?.correspondent && paperlessDoc(attachment)?.document_type"
+                class="text-muted-foreground/40"
+              >
+                ·
+              </span>
+              <MdiTagOutline v-if="paperlessDoc(attachment)?.document_type" class="size-3.5 shrink-0" />
+              <span v-if="paperlessDoc(attachment)?.document_type">
+                {{ paperlessDoc(attachment)?.document_type?.name }}
+              </span>
+            </p>
+
+            <div v-if="paperlessDoc(attachment)?.tags?.length" class="flex flex-wrap gap-1">
+              <span
+                v-for="tag in paperlessDoc(attachment)?.tags"
+                :key="tag.id"
+                class="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium"
+                :style="{ backgroundColor: tag.color, color: tag.text_color }"
+              >
+                {{ tag.name }}
+              </span>
+            </div>
+
+            <p class="flex items-center gap-2 text-xs text-muted-foreground">
+              <span v-if="paperlessDoc(attachment)?.created_date">{{ paperlessDoc(attachment)?.created_date }}</span>
+              <span v-if="paperlessDoc(attachment)?.page_count" class="text-muted-foreground/40">·</span>
+              <span v-if="paperlessDoc(attachment)?.page_count"
+                >{{ paperlessDoc(attachment)?.page_count }} pages</span
+              >
+            </p>
+          </div>
+
+          <!-- Actions area -->
+          <div class="ml-2 flex shrink-0 items-start gap-1">
+            <!-- ⚠ unreachable badge -->
+            <TooltipProvider v-if="isUnreachable(attachment)" :delay-duration="0">
+              <Tooltip>
+                <TooltipTrigger>
+                  <MdiAlertCircleOutline class="size-4 text-amber-500" aria-label="Service unreachable" />
+                </TooltipTrigger>
+                <TooltipContent>{{ attachError(attachment) }}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            <!-- Open in Paperless -->
+            <TooltipProvider :delay-duration="0">
+              <Tooltip>
+                <TooltipTrigger as-child>
+                  <a
+                    :class="buttonVariants({ size: 'icon', variant: 'outline' })"
+                    :href="paperlessOpenUrl(attachment)"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <MdiOpenInNew />
+                  </a>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {{ $t("components.item.attachments_list.open_in_service", { service: "Paperless" }) }}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
         </div>
       </template>
-      <template v-else>
-        <div class="flex w-0 flex-1 items-center">
-          <MdiPaperclip class="size-5 shrink-0 text-gray-400" aria-hidden="true" />
-          <span class="ml-2 w-0 flex-1 truncate"> {{ attachment.title }}</span>
+
+      <!-- Generic Link Attachment -->
+      <template v-else-if="isLink(attachment)">
+        <div class="flex items-center justify-between">
+          <div class="flex w-0 flex-1 items-center">
+            <MdiLinkVariant class="size-5 shrink-0 text-gray-400" aria-hidden="true" />
+            <a
+              class="ml-2 w-0 flex-1 truncate text-primary underline"
+              :href="attachment.path"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {{ attachment.title }}
+            </a>
+          </div>
+          <div class="ml-4 flex shrink-0 gap-2">
+            <TooltipProvider :delay-duration="0">
+              <Tooltip>
+                <TooltipTrigger as-child>
+                  <a
+                    :class="buttonVariants({ size: 'icon' })"
+                    :href="attachment.path"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <MdiOpenInNew />
+                  </a>
+                </TooltipTrigger>
+                <TooltipContent> {{ $t("components.item.attachments_list.open_new_tab") }} </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
         </div>
-        <div class="ml-4 flex shrink-0 gap-2">
-          <TooltipProvider :delay-duration="0">
-            <Tooltip>
-              <TooltipTrigger as-child>
-                <a
-                  :class="buttonVariants({ size: 'icon' })"
-                  :href="attachmentURL(attachment.id)"
-                  :download="attachment.title"
-                >
-                  <MdiDownload />
-                </a>
-              </TooltipTrigger>
-              <TooltipContent> {{ $t("components.item.attachments_list.download") }} </TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger as-child>
-                <a :class="buttonVariants({ size: 'icon' })" :href="attachmentURL(attachment.id)" target="_blank">
-                  <MdiOpenInNew />
-                </a>
-              </TooltipTrigger>
-              <TooltipContent> {{ $t("components.item.attachments_list.open_new_tab") }} </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+      </template>
+
+      <!-- File Attachment -->
+      <template v-else>
+        <div class="flex items-center justify-between">
+          <div class="flex w-0 flex-1 items-center">
+            <MdiPaperclip class="size-5 shrink-0 text-gray-400" aria-hidden="true" />
+            <span class="ml-2 w-0 flex-1 truncate"> {{ attachment.title }}</span>
+          </div>
+          <div class="ml-4 flex shrink-0 gap-2">
+            <TooltipProvider :delay-duration="0">
+              <Tooltip>
+                <TooltipTrigger as-child>
+                  <a
+                    :class="buttonVariants({ size: 'icon' })"
+                    :href="attachmentURL(attachment.id)"
+                    :download="attachment.title"
+                  >
+                    <MdiDownload />
+                  </a>
+                </TooltipTrigger>
+                <TooltipContent> {{ $t("components.item.attachments_list.download") }} </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger as-child>
+                  <a :class="buttonVariants({ size: 'icon' })" :href="attachmentURL(attachment.id)" target="_blank">
+                    <MdiOpenInNew />
+                  </a>
+                </TooltipTrigger>
+                <TooltipContent> {{ $t("components.item.attachments_list.open_new_tab") }} </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
         </div>
       </template>
     </li>
@@ -70,13 +183,25 @@
 </template>
 
 <script setup lang="ts">
+  import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
   import type { ItemAttachment } from "~~/lib/api/types/data-contracts";
+  import { useIntegrationCacheStore } from "~/stores/integration-cache";
+  import type { AttachmentFetchState } from "~/stores/integration-cache";
+  import { SERVICE_ADAPTERS } from "~/lib/integration-adapters";
   import MdiPaperclip from "~icons/mdi/paperclip";
   import MdiLinkVariant from "~icons/mdi/link-variant";
   import MdiDownload from "~icons/mdi/download";
   import MdiOpenInNew from "~icons/mdi/open-in-new";
+  import MdiFileDocument from "~icons/mdi/file-document";
+  import MdiAccountOutline from "~icons/mdi/account-outline";
+  import MdiTagOutline from "~icons/mdi/tag-outline";
+  import MdiLoading from "~icons/mdi/loading";
+  import MdiAlertCircleOutline from "~icons/mdi/alert-circle-outline";
   import { buttonVariants } from "@/components/ui/button";
   import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+  const MIME_PAPERLESS = "paperless/document";
+  const MIME_LINK = "link/url";
 
   const props = defineProps({
     attachments: {
@@ -90,17 +215,342 @@
   });
 
   const api = useUserApi();
+  const store = useIntegrationCacheStore();
+
+  // ---------------------------------------------------------------------------
+  // Settings state (reactive, driven by store)
+  // ---------------------------------------------------------------------------
+
+  const paperlessConfigured = computed(() => !!store.serviceUrls["paperless"]?.trim());
+
+  // ---------------------------------------------------------------------------
+  // Runtime lift: treat link/url attachments as their service type when the
+  // URL matches.
+  //  - Configured service + host matches → lifted (full card + hydration)
+  //  - No configured service URL + pattern matches → lifted (demoted plain
+  //    paperclip, no hydration because service is unconfigured)
+  //  - Configured service + host doesn't match → NOT lifted (URL link, safe)
+  // ---------------------------------------------------------------------------
+
+  function liftAttachment(attachment: ItemAttachment): ItemAttachment {
+    if (attachment.mimeType !== MIME_LINK) return attachment;
+    for (const adapter of SERVICE_ADAPTERS) {
+      const configuredUrl = store.serviceUrls[adapter.name]?.trim();
+      if (!configuredUrl) continue; // service not configured → keep as plain link/url
+      const id = adapter.extractId(attachment.path, configuredUrl);
+      if (id !== null) return { ...attachment, mimeType: adapter.mimeType, path: id };
+    }
+    return attachment;
+  }
+
+  /**
+   * Attachments as the template sees them.  link/url entries that match a
+   * service URL are lifted to the correct mimeType/path so the existing
+   * Paperless card branch handles them automatically.
+   */
+  const displayAttachments = computed(() => props.attachments.map(liftAttachment));
+
+  // ---------------------------------------------------------------------------
+  // Thumbnail state (component-local — objectURLs must be revoked on unmount)
+  // ---------------------------------------------------------------------------
+
+  const paperlessThumbUrls = ref<Record<string, string>>({});
+  const objectUrls = new Set<string>();
+
+  function createObjectUrl(blob: Blob): string {
+    const url = URL.createObjectURL(blob);
+    objectUrls.add(url);
+    return url;
+  }
+
+  onBeforeUnmount(() => {
+    for (const url of objectUrls) URL.revokeObjectURL(url);
+    objectUrls.clear();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Enriched-data types
+  // ---------------------------------------------------------------------------
+
+  interface PaperlessTag {
+    id: number;
+    name: string;
+    color: string;
+    text_color: string;
+  }
+
+  interface PaperlessRelated {
+    id: number;
+    name: string;
+  }
+
+  interface PaperlessEnrichedDoc {
+    id: number;
+    title: string;
+    created_date: string;
+    page_count: number;
+    correspondent: PaperlessRelated | null;
+    document_type: PaperlessRelated | null;
+    tags: PaperlessTag[];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Store-backed typed getters
+  // ---------------------------------------------------------------------------
+
+  function paperlessDoc(attachment: ItemAttachment): PaperlessEnrichedDoc | null {
+    return (store.getEnrichedData("paperless", attachment.path) as PaperlessEnrichedDoc | undefined) ?? null;
+  }
+
+  function attachState(attachment: ItemAttachment): AttachmentFetchState | undefined {
+    return store.fetchStates[attachment.id];
+  }
+
+  function attachError(attachment: ItemAttachment): string | undefined {
+    return store.fetchErrors[attachment.id];
+  }
+
+  /** True when state is stale or error (server was unreachable). */
+  function isUnreachable(attachment: ItemAttachment): boolean {
+    const s = attachState(attachment);
+    return s === "stale" || s === "error";
+  }
+
+  // ---------------------------------------------------------------------------
+  // URL helpers
+  // ---------------------------------------------------------------------------
 
   function attachmentURL(attachmentId: string) {
     return api.authURL(`/entities/${props.itemId}/attachments/${attachmentId}`);
   }
 
-  function isExternalURLAttachment(attachment: ItemAttachment) {
-    if (attachment.mimeType === "link/url") {
-      return true;
-    }
-    return attachment.path.startsWith("http://") || attachment.path.startsWith("https://");
+  function proxyUrl(serviceName: string, relativePath: string): string {
+    return `/api/v1/integrations/${serviceName}/proxy?path=${encodeURIComponent(relativePath)}`;
   }
+
+  function paperlessOpenUrl(attachment: ItemAttachment): string {
+    const base = (store.serviceUrls["paperless"] ?? "").replace(/\/$/, "");
+    if (!base) return "#";
+    return `${base}/documents/${attachment.path}/details`;
+  }
+
+
+  function isLink(attachment: ItemAttachment): boolean {
+    return attachment.mimeType === MIME_LINK;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Error classification
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Turn a caught fetch error into a human-readable tooltip string.
+   * Errors thrown by fetchX functions carry the HTTP status in their message
+   * as "HTTP {status}" so we can show a precise reason.
+   */
+  function describeRequestError(err: unknown, baseUrl: string): string {
+    const msg = err instanceof Error ? err.message : "";
+    const statusMatch = msg.match(/^HTTP (\d+)$/);
+    if (statusMatch) {
+      const status = Number(statusMatch[1]);
+      if (status === 401 || status === 403) {
+        return "Authentication failed — check your API token in Profile Settings";
+      }
+      return `Request failed (HTTP ${status}) — did you set an API token in Profile Settings?`;
+    }
+    // No HTTP status → network-level failure (DNS, refused connection, etc.)
+    return `Service unreachable at ${baseUrl}`;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Paperless hydration
+  // ---------------------------------------------------------------------------
+
+  async function fetchPaperlessEnrichedDoc(docId: string): Promise<PaperlessEnrichedDoc> {
+    const rawRes = await fetch(proxyUrl("paperless", `/api/documents/${docId}/`));
+    if (!rawRes.ok) throw new Error(`HTTP ${rawRes.status}`);
+
+    const raw = (await rawRes.json()) as {
+      id: number;
+      title: string;
+      created_date: string;
+      page_count: number;
+      correspondent?: number;
+      document_type?: number;
+      tags?: number[];
+    };
+
+    const doc: PaperlessEnrichedDoc = {
+      id: raw.id,
+      title: raw.title,
+      created_date: raw.created_date,
+      page_count: raw.page_count,
+      correspondent: null,
+      document_type: null,
+      tags: [],
+    };
+
+    const jobs: Promise<void>[] = [];
+
+    if (raw.correspondent) {
+      jobs.push(
+        fetch(proxyUrl("paperless", `/api/correspondents/${raw.correspondent}/`))
+          .then(r => (r.ok ? r.json() : null))
+          .then(c => {
+            if (c) {
+              doc.correspondent = {
+                id: Number((c as { id?: number }).id),
+                name: String((c as { name?: string }).name || ""),
+              };
+            }
+          })
+          .catch(() => {})
+      );
+    }
+
+    if (raw.document_type) {
+      jobs.push(
+        fetch(proxyUrl("paperless", `/api/document_types/${raw.document_type}/`))
+          .then(r => (r.ok ? r.json() : null))
+          .then(d => {
+            if (d) {
+              doc.document_type = {
+                id: Number((d as { id?: number }).id),
+                name: String((d as { name?: string }).name || ""),
+              };
+            }
+          })
+          .catch(() => {})
+      );
+    }
+
+    const tagIds = Array.isArray(raw.tags) ? raw.tags : [];
+    const tagResults: Array<PaperlessTag | null> = new Array(tagIds.length).fill(null);
+    tagIds.forEach((tagId, idx) => {
+      jobs.push(
+        fetch(proxyUrl("paperless", `/api/tags/${tagId}/`))
+          .then(r => (r.ok ? r.json() : null))
+          .then(t => {
+            if (t) {
+              tagResults[idx] = {
+                id: Number((t as { id?: number }).id),
+                name: String((t as { name?: string }).name || ""),
+                color: String((t as { color?: string }).color || "#E5E7EB"),
+                text_color: String((t as { text_color?: string }).text_color || "#111827"),
+              };
+            }
+          })
+          .catch(() => {})
+      );
+    });
+
+    await Promise.all(jobs);
+    doc.tags = tagResults.filter((tag): tag is PaperlessTag => tag !== null);
+    return doc;
+  }
+
+  async function fetchPaperlessThumbnail(docId: string): Promise<void> {
+    if (paperlessThumbUrls.value[docId]) return;
+    const res = await fetch(proxyUrl("paperless", `/api/documents/${docId}/thumb/`));
+    if (!res.ok) return;
+    paperlessThumbUrls.value[docId] = createObjectUrl(await res.blob());
+  }
+
+  async function hydratePaperless(attachment: ItemAttachment): Promise<void> {
+    const docId = attachment.path;
+    const configuredUrl = store.serviceUrls["paperless"] ?? "";
+    const cached = store.getEnrichedData("paperless", docId);
+
+    // Show cached data immediately (stale state) while we try to refresh.
+    store.setState(attachment.id, cached ? "stale" : "loading");
+
+    try {
+      const doc = await fetchPaperlessEnrichedDoc(docId);
+      store.setEnrichedData("paperless", docId, doc);
+      store.setState(attachment.id, "ok");
+      // Thumbnail is best-effort after enriched data succeeds.
+      fetchPaperlessThumbnail(docId).catch(() => {});
+    } catch (err) {
+      store.setState(attachment.id, cached ? "stale" : "error", describeRequestError(err, configuredUrl));
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Generic dispatch table — add a new service by adding one entry here
+  // ---------------------------------------------------------------------------
+
+  const hydrateHandlers: Partial<Record<string, (a: ItemAttachment) => Promise<void>>> = {
+    paperless: hydratePaperless,
+  };
+
+  async function hydrateAllAttachments(attachments: ItemAttachment[]): Promise<void> {
+    await Promise.all(
+      attachments.map(async attachment => {
+        const serviceName = mimeToServiceName(attachment.mimeType);
+        if (!serviceName) return; // not a service attachment
+        if (!store.serviceUrls[serviceName]?.trim()) return; // unconfigured — show degraded state
+        const handler = hydrateHandlers[serviceName];
+        if (!handler) return;
+        await handler(attachment);
+      })
+    );
+  }
+
+  /** Maps a service MIME type to its service name, or null for non-service types. */
+  function mimeToServiceName(mimeType: string): string | null {
+    if (mimeType === MIME_PAPERLESS) return "paperless";
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  onMounted(async () => {
+    await store.loadSettings(api);
+    void hydrateAllAttachments(displayAttachments.value);
+  });
+
+  // React to new/removed attachments.
+  watch(
+    () => props.attachments,
+    async newAttachments => {
+      const lifted = newAttachments.map(liftAttachment);
+      const fresh = lifted.filter(a => !(a.id in store.fetchStates));
+      if (fresh.length > 0) {
+        void hydrateAllAttachments(fresh);
+      }
+    }
+  );
+
+  /**
+   * React to URL additions/removals in the store (e.g. user saves/clears the
+   * service URL in Profile Settings while this component is mounted).
+   * - URL added   → hydrate all attachments for that service (promote)
+   * - URL removed → clear fetch state so they fall back to the unconfigured card
+   */
+  watch(
+    () => ({ ...store.serviceUrls }),
+    (newUrls, oldUrls) => {
+      for (const [name, newUrl] of Object.entries(newUrls)) {
+        const oldUrl = oldUrls?.[name] ?? "";
+        if (newUrl === oldUrl) continue;
+
+        const affected = displayAttachments.value.filter(a => mimeToServiceName(a.mimeType) === name);
+        if (affected.length === 0) continue;
+
+        if (!newUrl.trim()) {
+          // URL removed → demote: clear state so template shows the unconfigured card.
+          for (const a of affected) store.clearAttachmentState(a.id);
+        } else {
+          // URL added/changed → promote: re-hydrate all affected attachments.
+          for (const a of affected) store.clearAttachmentState(a.id);
+          void hydrateAllAttachments(affected);
+        }
+      }
+    },
+    { deep: false }
+  );
 </script>
 
 <style scoped></style>

--- a/frontend/composables/preferences-utils.ts
+++ b/frontend/composables/preferences-utils.ts
@@ -1,0 +1,101 @@
+/**
+ * Pure, framework-free utilities for view-preference syncing.
+ * Extracted so they can be unit-tested without a Nuxt/Vue environment.
+ */
+import type { EntitySummary } from "~/lib/api/types/data-contracts";
+import type { DaisyTheme } from "~~/lib/data/themes";
+
+export type ViewType = "table" | "card";
+
+export type DuplicateSettings = {
+  copyMaintenance: boolean;
+  copyAttachments: boolean;
+  copyCustomFields: boolean;
+  copyPrefixOverride: string | null;
+};
+
+export type LocationViewPreferences = {
+  showDetails: boolean;
+  showEmpty: boolean;
+  editorAdvancedView: boolean;
+  itemDisplayView: ViewType;
+  theme: DaisyTheme;
+  itemsPerTablePage: number;
+  tableHeaders?: {
+    value: keyof EntitySummary;
+    enabled: boolean;
+  }[];
+  displayLegacyHeader: boolean;
+  legacyImageFit: boolean;
+  language?: string | null;
+  overrideFormatLocale?: string | null;
+  collectionId?: string | null;
+  duplicateSettings: DuplicateSettings;
+  shownMultiTabWarning: boolean;
+  quickActions: {
+    enabled: boolean;
+  };
+};
+
+export type PreferenceSyncConfig = Partial<Record<keyof LocationViewPreferences, boolean>>;
+
+export const DEFAULT_PREFERENCES: LocationViewPreferences = {
+  showDetails: true,
+  showEmpty: true,
+  editorAdvancedView: false,
+  itemDisplayView: "card",
+  theme: "homebox",
+  itemsPerTablePage: 10,
+  displayLegacyHeader: false,
+  legacyImageFit: false,
+  language: null,
+  overrideFormatLocale: null,
+  duplicateSettings: {
+    copyMaintenance: false,
+    copyAttachments: true,
+    copyCustomFields: true,
+    copyPrefixOverride: null,
+  },
+  shownMultiTabWarning: false,
+  quickActions: {
+    enabled: true,
+  },
+};
+
+const preferenceKeys = Object.keys(DEFAULT_PREFERENCES) as (keyof LocationViewPreferences)[];
+
+export function forEachSyncedPreference(
+  syncConfig: PreferenceSyncConfig,
+  callback: (key: keyof LocationViewPreferences) => void
+) {
+  for (const key of preferenceKeys) {
+    if (syncConfig[key] !== false) {
+      callback(key);
+    }
+  }
+}
+
+export function buildSyncedSettings(
+  preferences: LocationViewPreferences,
+  syncConfig: PreferenceSyncConfig
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  forEachSyncedPreference(syncConfig, key => {
+    payload[key] = preferences[key];
+  });
+  return payload;
+}
+
+export function mergeSyncedSettings(
+  settings: Record<string, unknown>,
+  preferences: LocationViewPreferences,
+  syncConfig: PreferenceSyncConfig
+): LocationViewPreferences {
+  const nextPreferences = { ...preferences };
+  forEachSyncedPreference(syncConfig, key => {
+    if (key in settings) {
+      nextPreferences[key] = settings[key] as never;
+    }
+  });
+  return nextPreferences;
+}

--- a/frontend/composables/use-preferences.test.ts
+++ b/frontend/composables/use-preferences.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for the pure helper functions in preferences-utils.ts.
+ *
+ * These tests exist specifically to catch the class of bug where
+ * `saveToServer` would call `setSettings(buildSyncedSettings(...))` directly,
+ * wiping integration keys (paperless_url, paperless_token, etc.) that are
+ * stored alongside preference keys in the same settings object.
+ *
+ * Regression: the fix ensures `saveToServer` does GET → merge → PUT.
+ * The tests below verify the invariants that make the merge safe.
+ */
+import { describe, expect, it } from "vitest";
+import { DEFAULT_PREFERENCES, buildSyncedSettings, mergeSyncedSettings } from "./preferences-utils";
+
+// Keys that live in the settings object but are NOT preferences and must never
+// be overwritten by a bare preferences save.
+const INTEGRATION_KEYS = ["paperless_url", "paperless_token", "immich_url", "immich_token"] as const;
+
+// Default sync config (all preference keys synced).
+const SYNC_ALL = {};
+
+describe("use-preferences pure helpers", () => {
+  describe("buildSyncedSettings", () => {
+    it("never includes integration keys", () => {
+      const payload = buildSyncedSettings(DEFAULT_PREFERENCES, SYNC_ALL);
+      for (const key of INTEGRATION_KEYS) {
+        expect(Object.prototype.hasOwnProperty.call(payload, key)).toBe(false);
+      }
+    });
+
+    it("includes known preference keys", () => {
+      const payload = buildSyncedSettings(DEFAULT_PREFERENCES, SYNC_ALL);
+      expect(payload).toHaveProperty("showDetails");
+      expect(payload).toHaveProperty("theme");
+      expect(payload).toHaveProperty("duplicateSettings");
+    });
+
+    it("reflects actual preference values", () => {
+      const prefs = { ...DEFAULT_PREFERENCES, showDetails: false, theme: "dark" as never };
+      const payload = buildSyncedSettings(prefs, SYNC_ALL);
+      expect(payload.showDetails).toBe(false);
+      expect(payload.theme).toBe("dark");
+    });
+
+    it("respects syncConfig exclusions", () => {
+      const payload = buildSyncedSettings(DEFAULT_PREFERENCES, { itemDisplayView: false });
+      expect(payload).not.toHaveProperty("itemDisplayView");
+      expect(payload).toHaveProperty("showDetails");
+    });
+  });
+
+  describe("mergeSyncedSettings – regression: integration keys are preserved", () => {
+    it("does NOT copy integration keys from server settings into preferences", () => {
+      const serverSettings = {
+        showDetails: false,
+        paperless_url: "http://localhost:8000",
+        paperless_token: "secret",
+      };
+      const result = mergeSyncedSettings(serverSettings, DEFAULT_PREFERENCES, SYNC_ALL);
+      // mergeSyncedSettings only touches known preference keys – integration keys
+      // must not appear on the preferences object.
+      expect((result as Record<string, unknown>).paperless_url).toBeUndefined();
+      expect((result as Record<string, unknown>).paperless_token).toBeUndefined();
+    });
+
+    it("merges known preference keys from server settings", () => {
+      const serverSettings = { showDetails: false, theme: "dark" };
+      const result = mergeSyncedSettings(serverSettings, DEFAULT_PREFERENCES, SYNC_ALL);
+      expect(result.showDetails).toBe(false);
+      expect(result.theme).toBe("dark");
+    });
+
+    it("preserves local preference values for keys absent from server", () => {
+      const result = mergeSyncedSettings({}, { ...DEFAULT_PREFERENCES, showDetails: false }, SYNC_ALL);
+      expect(result.showDetails).toBe(false);
+    });
+  });
+
+  describe("merge round-trip – the exact scenario that was broken", () => {
+    /**
+     * Simulates what saveToServer now does correctly:
+     *   existing = await getSettings()         ← includes paperless_url
+     *   merged   = { ...existing, ...buildSyncedSettings(prefs, syncConfig) }
+     *   await setSettings(merged)              ← must still contain paperless_url
+     *
+     * Previously: setSettings(buildSyncedSettings(prefs))  ← wiped paperless_url
+     */
+    it("merged payload preserves integration keys after preference save", () => {
+      const existingServerSettings: Record<string, unknown> = {
+        showDetails: true,
+        theme: "homebox",
+        paperless_url: "http://localhost:8000",
+        paperless_token: "secret-token",
+        immich_url: "http://localhost:2283",
+        immich_token: "immich-key",
+      };
+
+      const localPrefs = { ...DEFAULT_PREFERENCES, showDetails: false };
+      const prefPayload = buildSyncedSettings(localPrefs, SYNC_ALL);
+
+      // This is the fixed merge: existing settings first, preferences on top.
+      const merged = { ...existingServerSettings, ...prefPayload };
+
+      expect(merged.paperless_url).toBe("http://localhost:8000");
+      expect(merged.paperless_token).toBe("secret-token");
+      expect(merged.immich_url).toBe("http://localhost:2283");
+      expect(merged.immich_token).toBe("immich-key");
+      // And preferences are still updated:
+      expect(merged.showDetails).toBe(false);
+    });
+
+    it("old (broken) approach would wipe integration keys", () => {
+      const existingServerSettings: Record<string, unknown> = {
+        paperless_url: "http://localhost:8000",
+        paperless_token: "secret-token",
+      };
+
+      const prefPayload = buildSyncedSettings(DEFAULT_PREFERENCES, SYNC_ALL);
+
+      // Old buggy approach: only send preference keys (no GET+merge first)
+      expect(prefPayload).not.toHaveProperty("paperless_url");
+      expect(prefPayload).not.toHaveProperty("paperless_token");
+
+      // Sending only prefPayload to the server would have left paperless_url absent.
+      // The fix is: { ...existingServerSettings, ...prefPayload }
+      const broken = prefPayload; // ← what the old code sent
+      const fixed = { ...existingServerSettings, ...prefPayload };
+
+      expect(broken).not.toHaveProperty("paperless_url");
+      expect(fixed).toHaveProperty("paperless_url", "http://localhost:8000");
+    });
+  });
+});

--- a/frontend/composables/use-preferences.ts
+++ b/frontend/composables/use-preferences.ts
@@ -1,62 +1,15 @@
 import type { Ref } from "vue";
-import type { EntitySummary } from "~/lib/api/types/data-contracts";
-import type { DaisyTheme } from "~~/lib/data/themes";
+import {
+  type LocationViewPreferences,
+  type PreferenceSyncConfig,
+  DEFAULT_PREFERENCES,
+  buildSyncedSettings,
+  mergeSyncedSettings,
+} from "./preferences-utils";
 
-export type ViewType = "table" | "card";
+export type { ViewType, DuplicateSettings, LocationViewPreferences, PreferenceSyncConfig } from "./preferences-utils";
+export { DEFAULT_PREFERENCES, buildSyncedSettings, mergeSyncedSettings } from "./preferences-utils";
 
-export type DuplicateSettings = {
-  copyMaintenance: boolean;
-  copyAttachments: boolean;
-  copyCustomFields: boolean;
-  copyPrefixOverride: string | null;
-};
-
-export type LocationViewPreferences = {
-  showDetails: boolean;
-  showEmpty: boolean;
-  editorAdvancedView: boolean;
-  itemDisplayView: ViewType;
-  theme: DaisyTheme;
-  itemsPerTablePage: number;
-  tableHeaders?: {
-    value: keyof EntitySummary;
-    enabled: boolean;
-  }[];
-  displayLegacyHeader: boolean;
-  legacyImageFit: boolean;
-  language?: string | null;
-  overrideFormatLocale?: string | null;
-  collectionId?: string | null;
-  duplicateSettings: DuplicateSettings;
-  shownMultiTabWarning: boolean;
-  quickActions: {
-    enabled: boolean;
-  };
-};
-export type PreferenceSyncConfig = Partial<Record<keyof LocationViewPreferences, boolean>>;
-
-const DEFAULT_PREFERENCES: LocationViewPreferences = {
-  showDetails: true,
-  showEmpty: true,
-  editorAdvancedView: false,
-  itemDisplayView: "card",
-  theme: "homebox",
-  itemsPerTablePage: 10,
-  displayLegacyHeader: false,
-  legacyImageFit: false,
-  language: null,
-  overrideFormatLocale: null,
-  duplicateSettings: {
-    copyMaintenance: false,
-    copyAttachments: true,
-    copyCustomFields: true,
-    copyPrefixOverride: null,
-  },
-  shownMultiTabWarning: false,
-  quickActions: {
-    enabled: true,
-  },
-};
 let syncConfig: PreferenceSyncConfig = {
   itemDisplayView: false,
   shownMultiTabWarning: false,
@@ -64,40 +17,7 @@ let syncConfig: PreferenceSyncConfig = {
 
 let syncInitialized = false;
 
-const preferenceKeys = Object.keys(DEFAULT_PREFERENCES) as (keyof LocationViewPreferences)[];
-
 const results = useLocalStorage("homebox/preferences/location", DEFAULT_PREFERENCES, { mergeDefaults: true });
-
-function forEachSyncedPreference(callback: (key: keyof LocationViewPreferences) => void) {
-  for (const key of preferenceKeys) {
-    if (syncConfig[key] !== false) {
-      callback(key);
-    }
-  }
-}
-
-function buildSyncedSettings(preferences: LocationViewPreferences): Record<string, unknown> {
-  const payload: Record<string, unknown> = {};
-  forEachSyncedPreference(key => {
-    payload[key] = preferences[key];
-  });
-  return payload;
-}
-
-function mergeSyncedSettings(
-  settings: Record<string, unknown>,
-  preferences: LocationViewPreferences
-): LocationViewPreferences {
-  const nextPreferences = { ...preferences };
-
-  forEachSyncedPreference(key => {
-    if (key in settings) {
-      nextPreferences[key] = settings[key] as never;
-    }
-  });
-
-  return nextPreferences;
-}
 
 export function configureViewPreferenceSync(config: PreferenceSyncConfig) {
   syncConfig = {
@@ -118,7 +38,7 @@ async function refreshViewPreferencesFromServer(preferences: Ref<LocationViewPre
     return;
   }
 
-  preferences.value = mergeSyncedSettings(data.item, preferences.value);
+  preferences.value = mergeSyncedSettings(data.item, preferences.value, syncConfig);
 }
 export function useViewPreferencesSync() {
   if (syncInitialized || !import.meta.client) {
@@ -163,7 +83,9 @@ export function useViewPreferencesSync() {
     try {
       while (syncedRevision < localRevision && !pauseServerSaves && auth.isAuthorized()) {
         const targetRevision = localRevision;
-        const { error } = await api.user.setSettings(buildSyncedSettings(preferences.value));
+        const { data: current } = await api.user.getSettings();
+        const merged = { ...(current?.item ?? {}), ...buildSyncedSettings(preferences.value, syncConfig) };
+        const { error } = await api.user.setSettings(merged);
         if (error) {
           scheduleRetry();
           return;

--- a/frontend/lib/integration-adapters.test.ts
+++ b/frontend/lib/integration-adapters.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import {
+  SERVICE_ADAPTERS,
+  classifyDroppedUrl,
+  detectServiceFromUrl,
+  extractPaperlessDocId,
+  getAdapter,
+  getAdapterByMimeType,
+} from "./integration-adapters";
+
+describe("integration adapters", () => {
+  describe("extractPaperlessDocId", () => {
+    it("extracts doc id from /documents/{id}", () => {
+      expect(extractPaperlessDocId("https://paperless.local/documents/42", "https://paperless.local")).toBe("42");
+    });
+
+    it("extracts doc id from /documents/{id}/details", () => {
+      expect(extractPaperlessDocId("https://paperless.local/documents/42/details", "https://paperless.local")).toBe(
+        "42"
+      );
+    });
+
+    it("returns null for foreign host", () => {
+      expect(extractPaperlessDocId("https://paperless.local.evil/documents/42", "https://paperless.local")).toBeNull();
+    });
+
+    it("supports base path setups", () => {
+      expect(
+        extractPaperlessDocId(
+          "https://example.local/paperless/documents/500/details",
+          "https://example.local/paperless"
+        )
+      ).toBe("500");
+    });
+
+    it("extracts doc id without base URL", () => {
+      expect(extractPaperlessDocId("https://paperless.local/documents/77/details")).toBe("77");
+    });
+
+    it("extracts doc id when configured base URL is invalid", () => {
+      expect(extractPaperlessDocId("https://paperless.local/documents/99/details", "homebox")).toBe("99");
+    });
+
+    it("extracts doc id from bare-hostname URLs", () => {
+      expect(extractPaperlessDocId("localhost/documents/2/details")).toBe("2");
+    });
+
+    it("trims whitespace around URL and base URL", () => {
+      expect(extractPaperlessDocId("  http://localhost:8000/documents/7/  ", "  http://localhost:8000/  ")).toBe("7");
+    });
+  });
+
+  describe("detectServiceFromUrl", () => {
+    const settings = {
+      paperless_url: "https://paperless.local",
+    } as Record<string, string>;
+
+    it("detects paperless via configured base URL", () => {
+      expect(detectServiceFromUrl("https://paperless.local/documents/1", settings)?.name).toBe("paperless");
+    });
+
+    it("detects paperless with sub-path installation", () => {
+      const subPathSettings = { paperless_url: "https://example.local/paperless" } as Record<string, string>;
+      expect(detectServiceFromUrl("https://example.local/paperless/documents/1", subPathSettings)?.name).toBe(
+        "paperless"
+      );
+    });
+
+    it("returns null for paperless URL when settings are empty (no fallback)", () => {
+      expect(detectServiceFromUrl("https://any.host/documents/1/details", {})).toBeNull();
+    });
+
+    it("does not match host-prefix attacks", () => {
+      expect(detectServiceFromUrl("https://paperless.local.evil/documents/1", settings)).toBeNull();
+    });
+
+    it("returns null for unknown services", () => {
+      expect(detectServiceFromUrl("https://example.org/something", settings)).toBeNull();
+    });
+  });
+
+  describe("classifyDroppedUrl", () => {
+    const settings = {
+      paperless_url: "https://paperless.local",
+    } as Record<string, string>;
+
+    it("classifies paperless URL", () => {
+      const result = classifyDroppedUrl("https://paperless.local/documents/42/details", settings);
+      expect(result?.adapter.name).toBe("paperless");
+      expect(result?.id).toBe("42");
+    });
+
+    it("returns null for paperless URL with no settings configured (no fallback)", () => {
+      expect(classifyDroppedUrl("https://any.host/documents/7/details", {})).toBeNull();
+    });
+
+    it("returns null for unrecognised URL", () => {
+      expect(classifyDroppedUrl("https://example.org/something", settings)).toBeNull();
+    });
+
+    it("returns null when URL matches service host but id cannot be extracted", () => {
+      // URL host matches paperless but path has no document ID
+      expect(classifyDroppedUrl("https://paperless.local/dashboard", settings)).toBeNull();
+    });
+
+    it("classifies paperless URL with whitespace around value", () => {
+      const result = classifyDroppedUrl("  https://paperless.local/documents/42/details  ", settings);
+      expect(result?.adapter.name).toBe("paperless");
+      expect(result?.id).toBe("42");
+    });
+  });
+
+  describe("getAdapter", () => {
+    it("returns paperless adapter by name", () => {
+      expect(getAdapter("paperless")?.name).toBe("paperless");
+    });
+
+    it("returns undefined for unknown name", () => {
+      expect(getAdapter("unknown")).toBeUndefined();
+    });
+  });
+
+  describe("getAdapterByMimeType", () => {
+    it("returns paperless adapter for paperless/document", () => {
+      expect(getAdapterByMimeType("paperless/document")?.name).toBe("paperless");
+    });
+
+    it("returns undefined for unknown MIME type", () => {
+      expect(getAdapterByMimeType("application/pdf")).toBeUndefined();
+    });
+  });
+
+  describe("adapter buildTitle", () => {
+    it("paperless buildTitle includes the doc id", () => {
+      expect(getAdapter("paperless")?.buildTitle("42")).toBe("Paperless Document 42");
+    });
+  });
+
+  describe("SERVICE_ADAPTERS registry", () => {
+    it("contains paperless", () => {
+      const names = SERVICE_ADAPTERS.map(a => a.name);
+      expect(names).toContain("paperless");
+    });
+
+    it("each adapter has required fields", () => {
+      for (const adapter of SERVICE_ADAPTERS) {
+        expect(adapter.name).toBeTruthy();
+        expect(adapter.mimeType).toContain("/");
+        expect(adapter.settingsUrlKey).toContain("_url");
+        expect(adapter.settingsTokenKey).toContain("_token");
+        expect(typeof adapter.extractId).toBe("function");
+        expect(typeof adapter.buildTitle).toBe("function");
+      }
+    });
+  });
+});

--- a/frontend/lib/integration-adapters.ts
+++ b/frontend/lib/integration-adapters.ts
@@ -1,0 +1,169 @@
+/**
+ * Integration adapter registry for external link services (Paperless, …).
+ *
+ * To add a new service:
+ *  1. Add an `extractXyzId` function below using `extractWithPattern`.
+ *  2. Push a new `ServiceAdapter` entry to `SERVICE_ADAPTERS`.
+ *  That's it – drop detection, classification, and hydration are all registry-driven.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ServiceAdapter {
+  /** Unique service identifier. Also used as the MIME type prefix and settings key prefix. */
+  name: string;
+  /** Full MIME type stored on attachments, e.g. "paperless/document". */
+  mimeType: string;
+  /** User-settings key for the service base URL. */
+  settingsUrlKey: string;
+  /** User-settings key for the service API token. */
+  settingsTokenKey: string;
+  /** Extract the provider-specific ID from a URL. Returns null when not matched. */
+  extractId: (url: string, baseUrl?: string) => string | null;
+  /** Build a default human-readable title for a newly linked attachment. */
+  buildTitle: (id: string) => string;
+}
+
+// ---------------------------------------------------------------------------
+// Shared extraction helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Try to extract a capture group from `url`'s path using `pattern`.
+ * If `baseUrl` is provided and parseable, the host must match and the path
+ * must start at the configured base path. If `baseUrl` is absent or invalid,
+ * the pattern is matched against the full pathname (heuristic fallback).
+ */
+function extractWithPattern(url: string, baseUrl: string | undefined, pattern: RegExp): string | null {
+  const trimmedUrl = url.trim();
+  if (!trimmedUrl) return null;
+
+  // Normalise bare hostnames (e.g. "localhost/documents/2") to a parseable URL.
+  const normalisedUrl = /^https?:\/\//i.test(trimmedUrl) ? trimmedUrl : `http://${trimmedUrl}`;
+  try {
+    const target = new URL(normalisedUrl);
+    let basePath = "";
+
+    if (baseUrl?.trim()) {
+      try {
+        const base = new URL(baseUrl.trim());
+        if (base.origin !== target.origin) return null;
+        basePath = base.pathname.replace(/\/$/, "");
+        if (basePath && !target.pathname.startsWith(basePath + "/") && target.pathname !== basePath) {
+          return null;
+        }
+      } catch {
+        // Invalid configured base URL – fall through to pattern-only match.
+      }
+    }
+
+    const pathAfterBase = target.pathname.slice(basePath.length || 0);
+    return pathAfterBase.match(pattern)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-service ID extractors (one function per service)
+// ---------------------------------------------------------------------------
+
+/** Extract Paperless document ID from patterns: /documents/{id} or /documents/{id}/details */
+export function extractPaperlessDocId(url: string, baseUrl?: string): string | null {
+  return extractWithPattern(url, baseUrl, /\/documents\/(\d+)(?:\/details)?\/?$/);
+}
+
+// ---------------------------------------------------------------------------
+// Service registry – the single source of truth for all integrations
+// ---------------------------------------------------------------------------
+
+export const SERVICE_ADAPTERS: ServiceAdapter[] = [
+  {
+    name: "paperless",
+    mimeType: "paperless/document",
+    settingsUrlKey: "paperless_url",
+    settingsTokenKey: "paperless_token",
+    extractId: extractPaperlessDocId,
+    buildTitle: id => `Paperless Document ${id}`,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Generic helpers consumed by the rest of the frontend
+// ---------------------------------------------------------------------------
+
+/** Look up an adapter by service name. */
+export function getAdapter(name: string): ServiceAdapter | undefined {
+  return SERVICE_ADAPTERS.find(a => a.name === name);
+}
+
+/** Look up an adapter by MIME type. */
+export function getAdapterByMimeType(mimeType: string): ServiceAdapter | undefined {
+  return SERVICE_ADAPTERS.find(a => a.mimeType === mimeType);
+}
+
+/**
+ * Detect which integration service a URL belongs to.
+ * Strategy:
+ *  1. Exact host+base-path match against each adapter's configured URL in settings.
+ *  2. Fallback: URL-pattern match across all adapters (works when settings are missing/invalid).
+ *
+ * @returns The matching `ServiceAdapter`, or `null` if none matched.
+ */
+export function detectServiceFromUrl(url: string, settings: Record<string, string>): ServiceAdapter | null {
+  const trimmedUrl = url.trim();
+  if (!trimmedUrl) return null;
+
+  const normUrl = /^https?:\/\//i.test(trimmedUrl) ? trimmedUrl : `http://${trimmedUrl}`;
+  try {
+    const target = new URL(normUrl);
+
+    // 1. Configured base URL match (most precise)
+    for (const adapter of SERVICE_ADAPTERS) {
+      const baseUrl = settings[adapter.settingsUrlKey]?.trim();
+      if (!baseUrl) continue;
+      try {
+        const base = new URL(baseUrl);
+        if (base.origin !== target.origin) continue;
+        const basePath = base.pathname.replace(/\/$/, "");
+        if (!basePath || target.pathname === basePath || target.pathname.startsWith(basePath + "/")) {
+          return adapter;
+        }
+      } catch {
+        // Unparseable configured URL – skip.
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  // Pattern-only fallback intentionally removed: a URL is only classified as a service
+  // link when the service base URL is configured AND the URL matches that base.
+  // If no URL is configured for a service, dropped URLs are stored as plain link/url
+  // attachments instead of being silently classified as service links.
+  return null;
+}
+
+/**
+ * Classify a dropped URL into a `{ adapter, id }` pair.
+ * Tries the configured base URL first, then falls back to pattern-only extraction.
+ *
+ * @returns `{ adapter, id }` when recognised, `null` when the URL matches no known service.
+ */
+export function classifyDroppedUrl(
+  url: string,
+  settings: Record<string, string>
+): { adapter: ServiceAdapter; id: string } | null {
+  const adapter = detectServiceFromUrl(url, settings);
+  if (!adapter) return null;
+
+  const configuredBase = settings[adapter.settingsUrlKey];
+  const id = adapter.extractId(url, configuredBase) ?? adapter.extractId(url);
+  if (!id) return null;
+
+  return { adapter, id };
+}
+
+

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -179,7 +179,11 @@
         "item": {
             "attachments_list": {
                 "download": "Download",
-                "open_new_tab": "Open in new tab"
+                "open_new_tab": "Open in new tab",
+                "configure_service": "Configure {service} URL in Profile Settings to access this attachment",
+                "request_failed": "Request to {url} failed",
+                "request_failed_stale": "Showing cached data — request to {url} failed",
+                "open_in_service": "Open in {service}"
             },
             "create_modal": {
                 "clear_template": "Clear Template",
@@ -790,8 +794,17 @@
             "failed_update_notifier": "Failed to update notifier.",
             "group_updated": "Group updated",
             "notifier_test_success": "Notifier test successful.",
-            "password_changed": "Password changed successfully."
+            "password_changed": "Password changed successfully.",
+            "settings_saved": "Integration settings saved.",
+            "failed_settings_save": "Failed to save integration settings."
         },
+        "integrations": "Integrations",
+        "integrations_sub": "Connect external services like Paperless-ngx.",
+        "paperless_settings": "Paperless-ngx",
+        "paperless_url": "Paperless URL",
+        "paperless_url_placeholder": "http://localhost:8000",
+        "paperless_token": "API Token",
+        "paperless_token_placeholder": "Your Paperless API token",
         "update_group": "Update Group",
         "update_language": "Update Language",
         "url": "URL",

--- a/frontend/pages/item/[id]/index/edit.vue
+++ b/frontend/pages/item/[id]/index/edit.vue
@@ -5,7 +5,7 @@
   import type { ItemAttachment, EntityFieldData, EntityOut, EntityUpdate } from "~~/lib/api/types/data-contracts";
   import { AttachmentTypes } from "~~/lib/api/types/non-generated";
   import { useTagStore } from "~/stores/tags";
-  import { useLocationStore } from "~~/stores/locations";
+  import { classifyDroppedUrl } from "~/lib/integration-adapters";
   import MdiLoading from "~icons/mdi/loading";
   import MdiDelete from "~icons/mdi/delete";
   import MdiPencil from "~icons/mdi/pencil";
@@ -37,6 +37,14 @@
 
   const { openDialog, closeDialog } = useDialog();
 
+  // Integration settings for drop detection
+  const integrationSettings = reactive({
+    paperless_url: "",
+    paperless_token: "",
+    immich_url: "",
+    immich_token: "",
+  });
+
   definePageMeta({
     middleware: ["auth"],
   });
@@ -46,9 +54,6 @@
   const preferences = useViewPreferences();
 
   const itemId = computed<string>(() => route.params.id as string);
-
-  const locationStore = useLocationStore();
-  const locations = computed(() => locationStore.allLocations);
 
   const tagStore = useTagStore();
   const tags = computed(() => tagStore.tags);
@@ -83,7 +88,21 @@
     }
   });
 
-  onMounted(() => {
+  async function loadIntegrationSettings() {
+    const { data, error } = await api.user.getSettings();
+    if (error || !data?.item) {
+      return;
+    }
+
+    const settings = data.item as Record<string, unknown>;
+    integrationSettings.paperless_url = (settings.paperless_url as string) || "";
+    integrationSettings.paperless_token = (settings.paperless_token as string) || "";
+    integrationSettings.immich_url = (settings.immich_url as string) || "";
+    integrationSettings.immich_token = (settings.immich_token as string) || "";
+  }
+
+  onMounted(async () => {
+    await loadIntegrationSettings();
     refresh();
   });
 
@@ -373,7 +392,12 @@
     const zoneEl = targetEl?.closest("[data-link-type]");
     const attachmentType = zoneEl?.getAttribute("data-link-type") || "attachment";
 
+    // Always use the URL-based title as fallback; the real document title is
+    // fetched from the service API at display time (hydration in AttachmentsList.vue).
     const title = fallbackLinkTitle(droppedURL);
+
+    const classified = classifyDroppedUrl(droppedURL, integrationSettings);
+
     const { data, error } = await api.items.attachments.addExternalLink(
       itemId.value,
       "link",
@@ -387,7 +411,12 @@
       return;
     }
 
-    toast.success(t("items.toast.attachment_uploaded"));
+    if (classified) {
+      const serviceName = classified.adapter.name.charAt(0).toUpperCase() + classified.adapter.name.slice(1);
+      toast.success(`${serviceName} linked`);
+    } else {
+      toast.success(t("items.toast.attachment_uploaded"));
+    }
     item.value.attachments = data.attachments;
   }
 
@@ -822,13 +851,7 @@
                     </TooltipTrigger>
                     <TooltipContent>{{ $t("items.edit.view_image") }}</TooltipContent>
                   </Tooltip>
-                  <Tooltip
-                    v-if="
-                      attachment.mimeType === 'link/url' ||
-                      (attachment.path ?? '').startsWith('http://') ||
-                      (attachment.path ?? '').startsWith('https://')
-                    "
-                  >
+                  <Tooltip v-if="(attachment.path ?? '').startsWith('http://') || (attachment.path ?? '').startsWith('https://')">
                     <TooltipTrigger as-child>
                       <a :href="attachment.path" target="_blank" rel="noopener noreferrer">
                         <Button variant="outline" size="icon">

--- a/frontend/pages/profile.vue
+++ b/frontend/pages/profile.vue
@@ -20,6 +20,7 @@
   import FormCheckbox from "~/components/Form/Checkbox.vue";
   import BaseContainer from "@/components/Base/Container.vue";
   import BaseCard from "@/components/Base/Card.vue";
+  import { useIntegrationCacheStore } from "~/stores/integration-cache";
   import BaseSectionHeader from "@/components/Base/SectionHeader.vue";
   import DetailsSection from "@/components/global/DetailsSection/DetailsSection.vue";
   import DateTime from "@/components/global/DateTime.vue";
@@ -207,6 +208,64 @@
     toast.success(t("profile.toast.api_key_deleted"));
     await loadApiKeys();
   }
+
+  // ---------------------------------------------------------------------------
+  // Integration settings
+
+  const integrationSettings = reactive({
+    paperlessUrl: "",
+    paperlessToken: "",
+    loading: false,
+    saving: false,
+  });
+
+  async function loadIntegrationSettings() {
+    integrationSettings.loading = true;
+    const { data, error } = await api.user.getSettings();
+    integrationSettings.loading = false;
+
+    if (error || !data?.item) {
+      toast.error(t("errors.api_failure"));
+      return;
+    }
+
+    const settings = data.item as Record<string, unknown>;
+    integrationSettings.paperlessUrl = (settings.paperless_url as string) || "";
+    integrationSettings.paperlessToken = (settings.paperless_token as string) || "";
+  }
+
+  async function saveIntegrationSettings() {
+    integrationSettings.saving = true;
+    const { data: current, error: currentError } = await api.user.getSettings();
+    if (currentError) {
+      integrationSettings.saving = false;
+      toast.error(t("profile.toast.failed_settings_save"));
+      return;
+    }
+
+    const { error } = await api.user.setSettings({
+      ...(current?.item ?? {}),
+      paperless_url: integrationSettings.paperlessUrl,
+      paperless_token: integrationSettings.paperlessToken,
+    });
+    integrationSettings.saving = false;
+
+    if (error) {
+      toast.error(t("profile.toast.failed_settings_save"));
+      return;
+    }
+
+    // Push the new URLs into the shared store so any mounted AttachmentsList
+    // immediately promotes or demotes its service attachments.
+    const integrationCacheStore = useIntegrationCacheStore();
+    integrationCacheStore.setServiceUrl("paperless", integrationSettings.paperlessUrl);
+
+    toast.success(t("profile.toast.settings_saved"));
+  }
+
+  onMounted(() => {
+    void loadIntegrationSettings();
+  });
 </script>
 
 <template>
@@ -431,6 +490,48 @@
           </div>
         </div>
       </BaseCard>
+
+      <BaseCard>
+        <template #title>
+          <BaseSectionHeader>
+            <span> {{ $t("profile.integrations") }} </span>
+            <template #description>
+              {{ $t("profile.integrations_sub") }}
+            </template>
+          </BaseSectionHeader>
+        </template>
+
+        <div class="space-y-6 px-4 pb-4">
+          <!-- Paperless Settings -->
+          <div class="space-y-2">
+            <h4 class="font-semibold">{{ $t("profile.paperless_settings") }}</h4>
+            <FormTextField
+              v-model="integrationSettings.paperlessUrl"
+              :label="$t('profile.paperless_url')"
+              :placeholder="$t('profile.paperless_url_placeholder')"
+              type="url"
+              class="mb-2"
+            />
+            <FormTextField
+              v-model="integrationSettings.paperlessToken"
+              :label="$t('profile.paperless_token')"
+              :placeholder="$t('profile.paperless_token_placeholder')"
+              type="password"
+            />
+          </div>
+
+          <div class="border-t pt-4">
+            <Button
+              :disabled="integrationSettings.saving || integrationSettings.loading"
+              @click="saveIntegrationSettings"
+            >
+              <MdiLoading v-if="integrationSettings.saving" class="animate-spin" />
+              {{ $t("global.save") }}
+            </Button>
+          </div>
+        </div>
+      </BaseCard>
+
       <BaseCard>
         <template #title>
           <BaseSectionHeader>

--- a/frontend/stores/integration-cache.ts
+++ b/frontend/stores/integration-cache.ts
@@ -1,0 +1,172 @@
+import { defineStore } from "pinia";
+import { SERVICE_ADAPTERS, type ServiceAdapter } from "~/lib/integration-adapters";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Lifecycle state of a single service-typed attachment. */
+export type AttachmentFetchState = "loading" | "ok" | "stale" | "error";
+
+// ---------------------------------------------------------------------------
+// localStorage helpers (TTL-based, key-prefixed)
+// ---------------------------------------------------------------------------
+
+const CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const LS_PREFIX = "homebox:integration:";
+
+interface StoredEntry {
+  data: unknown;
+  fetchedAt: number;
+}
+
+function lsRead(key: string): unknown | null {
+  if (typeof localStorage === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(LS_PREFIX + key);
+    if (!raw) return null;
+    const entry = JSON.parse(raw) as StoredEntry;
+    if (Date.now() - entry.fetchedAt > CACHE_TTL_MS) {
+      localStorage.removeItem(LS_PREFIX + key);
+      return null;
+    }
+    return entry.data;
+  } catch {
+    return null;
+  }
+}
+
+function lsWrite(key: string, data: unknown): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(LS_PREFIX + key, JSON.stringify({ data, fetchedAt: Date.now() } as StoredEntry));
+  } catch {
+    // localStorage quota exceeded or unavailable – ignore.
+  }
+}
+
+function lsDelete(key: string): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.removeItem(LS_PREFIX + key);
+  } catch {
+    // ignore
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export const useIntegrationCacheStore = defineStore("integrationCache", () => {
+  /**
+   * Configured base URL per service name (trailing slash stripped).
+   * Empty string = not configured.
+   */
+  const serviceUrls = reactive<Record<string, string>>({});
+
+  /**
+   * Resolved enriched metadata, keyed by `${serviceName}:${id}`.
+   * In-memory mirror of the localStorage cache; populated on first read.
+   */
+  const enrichedData = reactive<Record<string, unknown>>({});
+
+  /** Per-attachment-id fetch state. Key = attachment DB id. */
+  const fetchStates = reactive<Record<string, AttachmentFetchState>>({});
+
+  /** Per-attachment-id failure description. Key = attachment DB id. */
+  const fetchErrors = reactive<Record<string, string>>({});
+
+  /** Whether settings have been fetched this session (avoid duplicate API calls). */
+  const settingsLoaded = ref(false);
+
+  // -------------------------------------------------------------------------
+  // Settings
+  // -------------------------------------------------------------------------
+
+  /**
+   * Load service base URLs from user settings.
+   * No-ops on subsequent calls within the same page session.
+   */
+  async function loadSettings(api: ReturnType<typeof useUserApi>): Promise<void> {
+    if (settingsLoaded.value) return;
+    const { data, error } = await api.user.getSettings();
+    if (error || !data?.item) return;
+    const s = data.item as Record<string, unknown>;
+    for (const adapter of SERVICE_ADAPTERS) {
+      serviceUrls[adapter.name] = ((s[adapter.settingsUrlKey] as string) || "").replace(/\/$/, "");
+    }
+    settingsLoaded.value = true;
+  }
+
+  function isConfigured(adapter: ServiceAdapter): boolean {
+    return !!(serviceUrls[adapter.name]?.trim());
+  }
+
+  function getUrl(adapter: ServiceAdapter): string {
+    return serviceUrls[adapter.name] ?? "";
+  }
+
+  // -------------------------------------------------------------------------
+  // Enriched data cache
+  // -------------------------------------------------------------------------
+
+  function getEnrichedData(serviceName: string, id: string): unknown | null {
+    const key = `${serviceName}:${id}`;
+    if (key in enrichedData) return enrichedData[key];
+    const cached = lsRead(key);
+    if (cached !== null) enrichedData[key] = cached;
+    return cached;
+  }
+
+  function setEnrichedData(serviceName: string, id: string, data: unknown): void {
+    const key = `${serviceName}:${id}`;
+    enrichedData[key] = data;
+    lsWrite(key, data);
+  }
+
+  function invalidateEnrichedData(serviceName: string, id: string): void {
+    const key = `${serviceName}:${id}`;
+    delete enrichedData[key];
+    lsDelete(key);
+  }
+
+  // -------------------------------------------------------------------------
+  // Attachment fetch state
+  // -------------------------------------------------------------------------
+
+  function setState(attachmentId: string, state: AttachmentFetchState, errorMsg?: string): void {
+    fetchStates[attachmentId] = state;
+    if (errorMsg !== undefined) fetchErrors[attachmentId] = errorMsg;
+  }
+
+  function clearAttachmentState(attachmentId: string): void {
+    delete fetchStates[attachmentId];
+    delete fetchErrors[attachmentId];
+  }
+
+  /**
+   * Update a single service URL (e.g. after profile save).
+   * Resets settingsLoaded so loadSettings() will re-read on next call.
+   */
+  function setServiceUrl(name: string, url: string): void {
+    serviceUrls[name] = url.replace(/\/$/, "");
+    settingsLoaded.value = false;
+  }
+
+  return {
+    serviceUrls,
+    enrichedData,
+    fetchStates,
+    fetchErrors,
+    loadSettings,
+    isConfigured,
+    getUrl,
+    setServiceUrl,
+    getEnrichedData,
+    setEnrichedData,
+    invalidateEnrichedData,
+    setState,
+    clearAttachmentState,
+  };
+});


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Extends the external attachment infrastructure from #1481 with a full **Paperless-ngx** integration. Users can link Paperless documents to Homebox inventory items — no file copy, just a lightweight external reference — and get rich metadata directly in the attachment list.

### Changes by file

**Backend**
- `backend/app/api/handlers/v1/v1_ctrl_integration_proxy.go` *(new)* — generic authenticated reverse-proxy `GET /v1/integrations/{name}/proxy?path={relPath}`. Validates the integration name (regex `^[a-z][a-z0-9_-]{0,31}$` — prevents traversal), validates the path starts with `/` and contains no `://`, then proxies the request to the service's configured base URL with `Authorization: Token {token}`. One handler serves all current and future integrations.
- `backend/app/api/routes.go` — wire the new proxy handler.
- `backend/internal/data/repo/repo_item_attachments.go` — add `MimeTypePaperlessDocument = "paperless/document"` constant and register it in `MimeTypeForSourceType()` / `externalLinkMimeTypes`.
- `backend/internal/core/services/service_items_attachments_external_test.go` — extend existing service tests to cover Paperless MIME type registration.
- `backend/internal/data/repo/repo_item_attachments_test.go` — extend existing repo tests.

**Frontend**
- `frontend/lib/integration-adapters.ts` *(new)* — `ServiceAdapter` interface and `SERVICE_ADAPTERS` registry (name, MIME type, settings keys, ID extractor, title builder). Adding a future integration only requires a new entry here; all detection, classification and hydration are registry-driven.
- `frontend/lib/integration-adapters.test.ts` *(new)* — 25 Vitest unit tests covering `extractPaperlessDocId`, `detectServiceFromUrl`, `classifyDroppedUrl`, `getAdapter`, `getAdapterByMimeType`, `buildTitle` and registry shape.
- `frontend/stores/integration-cache.ts` *(new)* — Pinia store holding per-service URL state and enriched-data / fetch-state caches. Drives reactive card promotion/demotion when the user saves or clears a service URL in Profile settings while the attachment list is mounted.
- `frontend/components/Item/AttachmentsList.vue` — Paperless document card with: thumbnail, title (from Paperless API), correspondent, document type, colour-coded tags, page count, created date, open-in-Paperless button, and an amber ⚠ unreachable/error badge with tooltip. `link/url` attachments whose URL matches the configured Paperless base URL are transparently promoted to the rich card at render time (and demoted back if the URL is cleared).
- `frontend/pages/item/[id]/index/edit.vue` — drag-and-drop Paperless URL detection: detects a dropped Paperless document URL, extracts the document ID and calls `POST /v1/entities/{id}/attachments/external`.
- `frontend/pages/profile.vue` — Paperless URL + API token fields in the Integrations settings section; saves to user settings and immediately pushes the new URL into the shared store.
- `frontend/composables/preferences-utils.ts` *(new)* — shared preference helpers extracted from `use-preferences.ts` (no functional change, pure refactor to avoid circular imports).
- `frontend/composables/use-preferences.test.ts` *(new)* — tests for the extracted composable.
- `frontend/locales/en.json` — add Paperless i18n keys (`paperless_settings`, `paperless_url`, `paperless_url_placeholder`, `paperless_token`, `paperless_token_placeholder`, `integrations_sub`).

## Special notes for your reviewer:

- The generic proxy handler (`v1_ctrl_integration_proxy.go`) is intentionally Paperless-unaware. It reads `{name}_url` and `{name}_token` from user settings and forwards with `Authorization: Token {token}`. Adding a future integration (e.g. Docspell) requires only a new `SERVICE_ADAPTERS` entry on the frontend and one line in `MimeTypeForSourceType()` on the backend.
- The adapter registry pattern (`integration-adapters.ts`) is the single source of truth: drop detection, URL classification and card hydration all iterate `SERVICE_ADAPTERS` — no service-specific `if/else` chains.
- Credentials are never exposed to the browser: the proxy reads them server-side and forwards them; only the URL is visible to the frontend.
- Object URLs for thumbnails are created and revoked in `onBeforeUnmount` to avoid memory leaks.

## Testing

- **Unit tests**: `frontend/lib/integration-adapters.test.ts` — 25 tests, all green (`npx vitest run lib/integration-adapters.test.ts`).
- **Manual**: tested against a live Paperless-ngx v2.x instance — drag-and-drop, card rendering (thumbnail, tags, correspondent), error badge when token is wrong, graceful demotion when URL is cleared.