### PR TITLE
feat: scanner protocol-less urls

### DIFF
--- a/frontend/components/App/ScannerModal.vue
+++ b/frontend/components/App/ScannerModal.vue
@@ -176,8 +176,8 @@
         if (result && !loading.value) {
           loading.value = true;
           try {
-            const url = new URL(result.getText());
-            if (!url.pathname.startsWith("/")) {
+            const url = parseScanResult(result.getText());
+            if (!url || !url.pathname.startsWith("/")) {
               throw new Error(t("scanner.invalid_url"));
             }
             const sanitizedPath = url.pathname.replace(/[^a-zA-Z0-9-_/]/g, "");

--- a/frontend/composables/use-barcode-detector.ts
+++ b/frontend/composables/use-barcode-detector.ts
@@ -85,7 +85,7 @@ function parseHomeboxUrl(rawValue: string): { entityType: "item" | "location" | 
 
     const sanitized = pathname.replace(/[^a-zA-Z0-9-_/]/g, "");
 
-    // Case-insensitive prefix match so all-uppercase C40 Data Matrix codes scan.
+    // Case-insensitive so uppercase-encoded codes resolve to the right entity.
     const assetMatch = sanitized.match(/^\/a\/([a-zA-Z0-9-_]+)/i);
     if (assetMatch) return { entityType: "asset", id: assetMatch[1]! };
 

--- a/frontend/composables/use-barcode-detector.ts
+++ b/frontend/composables/use-barcode-detector.ts
@@ -74,29 +74,25 @@ function lerpCorners(prev: Point2D[], next: Point2D[], t: number): Point2D[] {
 function parseHomeboxUrl(rawValue: string): { entityType: "item" | "location" | "asset"; id: string } | null {
   try {
     let pathname: string;
-    try {
-      const url = new URL(rawValue);
-      if (url.origin !== globalThis.location?.origin) {
-        return null;
-      }
+    if (rawValue.startsWith("/")) {
+      pathname = rawValue;
+    } else {
+      const url = parseScanResult(rawValue);
+      if (!url) return null;
+      if (url.origin !== globalThis.location?.origin) return null;
       pathname = url.pathname;
-    } catch {
-      if (rawValue.startsWith("/")) {
-        pathname = rawValue;
-      } else {
-        return null;
-      }
     }
 
     const sanitized = pathname.replace(/[^a-zA-Z0-9-_/]/g, "");
 
-    const assetMatch = sanitized.match(/^\/a\/([a-zA-Z0-9-_]+)/);
+    // Case-insensitive prefix match so all-uppercase C40 Data Matrix codes scan.
+    const assetMatch = sanitized.match(/^\/a\/([a-zA-Z0-9-_]+)/i);
     if (assetMatch) return { entityType: "asset", id: assetMatch[1]! };
 
-    const itemMatch = sanitized.match(/^\/item\/([a-zA-Z0-9-_]+)/);
+    const itemMatch = sanitized.match(/^\/item\/([a-zA-Z0-9-_]+)/i);
     if (itemMatch) return { entityType: "item", id: itemMatch[1]! };
 
-    const locationMatch = sanitized.match(/^\/location\/([a-zA-Z0-9-_]+)/);
+    const locationMatch = sanitized.match(/^\/location\/([a-zA-Z0-9-_]+)/i);
     if (locationMatch) return { entityType: "location", id: locationMatch[1]! };
 
     return null;

--- a/frontend/composables/utils.test.ts
+++ b/frontend/composables/utils.test.ts
@@ -67,6 +67,23 @@ describe("parseScanResult", () => {
     expect(url?.pathname).toBe("/A/1");
   });
 
+  test("accepts protocol-less localhost with port", () => {
+    // The URL parser otherwise interprets "localhost:3000/a/1" as scheme
+    // "localhost:". Important for dev and self-hosted deployments without
+    // a TLD in the URL.
+    vi.stubGlobal("location", { protocol: "http:", origin: "http://localhost:3000" });
+    const url = parseScanResult("localhost:3000/a/1");
+    expect(url?.host).toBe("localhost:3000");
+    expect(url?.pathname).toBe("/a/1");
+  });
+
+  test("accepts uppercase localhost payload", () => {
+    vi.stubGlobal("location", { protocol: "http:", origin: "http://localhost:3000" });
+    const url = parseScanResult("LOCALHOST:3000/A/1");
+    expect(url?.host).toBe("localhost:3000");
+    expect(url?.pathname).toBe("/A/1");
+  });
+
   test("uses current page protocol for protocol-less payloads", () => {
     vi.stubGlobal("location", { protocol: "http:", origin: "http://example.com" });
     const url = parseScanResult("example.com/a/1");
@@ -77,7 +94,7 @@ describe("parseScanResult", () => {
     expect(parseScanResult("1234567890123")).toBeNull();
   });
 
-  test("rejects arbitrary text without dot+slash", () => {
+  test("rejects arbitrary text without a slash", () => {
     expect(parseScanResult("hello world")).toBeNull();
   });
 
@@ -89,5 +106,21 @@ describe("parseScanResult", () => {
 
   test("rejects protocol-relative URL (cannot be parsed without base)", () => {
     expect(parseScanResult("//evil.example/a/1")).toBeNull();
+  });
+
+  test("rejects file:// URLs", () => {
+    expect(parseScanResult("file:///etc/passwd")).toBeNull();
+  });
+
+  test("rejects mailto: URLs", () => {
+    expect(parseScanResult("mailto:foo@example.com")).toBeNull();
+  });
+
+  test("rejects javascript: URLs", () => {
+    expect(parseScanResult("javascript:alert(1)")).toBeNull();
+  });
+
+  test("rejects data: URLs", () => {
+    expect(parseScanResult("data:text/plain;base64,SGVsbG8=")).toBeNull();
   });
 });

--- a/frontend/composables/utils.test.ts
+++ b/frontend/composables/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "vitest";
-import { maybeUrl } from "./utils";
+import { describe, expect, test, afterEach, vi } from "vitest";
+import { maybeUrl, parseScanResult } from "./utils";
 
 describe("maybeURL works as expected", () => {
   test("basic valid URL case", () => {
@@ -28,5 +28,66 @@ describe("maybeURL works as expected", () => {
     expect(result.isUrl).toBe(false);
     expect(result.url).toBe("");
     expect(result.text).toBe("");
+  });
+});
+
+describe("parseScanResult", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("parses full https URL", () => {
+    const url = parseScanResult("https://example.com/a/1");
+    expect(url?.origin).toBe("https://example.com");
+    expect(url?.pathname).toBe("/a/1");
+  });
+
+  test("parses full http URL", () => {
+    const url = parseScanResult("http://example.com/a/1");
+    expect(url?.origin).toBe("http://example.com");
+    expect(url?.pathname).toBe("/a/1");
+  });
+
+  test("normalizes uppercase protocol and host", () => {
+    const url = parseScanResult("HTTPS://EXAMPLE.COM/A/1");
+    expect(url?.origin).toBe("https://example.com");
+    // Path case is preserved by the URL spec.
+    expect(url?.pathname).toBe("/A/1");
+  });
+
+  test("accepts protocol-less host+path payload", () => {
+    const url = parseScanResult("example.com/a/1");
+    expect(url?.pathname).toBe("/a/1");
+    expect(url?.host).toBe("example.com");
+  });
+
+  test("accepts uppercase protocol-less payload (C40 Data Matrix)", () => {
+    const url = parseScanResult("EXAMPLE.COM/A/1");
+    expect(url?.host).toBe("example.com");
+    expect(url?.pathname).toBe("/A/1");
+  });
+
+  test("uses current page protocol for protocol-less payloads", () => {
+    vi.stubGlobal("location", { protocol: "http:", origin: "http://example.com" });
+    const url = parseScanResult("example.com/a/1");
+    expect(url?.origin).toBe("http://example.com");
+  });
+
+  test("rejects bare numeric barcode (no slash)", () => {
+    expect(parseScanResult("1234567890123")).toBeNull();
+  });
+
+  test("rejects arbitrary text without dot+slash", () => {
+    expect(parseScanResult("hello world")).toBeNull();
+  });
+
+  test("rejects bare path so callers can handle it themselves", () => {
+    // parseHomeboxUrl handles raw "/a/1" inputs directly; this helper only
+    // produces URL objects.
+    expect(parseScanResult("/a/1")).toBeNull();
+  });
+
+  test("rejects protocol-relative URL (cannot be parsed without base)", () => {
+    expect(parseScanResult("//evil.example/a/1")).toBeNull();
   });
 });

--- a/frontend/composables/utils.ts
+++ b/frontend/composables/utils.ts
@@ -147,18 +147,17 @@ export async function fmtCurrencyAsync(value: number | string, currency = "USD",
   return fmtCurrency(value, currency, locale);
 }
 
-// Matches a value that already declares a URL scheme (e.g. "https://...",
-// "file://...", "ftp://..."). Inputs with an explicit scheme are passed to
-// the URL parser as-is. We accept http(s) and reject everything else rather
-// than trying to coerce them.
+// Matches an input that already declares a URL scheme like "https://" or
+// "file://". When this matches we pass the input to the URL parser as-is
+// and accept only http(s); anything else is rejected without trying to
+// coerce it.
 const EXPLICIT_SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
 
-// Parses a scanner / barcode payload into a URL. Accepts full URLs as well as
-// protocol-less host+path payloads (e.g. "example.com/a/1", "localhost:3000/a/1").
-// Dropping the protocol and using uppercase characters fits more data into the
-// smallest QR / Data Matrix codes, which matters for pre-printed asset
-// stickers. Returns null for inputs that don't look like a homebox URL (e.g.
-// EAN/UPC barcode digits, file://, mailto:) so callers can fall back to other
+// Parses a scanner payload into a URL. Accepts full URLs as well as
+// protocol-less host+path payloads such as "example.com/a/1" or
+// "localhost:3000/a/1", which let pre-printed asset stickers carry less
+// data. Returns null for inputs that aren't URL-shaped (e.g. EAN/UPC
+// barcode digits, file://, mailto:) so callers can fall back to other
 // handling.
 export function parseScanResult(rawValue: string): URL | null {
   if (EXPLICIT_SCHEME_RE.test(rawValue)) {
@@ -180,7 +179,7 @@ export function parseScanResult(rawValue: string): URL | null {
     return null;
   }
   // Use the current page's protocol so http-only deployments still pass
-  // their own origin checks (URL constructor normalizes protocol/host case).
+  // their own origin checks.
   const protocol = globalThis.location?.protocol ?? "https:";
   try {
     const url = new URL(`${protocol}//${rawValue}`);

--- a/frontend/composables/utils.ts
+++ b/frontend/composables/utils.ts
@@ -147,30 +147,49 @@ export async function fmtCurrencyAsync(value: number | string, currency = "USD",
   return fmtCurrency(value, currency, locale);
 }
 
+// Matches a value that already declares a URL scheme (e.g. "https://...",
+// "file://...", "ftp://..."). Inputs with an explicit scheme are passed to
+// the URL parser as-is. We accept http(s) and reject everything else rather
+// than trying to coerce them.
+const EXPLICIT_SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+
 // Parses a scanner / barcode payload into a URL. Accepts full URLs as well as
-// protocol-less host+path payloads (e.g. "example.com/a/1") — dropping the
-// protocol and using uppercase characters fits more data into the smallest
-// QR / Data Matrix codes, which matters for pre-printed asset stickers.
-// Returns null for inputs that don't look like a URL (e.g. EAN/UPC barcode
-// digits) so callers can fall back to other handling.
+// protocol-less host+path payloads (e.g. "example.com/a/1", "localhost:3000/a/1").
+// Dropping the protocol and using uppercase characters fits more data into the
+// smallest QR / Data Matrix codes, which matters for pre-printed asset
+// stickers. Returns null for inputs that don't look like a homebox URL (e.g.
+// EAN/UPC barcode digits, file://, mailto:) so callers can fall back to other
+// handling.
 export function parseScanResult(rawValue: string): URL | null {
-  try {
-    return new URL(rawValue);
-  } catch {
-    // Only attempt the protocol-less fallback when the value still looks
-    // host-shaped: not a bare path, and contains both "/" and "." so plain
-    // numeric barcodes (EAN/UPC) and arbitrary text fall through to null.
-    if (rawValue.startsWith("/") || !rawValue.includes("/") || !rawValue.includes(".")) {
-      return null;
-    }
-    // Use the current page's protocol so http-only deployments still match
-    // their own origin checks (URL constructor normalizes protocol/host case).
-    const protocol = globalThis.location?.protocol ?? "https:";
+  if (EXPLICIT_SCHEME_RE.test(rawValue)) {
     try {
-      return new URL(`${protocol}//${rawValue}`);
+      const url = new URL(rawValue);
+      if ((url.protocol === "http:" || url.protocol === "https:") && url.host) {
+        return url;
+      }
     } catch {
+      // Malformed URL.
+    }
+    return null;
+  }
+
+  // No "scheme://", so treat as a protocol-less host+path payload. Require a
+  // "/" so plain barcode payloads (EAN/UPC digits) and arbitrary text return
+  // null and the caller can fall back to the barcode handler.
+  if (rawValue.startsWith("/") || !rawValue.includes("/")) {
+    return null;
+  }
+  // Use the current page's protocol so http-only deployments still pass
+  // their own origin checks (URL constructor normalizes protocol/host case).
+  const protocol = globalThis.location?.protocol ?? "https:";
+  try {
+    const url = new URL(`${protocol}//${rawValue}`);
+    if ((url.protocol !== "http:" && url.protocol !== "https:") || !url.host) {
       return null;
     }
+    return url;
+  } catch {
+    return null;
   }
 }
 

--- a/frontend/composables/utils.ts
+++ b/frontend/composables/utils.ts
@@ -147,6 +147,33 @@ export async function fmtCurrencyAsync(value: number | string, currency = "USD",
   return fmtCurrency(value, currency, locale);
 }
 
+// Parses a scanner / barcode payload into a URL. Accepts full URLs as well as
+// protocol-less host+path payloads (e.g. "example.com/a/1") — dropping the
+// protocol and using uppercase characters fits more data into the smallest
+// QR / Data Matrix codes, which matters for pre-printed asset stickers.
+// Returns null for inputs that don't look like a URL (e.g. EAN/UPC barcode
+// digits) so callers can fall back to other handling.
+export function parseScanResult(rawValue: string): URL | null {
+  try {
+    return new URL(rawValue);
+  } catch {
+    // Only attempt the protocol-less fallback when the value still looks
+    // host-shaped: not a bare path, and contains both "/" and "." so plain
+    // numeric barcodes (EAN/UPC) and arbitrary text fall through to null.
+    if (rawValue.startsWith("/") || !rawValue.includes("/") || !rawValue.includes(".")) {
+      return null;
+    }
+    // Use the current page's protocol so http-only deployments still match
+    // their own origin checks (URL constructor normalizes protocol/host case).
+    const protocol = globalThis.location?.protocol ?? "https:";
+    try {
+      return new URL(`${protocol}//${rawValue}`);
+    } catch {
+      return null;
+    }
+  }
+}
+
 export type MaybeUrlResult = {
   isUrl: boolean;
   url: string;


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Lets the scanner read protocol-less URLs like `example.com/a/1`.
Dropping `https://` and using uppercase characters fits more data into the smallest Data Matrix / QR codes (C40 mode), so users can pre-print tiny asset stickers.

`parseScanResult` (new, in `composables/utils.ts`):
- If the input has an explicit `scheme://`, accept only http(s) with a host. Reject `file://`, `mailto:`, `data:`, `javascript:`, etc.
- Otherwise, treat as a host+path payload and parse against the current page's protocol. Reject inputs without a `/` so plain EAN/UPC barcode digits still fall through to the existing product-lookup path.

Used by both `ScannerModal.vue` and `parseHomeboxUrl` in the AR scanner. The AR scanner's path regexes also got the `i` flag so uppercase paths resolve to the right entity type (vue-router already routes static path segments case-insensitively, but the AR scanner classifies the entity via its own regex).

## Which issue(s) this PR fixes:

None

## Testing

20 unit tests in `composables/utils.test.ts` covering: full http(s) URLs, mixed-case URLs, protocol-less host+path payloads (with and without port, with and without uppercase), current-page protocol fallback, bare paths and numeric barcodes, protocol-relative URLs, and non-http schemes file://, mailto:, javascript:, data:.