### PR TITLE
feat: use full path in location search

### DIFF
--- a/frontend/components/Location/Selector.vue
+++ b/frontend/components/Location/Selector.vue
@@ -101,7 +101,8 @@
   }
 
   const filteredLocations = computed(() => {
-    const filtered = fuzzysort.go(search.value, locations.value, { key: "name", all: true }).map(i => i.obj);
+    const keys = ["name", "treeString"];
+    const filtered = fuzzysort.go(search.value, locations.value, { keys, all: true }).map(i => i.obj);
 
     return filtered;
   });


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

This PR is including `treeString` in location search. The reason for that is, that if you have like me locations that are following some pattern, e.g. "Rack 1 > Shelf 1", "Rack 2 > Shelf 1", etc. it's impossible currently to search particular Shelf. Searching "Shelf 1" will return multiple results. Especially on a mobile phone, the usability is low.

This PR additionally includes `treeString` in the search, so searches like "Rack 1 > Shelf 1" or "Shelf 1 Rack 1" can be performed. The drawback is that search for "Rack 1" will now also return sub-categories, but I think it's an acceptable drawback, as the "Rack 1" should be shown first anyway (being more specific).

## Which issue(s) this PR fixes:

I have not created an issue for this.

## Testing

I tested it manually, by running searches in a running application.

PS. Sorry I closed this original PR, because I thought it was merged  15cdd6d8e1337c0ef7e370a9542cffdbdfee0b0b (but now I can't find it)