### PR TITLE
Preserve item parent relationships in CSV import/export

### DIFF
--- a/backend/internal/core/services/reporting/io_row.go
+++ b/backend/internal/core/services/reporting/io_row.go
@@ -14,12 +14,13 @@ type ExportItemFields struct {
 }
 
 type ExportCSVRow struct {
-	ImportRef string         `csv:"HB.import_ref"`
-	Location  LocationString `csv:"HB.location"`
-	TagStr    TagString      `csv:"HB.tags|HB.labels"`
-	AssetID   repo.AssetID   `csv:"HB.asset_id"`
-	Archived  bool           `csv:"HB.archived"`
-	URL       string         `csv:"HB.url"`
+	ImportRef       string         `csv:"HB.import_ref"`
+	ParentImportRef string         `csv:"HB.parent_import_ref"`
+	Location        LocationString `csv:"HB.location"`
+	TagStr          TagString      `csv:"HB.tags|HB.labels"`
+	AssetID         repo.AssetID   `csv:"HB.asset_id"`
+	Archived        bool           `csv:"HB.archived"`
+	URL             string         `csv:"HB.url"`
 
 	Name        string  `csv:"HB.name"`
 	Quantity    float64 `csv:"HB.quantity"`

--- a/backend/internal/core/services/reporting/io_sheet.go
+++ b/backend/internal/core/services/reporting/io_sheet.go
@@ -205,20 +205,27 @@ func (s *IOSheet) ReadItems(ctx context.Context, entities []repo.EntityOut, gid 
 	s.Rows = make([]ExportCSVRow, len(entities))
 
 	extraHeaders := map[string]struct{}{}
+	importRefByID := lo.SliceToMap(entities, func(item repo.EntityOut) (uuid.UUID, string) {
+		return item.ID, exportImportRef(item.ImportRef, item.ID)
+	})
 
 	for i := range entities {
 		item := entities[i]
 
-		// Resolve parent (location) path
+		// Resolve parent path. Locations remain in HB.location; item parents
+		// are represented by HB.parent_import_ref so child relationships can
+		// round-trip through CSV import/export.
 		var locString LocationString
+		parentImportRef := ""
 		if item.Parent != nil {
-			locPaths, err := repos.Entities.PathForEntity(ctx, gid, item.Parent.ID)
+			parentPath, err := repos.Entities.PathForEntity(ctx, gid, item.Parent.ID)
 			if err != nil {
 				log.Error().Err(err).Msg("could not get entity path")
 				return err
 			}
 
-			locString = fromPathSlice(locPaths)
+			locString = locationStringFromPath(parentPath)
+			parentImportRef = itemParentImportRef(parentPath, importRefByID)
 		}
 
 		tagString := lo.Map(item.Tags, func(l repo.TagSummary, _ int) string {
@@ -237,10 +244,11 @@ func (s *IOSheet) ReadItems(ctx context.Context, entities []repo.EntityOut, gid 
 
 		s.Rows[i] = ExportCSVRow{
 			// fill struct
-			Location: locString,
-			TagStr:   tagString,
+			Location:        locString,
+			ParentImportRef: parentImportRef,
+			TagStr:          tagString,
 
-			ImportRef:   item.ImportRef,
+			ImportRef:   exportImportRef(item.ImportRef, item.ID),
 			AssetID:     item.AssetID,
 			Name:        item.Name,
 			Quantity:    item.Quantity,
@@ -294,6 +302,39 @@ func (s *IOSheet) ReadItems(ctx context.Context, entities []repo.EntityOut, gid 
 	}
 
 	return nil
+}
+
+func exportImportRef(importRef string, id uuid.UUID) string {
+	if importRef != "" {
+		return importRef
+	}
+	if id == uuid.Nil {
+		return ""
+	}
+	return id.String()
+}
+
+func locationStringFromPath(path []repo.EntityPath) LocationString {
+	locations := lo.Filter(path, func(p repo.EntityPath, _ int) bool {
+		return p.Type == repo.EntityPathTypeLocation
+	})
+
+	return fromPathSlice(locations)
+}
+
+func itemParentImportRef(path []repo.EntityPath, importRefByID map[uuid.UUID]string) string {
+	for i := len(path) - 1; i >= 0; i-- {
+		entry := path[i]
+		if entry.Type != repo.EntityPathTypeItem {
+			continue
+		}
+		if ref := importRefByID[entry.ID]; ref != "" {
+			return ref
+		}
+		return entry.ID.String()
+	}
+
+	return ""
 }
 
 func generateEntityURL(entity repo.EntityOut, d string) string {

--- a/backend/internal/core/services/service_entities.go
+++ b/backend/internal/core/services/service_entities.go
@@ -172,6 +172,12 @@ func serializeLocation[T ~[]string](location T) string {
 	return strings.Join(location, "/")
 }
 
+type csvParentImportLink struct {
+	childID         uuid.UUID
+	parentImportRef string
+	rowIndex        int
+}
+
 // CsvImport imports entities from a CSV file using the standard defined format.
 //
 // CsvImport applies the following rules/operations
@@ -274,6 +280,8 @@ func (svc *EntityService) CsvImport(ctx context.Context, gid uuid.UUID, data io.
 	defer importSpan.End()
 
 	finished := 0
+	entityIDByImportRef := make(map[string]uuid.UUID, len(sheet.Rows))
+	parentLinks := make([]csvParentImportLink, 0)
 
 	for i := range sheet.Rows {
 		row := sheet.Rows[i]
@@ -288,22 +296,13 @@ func (svc *EntityService) CsvImport(ctx context.Context, gid uuid.UUID, data io.
 			))
 		ctx := rowCtx
 
-		createRequired := true
-
-		if row.ImportRef != "" {
-			exists, err := svc.repo.Entities.CheckRef(ctx, gid, row.ImportRef)
-			if err != nil {
-				wrapped := fmt.Errorf("error checking for existing entity with ref %q: %w", row.ImportRef, err)
-				recordServiceSpanError(rowSpan, wrapped)
-				rowSpan.End()
-				recordServiceSpanError(importSpan, wrapped)
-				recordServiceSpanError(span, wrapped)
-				return 0, wrapped
-			}
-
-			if exists {
-				createRequired = false
-			}
+		createRequired, err := svc.csvImportCreateRequired(ctx, gid, row.ImportRef)
+		if err != nil {
+			recordServiceSpanError(rowSpan, err)
+			rowSpan.End()
+			recordServiceSpanError(importSpan, err)
+			recordServiceSpanError(span, err)
+			return 0, err
 		}
 		rowSpan.SetAttributes(attribute.Bool("row.create_required", createRequired))
 
@@ -447,6 +446,16 @@ func (svc *EntityService) CsvImport(ctx context.Context, gid uuid.UUID, data io.
 			return 0, wrapped
 		}
 		rowSpan.SetAttributes(attribute.String("entity.id", entity.ID.String()))
+		if row.ImportRef != "" {
+			entityIDByImportRef[row.ImportRef] = entity.ID
+		}
+		if row.ParentImportRef != "" {
+			parentLinks = append(parentLinks, csvParentImportLink{
+				childID:         entity.ID,
+				parentImportRef: row.ParentImportRef,
+				rowIndex:        i,
+			})
+		}
 
 		fields := lo.Map(row.Fields, func(f reporting.ExportItemFields, _ int) repo.EntityFieldData {
 			return repo.EntityFieldData{
@@ -502,9 +511,70 @@ func (svc *EntityService) CsvImport(ctx context.Context, gid uuid.UUID, data io.
 		rowSpan.End()
 	}
 
+	linked, err := svc.linkCsvParentImportRefs(importCtx, gid, entityIDByImportRef, parentLinks)
+	if err != nil {
+		recordServiceSpanError(importSpan, err)
+		recordServiceSpanError(span, err)
+		return 0, err
+	}
+	importSpan.SetAttributes(attribute.Int("parent_links.updated.count", linked))
+
 	importSpan.SetAttributes(attribute.Int("rows.imported.count", finished))
 	span.SetAttributes(attribute.Int("rows.imported.count", finished))
 	return finished, nil
+}
+
+func (svc *EntityService) csvImportCreateRequired(ctx context.Context, gid uuid.UUID, importRef string) (bool, error) {
+	if importRef == "" {
+		return true, nil
+	}
+
+	exists, err := svc.repo.Entities.CheckRef(ctx, gid, importRef)
+	if err != nil {
+		return false, fmt.Errorf("error checking for existing entity with ref %q: %w", importRef, err)
+	}
+
+	return !exists, nil
+}
+
+func (svc *EntityService) linkCsvParentImportRefs(
+	ctx context.Context,
+	gid uuid.UUID,
+	entityIDByImportRef map[string]uuid.UUID,
+	parentLinks []csvParentImportLink,
+) (int, error) {
+	if len(parentLinks) == 0 {
+		return 0, nil
+	}
+
+	parentCtx, parentSpan := entityServiceTracer().Start(ctx, "service.EntityService.CsvImport.parentLinks",
+		trace.WithAttributes(attribute.Int("parent_links.count", len(parentLinks))))
+	defer parentSpan.End()
+
+	linked := 0
+	for _, link := range parentLinks {
+		parentID, ok := entityIDByImportRef[link.parentImportRef]
+		if !ok {
+			parent, err := svc.repo.Entities.GetByRef(parentCtx, gid, link.parentImportRef)
+			if err != nil {
+				wrapped := fmt.Errorf("row %d parent import ref %q could not be resolved: %w", link.rowIndex, link.parentImportRef, err)
+				recordServiceSpanError(parentSpan, wrapped)
+				return 0, wrapped
+			}
+			parentID = parent.ID
+			entityIDByImportRef[link.parentImportRef] = parentID
+		}
+
+		err := svc.repo.Entities.Patch(parentCtx, gid, link.childID, repo.EntityPatch{ParentID: parentID})
+		if err != nil {
+			wrapped := fmt.Errorf("row %d failed to set parent import ref %q: %w", link.rowIndex, link.parentImportRef, err)
+			recordServiceSpanError(parentSpan, wrapped)
+			return 0, wrapped
+		}
+		linked++
+	}
+	parentSpan.SetAttributes(attribute.Int("parent_links.updated.count", linked))
+	return linked, nil
 }
 
 func (svc *EntityService) ExportCSV(ctx context.Context, gid uuid.UUID, hbURL string) ([][]string, error) {

--- a/backend/internal/core/services/service_entities.go
+++ b/backend/internal/core/services/service_entities.go
@@ -577,7 +577,7 @@ func (svc *EntityService) linkCsvParentImportRefs(
 			return 0, wrapped
 		}
 
-		err := svc.repo.Entities.Patch(parentCtx, gid, link.childID, repo.EntityPatch{ParentID: parentID})
+		err = svc.repo.Entities.Patch(parentCtx, gid, link.childID, repo.EntityPatch{ParentID: parentID})
 		if err != nil {
 			wrapped := fmt.Errorf("row %d failed to set parent import ref %q: %w", link.rowIndex, link.parentImportRef, err)
 			recordServiceSpanError(parentSpan, wrapped)

--- a/backend/internal/core/services/service_entities.go
+++ b/backend/internal/core/services/service_entities.go
@@ -565,6 +565,18 @@ func (svc *EntityService) linkCsvParentImportRefs(
 			entityIDByImportRef[link.parentImportRef] = parentID
 		}
 
+		wouldCycle, err := svc.repo.Entities.WouldCreateParentCycle(parentCtx, gid, link.childID, parentID)
+		if err != nil {
+			wrapped := fmt.Errorf("row %d failed to validate parent import ref %q: %w", link.rowIndex, link.parentImportRef, err)
+			recordServiceSpanError(parentSpan, wrapped)
+			return 0, wrapped
+		}
+		if wouldCycle {
+			wrapped := fmt.Errorf("row %d parent import ref %q creates an invalid parent relationship: %w", link.rowIndex, link.parentImportRef, repo.ErrEntityParentCycle)
+			recordServiceSpanError(parentSpan, wrapped)
+			return 0, wrapped
+		}
+
 		err := svc.repo.Entities.Patch(parentCtx, gid, link.childID, repo.EntityPatch{ParentID: parentID})
 		if err != nil {
 			wrapped := fmt.Errorf("row %d failed to set parent import ref %q: %w", link.rowIndex, link.parentImportRef, err)

--- a/backend/internal/core/services/service_entities_csv_test.go
+++ b/backend/internal/core/services/service_entities_csv_test.go
@@ -47,3 +47,20 @@ func TestEntityService_CsvImportParentImportRef(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Garage", itemLocation.Name)
 }
+
+func TestEntityService_CsvImportParentImportRefRejectsSelfParent(t *testing.T) {
+	ctx := context.Background()
+
+	g, err := tRepos.Groups.GroupCreate(ctx, "csv-parent-self-"+fk.Str(4), uuid.Nil)
+	require.NoError(t, err)
+
+	data := strings.NewReader(strings.Join([]string{
+		"HB.location,HB.import_ref,HB.parent_import_ref,HB.name,HB.quantity",
+		"Garage,self,self,Self,1",
+		"",
+	}, "\n"))
+
+	_, err = tSvc.Entities.CsvImport(ctx, g.ID, data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "entity parent cycle detected")
+}

--- a/backend/internal/core/services/service_entities_csv_test.go
+++ b/backend/internal/core/services/service_entities_csv_test.go
@@ -17,6 +17,9 @@ func TestEntityService_CsvImportParentImportRef(t *testing.T) {
 
 	g, err := tRepos.Groups.GroupCreate(ctx, "csv-parent-"+fk.Str(4), uuid.Nil)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tRepos.Groups.GroupDelete(context.Background(), g.ID)
+	})
 
 	data := strings.NewReader(strings.Join([]string{
 		"HB.location,HB.import_ref,HB.parent_import_ref,HB.name,HB.quantity",
@@ -53,6 +56,9 @@ func TestEntityService_CsvImportParentImportRefRejectsSelfParent(t *testing.T) {
 
 	g, err := tRepos.Groups.GroupCreate(ctx, "csv-parent-self-"+fk.Str(4), uuid.Nil)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tRepos.Groups.GroupDelete(context.Background(), g.ID)
+	})
 
 	data := strings.NewReader(strings.Join([]string{
 		"HB.location,HB.import_ref,HB.parent_import_ref,HB.name,HB.quantity",

--- a/backend/internal/core/services/service_entities_csv_test.go
+++ b/backend/internal/core/services/service_entities_csv_test.go
@@ -1,0 +1,49 @@
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entity"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/group"
+)
+
+func TestEntityService_CsvImportParentImportRef(t *testing.T) {
+	ctx := context.Background()
+
+	g, err := tRepos.Groups.GroupCreate(ctx, "csv-parent-"+fk.Str(4), uuid.Nil)
+	require.NoError(t, err)
+
+	data := strings.NewReader(strings.Join([]string{
+		"HB.location,HB.import_ref,HB.parent_import_ref,HB.name,HB.quantity",
+		"Garage,child,parent,Child,1",
+		"Garage,parent,,Parent,1",
+		"",
+	}, "\n"))
+
+	imported, err := tSvc.Entities.CsvImport(ctx, g.ID, data)
+	require.NoError(t, err)
+	assert.Equal(t, 2, imported)
+
+	parentItem, err := tClient.Entity.Query().
+		Where(entity.HasGroupWith(group.ID(g.ID)), entity.Name("Parent")).
+		Only(ctx)
+	require.NoError(t, err)
+
+	childItem, err := tClient.Entity.Query().
+		Where(entity.HasGroupWith(group.ID(g.ID)), entity.Name("Child")).
+		Only(ctx)
+	require.NoError(t, err)
+
+	childParent, err := childItem.QueryParent().Only(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, parentItem.ID, childParent.ID)
+
+	itemLocation, err := parentItem.QueryParent().Only(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "Garage", itemLocation.Name)
+}

--- a/backend/internal/data/repo/repo_entities.go
+++ b/backend/internal/data/repo/repo_entities.go
@@ -2774,7 +2774,7 @@ func (r *EntityRepository) PathForEntity(ctx context.Context, gid, entityID uuid
 
 	for rows.Next() {
 		var entry EntityPath
-		parentID := sql.NullScanner{S: new(uuid.UUID)}
+		var parentID sql.NullString
 		var isLocation bool
 		if err := rows.Scan(&entry.ID, &entry.Name, &parentID, &isLocation); err != nil {
 			recordSpanError(querySpan, err)
@@ -2790,7 +2790,13 @@ func (r *EntityRepository) PathForEntity(ctx context.Context, gid, entityID uuid
 
 		var parsedParentID uuid.UUID
 		if parentID.Valid {
-			parsedParentID = *parentID.S.(*uuid.UUID)
+			parsedParentID, err = uuid.Parse(parentID.String)
+			if err != nil {
+				recordSpanError(querySpan, err)
+				querySpan.End()
+				recordSpanError(span, err)
+				return nil, err
+			}
 		}
 
 		entries[entry.ID] = pathEntry{

--- a/backend/internal/data/repo/repo_entities.go
+++ b/backend/internal/data/repo/repo_entities.go
@@ -2680,20 +2680,21 @@ func (r *EntityRepository) PathForEntity(ctx context.Context, gid, entityID uuid
 	defer span.End()
 
 	query := `WITH RECURSIVE entity_path AS (
-		SELECT id, name, entity_children
+		SELECT id, name, entity_children, entity_type_entities
 		FROM entities
 		WHERE id = $1
 		AND group_entities = $2
 
 		UNION ALL
 
-		SELECT e.id, e.name, e.entity_children
+		SELECT e.id, e.name, e.entity_children, e.entity_type_entities
 		FROM entities e
 		JOIN entity_path ep ON e.id = ep.entity_children
 	  )
 
-	  SELECT id, name
-	  FROM entity_path`
+	  SELECT ep.id, ep.name, et.is_location
+	  FROM entity_path ep
+	  JOIN entity_types et ON et.id = ep.entity_type_entities`
 
 	queryCtx, querySpan := entityTracer().Start(ctx, "repo.EntityRepository.PathForEntity.query")
 	rows, err := r.db.Sql().QueryContext(queryCtx, query, entityID, gid)
@@ -2709,12 +2710,17 @@ func (r *EntityRepository) PathForEntity(ctx context.Context, gid, entityID uuid
 
 	for rows.Next() {
 		var entry EntityPath
-		entry.Type = EntityPathTypeLocation
-		if err := rows.Scan(&entry.ID, &entry.Name); err != nil {
+		var isLocation bool
+		if err := rows.Scan(&entry.ID, &entry.Name, &isLocation); err != nil {
 			recordSpanError(querySpan, err)
 			querySpan.End()
 			recordSpanError(span, err)
 			return nil, err
+		}
+		if isLocation {
+			entry.Type = EntityPathTypeLocation
+		} else {
+			entry.Type = EntityPathTypeItem
 		}
 		path = append(path, entry)
 	}

--- a/backend/internal/data/repo/repo_entities.go
+++ b/backend/internal/data/repo/repo_entities.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"math"
@@ -2751,7 +2752,7 @@ func (r *EntityRepository) PathForEntity(ctx context.Context, gid, entityID uuid
 		WHERE e.group_entities = $2
 	  )
 
-	  SELECT ep.id, ep.name, et.is_location
+	  SELECT ep.id, ep.name, ep.entity_children, et.is_location
 	  FROM entity_path ep
 	  JOIN entity_types et ON et.id = ep.entity_type_entities`
 
@@ -2765,12 +2766,17 @@ func (r *EntityRepository) PathForEntity(ctx context.Context, gid, entityID uuid
 	}
 	defer func() { _ = rows.Close() }()
 
-	var path []EntityPath
+	type pathEntry struct {
+		path     EntityPath
+		parentID uuid.UUID
+	}
+	entries := make(map[uuid.UUID]pathEntry)
 
 	for rows.Next() {
 		var entry EntityPath
+		parentID := sql.NullScanner{S: new(uuid.UUID)}
 		var isLocation bool
-		if err := rows.Scan(&entry.ID, &entry.Name, &isLocation); err != nil {
+		if err := rows.Scan(&entry.ID, &entry.Name, &parentID, &isLocation); err != nil {
 			recordSpanError(querySpan, err)
 			querySpan.End()
 			recordSpanError(span, err)
@@ -2781,7 +2787,16 @@ func (r *EntityRepository) PathForEntity(ctx context.Context, gid, entityID uuid
 		} else {
 			entry.Type = EntityPathTypeItem
 		}
-		path = append(path, entry)
+
+		var parsedParentID uuid.UUID
+		if parentID.Valid {
+			parsedParentID = *parentID.S.(*uuid.UUID)
+		}
+
+		entries[entry.ID] = pathEntry{
+			path:     entry,
+			parentID: parsedParentID,
+		}
 	}
 
 	if err := rows.Err(); err != nil {
@@ -2790,8 +2805,25 @@ func (r *EntityRepository) PathForEntity(ctx context.Context, gid, entityID uuid
 		recordSpanError(span, err)
 		return nil, err
 	}
-	querySpan.SetAttributes(attribute.Int("path.depth", len(path)))
 	querySpan.End()
+
+	path := make([]EntityPath, 0, len(entries))
+	seen := make(map[uuid.UUID]struct{}, len(entries))
+	for currentID := entityID; currentID != uuid.Nil; {
+		if _, ok := seen[currentID]; ok {
+			recordSpanError(span, ErrEntityParentCycle)
+			return nil, ErrEntityParentCycle
+		}
+		seen[currentID] = struct{}{}
+
+		entry, ok := entries[currentID]
+		if !ok {
+			break
+		}
+
+		path = append(path, entry.path)
+		currentID = entry.parentID
+	}
 
 	// Reverse the order so that the root is first
 	mutable.Reverse(path)

--- a/backend/internal/data/repo/repo_entities.go
+++ b/backend/internal/data/repo/repo_entities.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -39,6 +40,8 @@ func recordSpanError(span trace.Span, err error) {
 	span.RecordError(err)
 	span.SetStatus(codes.Error, err.Error())
 }
+
+var ErrEntityParentCycle = errors.New("entity parent cycle detected")
 
 type EntityRepository struct {
 	db          *ent.Client
@@ -1835,6 +1838,12 @@ func (r *EntityRepository) Patch(ctx context.Context, gid, id uuid.UUID, data En
 			return err
 		}
 	}
+	if data.ParentID != uuid.Nil {
+		if err := r.validateParentPatch(ctx, gid, id, data.ParentID); err != nil {
+			recordSpanError(span, err)
+			return err
+		}
+	}
 
 	tx, err := r.db.Tx(ctx)
 	if err != nil {
@@ -1913,6 +1922,55 @@ func (r *EntityRepository) Patch(ctx context.Context, gid, id uuid.UUID, data En
 
 	r.publishMutationEvent(gid)
 	return nil
+}
+
+func (r *EntityRepository) validateParentPatch(ctx context.Context, gid, childID, parentID uuid.UUID) error {
+	wouldCycle, err := r.WouldCreateParentCycle(ctx, gid, childID, parentID)
+	if err != nil {
+		return err
+	}
+	if wouldCycle {
+		return ErrEntityParentCycle
+	}
+	return nil
+}
+
+func (r *EntityRepository) WouldCreateParentCycle(ctx context.Context, gid, childID, parentID uuid.UUID) (bool, error) {
+	if parentID == uuid.Nil {
+		return false, nil
+	}
+	if childID == parentID {
+		return true, nil
+	}
+
+	query := `
+		WITH RECURSIVE ancestors(id, parent_id) AS (
+			SELECT id, entity_children
+			FROM entities
+			WHERE id = $1
+			AND group_entities = $3
+
+			UNION
+
+			SELECT e.id, e.entity_children
+			FROM entities e
+			JOIN ancestors ON e.id = ancestors.parent_id
+			WHERE e.group_entities = $3
+		)
+		SELECT 1 FROM ancestors WHERE id = $2 LIMIT 1;
+	`
+
+	rows, err := r.db.Sql().QueryContext(ctx, query, parentID, childID, gid)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	found := rows.Next()
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+	return found, nil
 }
 
 func (r *EntityRepository) GetAllCustomFieldValues(ctx context.Context, gid uuid.UUID, name string) ([]string, error) {
@@ -2685,11 +2743,12 @@ func (r *EntityRepository) PathForEntity(ctx context.Context, gid, entityID uuid
 		WHERE id = $1
 		AND group_entities = $2
 
-		UNION ALL
+		UNION
 
 		SELECT e.id, e.name, e.entity_children, e.entity_type_entities
 		FROM entities e
 		JOIN entity_path ep ON e.id = ep.entity_children
+		WHERE e.group_entities = $2
 	  )
 
 	  SELECT ep.id, ep.name, et.is_location

--- a/backend/internal/data/repo/repo_entities_test.go
+++ b/backend/internal/data/repo/repo_entities_test.go
@@ -445,11 +445,11 @@ func TestEntityRepository_Patch_RejectsParentCycles(t *testing.T) {
 
 	err = tRepos.Entities.Patch(ctx, tGroup.ID, parent.ID, EntityPatch{ParentID: parent.ID})
 	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrEntityParentCycle)
+	require.ErrorIs(t, err, ErrEntityParentCycle)
 
 	err = tRepos.Entities.Patch(ctx, tGroup.ID, parent.ID, EntityPatch{ParentID: child.ID})
 	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrEntityParentCycle)
+	require.ErrorIs(t, err, ErrEntityParentCycle)
 }
 
 func TestEntityRepository_CreateFromTemplate_RejectsNonFiniteQuantity(t *testing.T) {

--- a/backend/internal/data/repo/repo_entities_test.go
+++ b/backend/internal/data/repo/repo_entities_test.go
@@ -428,6 +428,30 @@ func TestEntityRepository_Patch_RejectsNonFiniteQuantity(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid quantity: must be a finite number")
 }
 
+func TestEntityRepository_Patch_RejectsParentCycles(t *testing.T) {
+	ctx := context.Background()
+	itemET := useItemEntityType(t)
+
+	parentData := entityFactory()
+	parentData.EntityTypeID = itemET.ID
+	parent, err := tRepos.Entities.Create(ctx, tGroup.ID, parentData)
+	require.NoError(t, err)
+
+	childData := entityFactory()
+	childData.EntityTypeID = itemET.ID
+	childData.ParentID = parent.ID
+	child, err := tRepos.Entities.Create(ctx, tGroup.ID, childData)
+	require.NoError(t, err)
+
+	err = tRepos.Entities.Patch(ctx, tGroup.ID, parent.ID, EntityPatch{ParentID: parent.ID})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEntityParentCycle)
+
+	err = tRepos.Entities.Patch(ctx, tGroup.ID, parent.ID, EntityPatch{ParentID: child.ID})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEntityParentCycle)
+}
+
 func TestEntityRepository_CreateFromTemplate_RejectsNonFiniteQuantity(t *testing.T) {
 	containerET := useContainerEntityType(t)
 

--- a/backend/internal/data/repo/repo_entities_test.go
+++ b/backend/internal/data/repo/repo_entities_test.go
@@ -114,6 +114,51 @@ func TestEntityRepository_RecursiveRelationships(t *testing.T) {
 	}
 }
 
+func TestEntityRepository_PathForEntity_OrdersRootToLeafAndKeepsTypes(t *testing.T) {
+	containerET := useContainerEntityType(t)
+	itemET := useItemEntityType(t)
+
+	rootData := containerFactory()
+	rootData.EntityTypeID = containerET.ID
+	rootData.Name = "path-root"
+	root, err := tRepos.Entities.Create(context.Background(), tGroup.ID, rootData)
+	require.NoError(t, err)
+
+	childData := containerFactory()
+	childData.EntityTypeID = containerET.ID
+	childData.ParentID = root.ID
+	childData.Name = "path-child"
+	child, err := tRepos.Entities.Create(context.Background(), tGroup.ID, childData)
+	require.NoError(t, err)
+
+	itemData := entityFactory()
+	itemData.EntityTypeID = itemET.ID
+	itemData.ParentID = child.ID
+	itemData.Name = "path-item"
+	item, err := tRepos.Entities.Create(context.Background(), tGroup.ID, itemData)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = tRepos.Entities.Delete(context.Background(), item.ID)
+		_ = tRepos.Entities.Delete(context.Background(), child.ID)
+		_ = tRepos.Entities.Delete(context.Background(), root.ID)
+	})
+
+	path, err := tRepos.Entities.PathForEntity(context.Background(), tGroup.ID, item.ID)
+	require.NoError(t, err)
+	require.Len(t, path, 3)
+
+	names := make([]string, len(path))
+	types := make([]EntityPathType, len(path))
+	for i, entry := range path {
+		names[i] = entry.Name
+		types[i] = entry.Type
+	}
+
+	assert.Equal(t, []string{"path-root", "path-child", "path-item"}, names)
+	assert.Equal(t, []EntityPathType{EntityPathTypeLocation, EntityPathTypeLocation, EntityPathTypeItem}, types)
+}
+
 func TestEntityRepository_GetOne(t *testing.T) {
 	entities := useEntities(t, 3)
 

--- a/backend/internal/data/repo/repo_entities_test.go
+++ b/backend/internal/data/repo/repo_entities_test.go
@@ -487,6 +487,10 @@ func TestEntityRepository_Patch_RejectsParentCycles(t *testing.T) {
 	childData.ParentID = parent.ID
 	child, err := tRepos.Entities.Create(ctx, tGroup.ID, childData)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tRepos.Entities.Delete(context.Background(), child.ID)
+		_ = tRepos.Entities.Delete(context.Background(), parent.ID)
+	})
 
 	err = tRepos.Entities.Patch(ctx, tGroup.ID, parent.ID, EntityPatch{ParentID: parent.ID})
 	require.Error(t, err)

--- a/docs/src/content/docs/en/advanced/import-csv.mdx
+++ b/docs/src/content/docs/en/advanced/import-csv.mdx
@@ -9,7 +9,6 @@ to import any large number of items and provides the most flexibility when it co
 - Imports only support importing items, locations, and labels
 - Imports and Exports do not support attachments. Attachments must be uploaded after import
 - CSV Exports do not support nested path exports (e.g., Home / Office / Desk) and will only export the Items direct parent (though imports do support nested paths)
-- Cannot specify item-to-item relationships (e.g. `Item A` is a child of `Item B`)
 
 > [!NOTE]
 > The CSV import supports both CSV and TSV files. The only difference is the delimiter used. CSV files use commas as the delimiter,
@@ -40,6 +39,15 @@ items in your database on later imports.
 This is the location of the item that will be created. These are deduplicated and won't create another instance when reused.
 
 Supports Path Separators for nested locations (e.g. `Home / Office / Desk`)
+
+`HB.parent_import_ref`
+
+This is the import ref of another item that should become the imported item's parent. Use this when importing nested
+items, for example when `Battery` should be a child item of `Camera`.
+
+- The parent item must be present in the same CSV or already exist in Homebox with the matching `HB.import_ref`.
+- Row order does not matter; parent links are resolved after all rows are imported.
+- If this column is empty, the item is placed under `HB.location`.
 
 `HB.label`
 List of labels to apply to the item separated by a comma can be an existing or new label.


### PR DESCRIPTION
Fixes #62.

## Summary

- add `HB.parent_import_ref` so CSV export can represent item-to-item parent relationships
- keep `HB.location` as a location-only path instead of flattening item parents into locations
- resolve parent item links after CSV row creation so parent and child rows can be in any order
- document `HB.parent_import_ref` and remove the outdated limitation that item-to-item relationships cannot be imported

## Testing

- `go test ./internal/core/services/reporting -run TestSheet_Read -count=1`
- `go test ./internal/core/services -run TestEntityService_CsvImportParentImportRef -count=1`
- `go test ./internal/data/repo -run 'TestEntityRepository_(Create|QueryByGroup|GetAll|Path|Tree)' -count=1`
- `git diff --check`

Note: a broader package run on Windows hit existing temp path/storage failures unrelated to this change, where `file://C:\Users\admin\AppData\Local\Temp` was interpreted as a relative package path. Focused tests for the changed behavior passed.