### PR TITLE
fix: preserve CSV item parent relationships

### DIFF
--- a/backend/internal/core/services/reporting/io_row.go
+++ b/backend/internal/core/services/reporting/io_row.go
@@ -14,12 +14,13 @@ type ExportItemFields struct {
 }
 
 type ExportCSVRow struct {
-	ImportRef string         `csv:"HB.import_ref"`
-	Location  LocationString `csv:"HB.location"`
-	TagStr    TagString      `csv:"HB.tags|HB.labels"`
-	AssetID   repo.AssetID   `csv:"HB.asset_id"`
-	Archived  bool           `csv:"HB.archived"`
-	URL       string         `csv:"HB.url"`
+	ImportRef       string         `csv:"HB.import_ref"`
+	ParentImportRef string         `csv:"HB.parent_import_ref"`
+	Location        LocationString `csv:"HB.location"`
+	TagStr          TagString      `csv:"HB.tags|HB.labels"`
+	AssetID         repo.AssetID   `csv:"HB.asset_id"`
+	Archived        bool           `csv:"HB.archived"`
+	URL             string         `csv:"HB.url"`
 
 	Name        string  `csv:"HB.name"`
 	Quantity    float64 `csv:"HB.quantity"`

--- a/backend/internal/core/services/reporting/io_sheet.go
+++ b/backend/internal/core/services/reporting/io_sheet.go
@@ -205,20 +205,35 @@ func (s *IOSheet) ReadItems(ctx context.Context, entities []repo.EntityOut, gid 
 	s.Rows = make([]ExportCSVRow, len(entities))
 
 	extraHeaders := map[string]struct{}{}
+	entitiesByID := lo.SliceToMap(entities, func(item repo.EntityOut) (uuid.UUID, repo.EntityOut) {
+		return item.ID, item
+	})
 
 	for i := range entities {
 		item := entities[i]
 
-		// Resolve parent (location) path
 		var locString LocationString
+		var parentImportRef string
 		if item.Parent != nil {
-			locPaths, err := repos.Entities.PathForEntity(ctx, gid, item.Parent.ID)
-			if err != nil {
-				log.Error().Err(err).Msg("could not get entity path")
-				return err
+			locationParentID := item.Parent.ID
+
+			if parent, ok := entitiesByID[item.Parent.ID]; ok && parent.EntityType != nil && !parent.EntityType.IsLocation {
+				parentImportRef = parent.ImportRef
+				locationParentID = uuid.Nil
+				if parent.Parent != nil {
+					locationParentID = parent.Parent.ID
+				}
 			}
 
-			locString = fromPathSlice(locPaths)
+			if locationParentID != uuid.Nil {
+				locPaths, err := repos.Entities.PathForEntity(ctx, gid, locationParentID)
+				if err != nil {
+					log.Error().Err(err).Msg("could not get entity path")
+					return err
+				}
+
+				locString = fromPathSlice(locPaths)
+			}
 		}
 
 		tagString := lo.Map(item.Tags, func(l repo.TagSummary, _ int) string {
@@ -240,14 +255,15 @@ func (s *IOSheet) ReadItems(ctx context.Context, entities []repo.EntityOut, gid 
 			Location: locString,
 			TagStr:   tagString,
 
-			ImportRef:   item.ImportRef,
-			AssetID:     item.AssetID,
-			Name:        item.Name,
-			Quantity:    item.Quantity,
-			Description: item.Description,
-			Insured:     item.Insured,
-			Archived:    item.Archived,
-			URL:         url,
+			ImportRef:       item.ImportRef,
+			ParentImportRef: parentImportRef,
+			AssetID:         item.AssetID,
+			Name:            item.Name,
+			Quantity:        item.Quantity,
+			Description:     item.Description,
+			Insured:         item.Insured,
+			Archived:        item.Archived,
+			URL:             url,
 
 			PurchasePrice: item.PurchasePrice,
 			PurchaseFrom:  item.PurchaseFrom,

--- a/backend/internal/core/services/service_entities.go
+++ b/backend/internal/core/services/service_entities.go
@@ -524,6 +524,13 @@ func (svc *EntityService) CsvImport(ctx context.Context, gid uuid.UUID, data io.
 			return 0, wrapped
 		}
 
+		if child.ID == parent.ID {
+			wrapped := fmt.Errorf("invalid parent relationship: entity %q cannot be its own parent", row.ImportRef)
+			recordServiceSpanError(importSpan, wrapped)
+			recordServiceSpanError(span, wrapped)
+			return 0, wrapped
+		}
+
 		err = svc.repo.Entities.Patch(ctx, gid, child.ID, repo.EntityPatch{
 			ParentID: parent.ID,
 		})

--- a/backend/internal/core/services/service_entities.go
+++ b/backend/internal/core/services/service_entities.go
@@ -502,6 +502,38 @@ func (svc *EntityService) CsvImport(ctx context.Context, gid uuid.UUID, data io.
 		rowSpan.End()
 	}
 
+	for i := range sheet.Rows {
+		row := sheet.Rows[i]
+		if row.ImportRef == "" || row.ParentImportRef == "" {
+			continue
+		}
+
+		child, err := svc.repo.Entities.GetByRef(ctx, gid, row.ImportRef)
+		if err != nil {
+			wrapped := fmt.Errorf("error resolving child entity with ref %q: %w", row.ImportRef, err)
+			recordServiceSpanError(importSpan, wrapped)
+			recordServiceSpanError(span, wrapped)
+			return 0, wrapped
+		}
+
+		parent, err := svc.repo.Entities.GetByRef(ctx, gid, row.ParentImportRef)
+		if err != nil {
+			wrapped := fmt.Errorf("error resolving parent entity with ref %q: %w", row.ParentImportRef, err)
+			recordServiceSpanError(importSpan, wrapped)
+			recordServiceSpanError(span, wrapped)
+			return 0, wrapped
+		}
+
+		err = svc.repo.Entities.Patch(ctx, gid, child.ID, repo.EntityPatch{
+			ParentID: parent.ID,
+		})
+		if err != nil {
+			recordServiceSpanError(importSpan, err)
+			recordServiceSpanError(span, err)
+			return 0, err
+		}
+	}
+
 	importSpan.SetAttributes(attribute.Int("rows.imported.count", finished))
 	span.SetAttributes(attribute.Int("rows.imported.count", finished))
 	return finished, nil

--- a/backend/internal/core/services/service_entities.go
+++ b/backend/internal/core/services/service_entities.go
@@ -502,48 +502,44 @@ func (svc *EntityService) CsvImport(ctx context.Context, gid uuid.UUID, data io.
 		rowSpan.End()
 	}
 
-	for i := range sheet.Rows {
-		row := sheet.Rows[i]
+	if err := svc.patchCSVParentRefs(ctx, gid, sheet.Rows); err != nil {
+		recordServiceSpanError(importSpan, err)
+		recordServiceSpanError(span, err)
+		return 0, err
+	}
+
+	importSpan.SetAttributes(attribute.Int("rows.imported.count", finished))
+	span.SetAttributes(attribute.Int("rows.imported.count", finished))
+	return finished, nil
+}
+
+func (svc *EntityService) patchCSVParentRefs(ctx context.Context, gid uuid.UUID, rows []reporting.ExportCSVRow) error {
+	for i := range rows {
+		row := rows[i]
 		if row.ImportRef == "" || row.ParentImportRef == "" {
 			continue
 		}
 
 		child, err := svc.repo.Entities.GetByRef(ctx, gid, row.ImportRef)
 		if err != nil {
-			wrapped := fmt.Errorf("error resolving child entity with ref %q: %w", row.ImportRef, err)
-			recordServiceSpanError(importSpan, wrapped)
-			recordServiceSpanError(span, wrapped)
-			return 0, wrapped
+			return fmt.Errorf("error resolving child entity with ref %q: %w", row.ImportRef, err)
 		}
 
 		parent, err := svc.repo.Entities.GetByRef(ctx, gid, row.ParentImportRef)
 		if err != nil {
-			wrapped := fmt.Errorf("error resolving parent entity with ref %q: %w", row.ParentImportRef, err)
-			recordServiceSpanError(importSpan, wrapped)
-			recordServiceSpanError(span, wrapped)
-			return 0, wrapped
+			return fmt.Errorf("error resolving parent entity with ref %q: %w", row.ParentImportRef, err)
 		}
 
 		if child.ID == parent.ID {
-			wrapped := fmt.Errorf("invalid parent relationship: entity %q cannot be its own parent", row.ImportRef)
-			recordServiceSpanError(importSpan, wrapped)
-			recordServiceSpanError(span, wrapped)
-			return 0, wrapped
+			return fmt.Errorf("invalid parent relationship: entity %q cannot be its own parent", row.ImportRef)
 		}
 
-		err = svc.repo.Entities.Patch(ctx, gid, child.ID, repo.EntityPatch{
-			ParentID: parent.ID,
-		})
-		if err != nil {
-			recordServiceSpanError(importSpan, err)
-			recordServiceSpanError(span, err)
-			return 0, err
+		if err := svc.repo.Entities.Patch(ctx, gid, child.ID, repo.EntityPatch{ParentID: parent.ID}); err != nil {
+			return err
 		}
 	}
 
-	importSpan.SetAttributes(attribute.Int("rows.imported.count", finished))
-	span.SetAttributes(attribute.Int("rows.imported.count", finished))
-	return finished, nil
+	return nil
 }
 
 func (svc *EntityService) ExportCSV(ctx context.Context, gid uuid.UUID, hbURL string) ([][]string, error) {

--- a/backend/internal/core/services/service_exports_test.go
+++ b/backend/internal/core/services/service_exports_test.go
@@ -303,6 +303,23 @@ func TestCSVExportImportPreservesItemParent(t *testing.T) {
 	assert.Equal(t, "Toolbox", importedChild.Parent.Name)
 }
 
+func TestCSVImportRejectsSelfParentRef(t *testing.T) {
+	ctx := context.Background()
+
+	dst, err := tRepos.Groups.GroupCreate(ctx, "csv-self-parent-"+fk.Str(4), uuid.Nil)
+	require.NoError(t, err)
+
+	csvData := strings.Join([]string{
+		"HB.import_ref,HB.parent_import_ref,HB.location,HB.name",
+		"self-ref,self-ref,Garage,Loop",
+		"",
+	}, "\n")
+
+	_, err = tSvc.Entities.CsvImport(ctx, dst.ID, strings.NewReader(csvData))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, `entity "self-ref" cannot be its own parent`)
+}
+
 // TestIsGroupReadyForImport_BlocksUserCreatedRows asserts that the import
 // gate blocks not just on items but on user-created rows in any table the
 // import would wipe (tags, entity_templates, notifiers, custom entity_types,

--- a/backend/internal/core/services/service_exports_test.go
+++ b/backend/internal/core/services/service_exports_test.go
@@ -47,7 +47,7 @@ func TestExportRoundTrip(t *testing.T) {
 
 	// One location, one item nested in it.
 	loc, err := tRepos.Entities.Create(ctx, src.ID, repo.EntityCreate{
-		Name:         "Garage",
+		Name:         defaultLocationGarage,
 		Description:  "primary",
 		EntityTypeID: containerET.ID,
 	})
@@ -121,7 +121,7 @@ func TestExportRoundTrip(t *testing.T) {
 
 	dstContainerET, err := tRepos.EntityTypes.GetDefault(ctx, dst.ID, true)
 	require.NoError(t, err)
-	for _, name := range []string{"Living Room", "Garage", "Kitchen"} {
+	for _, name := range []string{"Living Room", defaultLocationGarage, "Kitchen"} {
 		_, err := tRepos.Entities.Create(ctx, dst.ID, repo.EntityCreate{
 			Name:         name,
 			EntityTypeID: dstContainerET.ID,
@@ -161,7 +161,7 @@ func TestExportRoundTrip(t *testing.T) {
 
 	parent, err := gotItem.QueryParent().Only(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, "Garage", parent.Name, "parent FK must be restored on second pass")
+	assert.Equal(t, defaultLocationGarage, parent.Name, "parent FK must be restored on second pass")
 
 	tags, err := gotItem.QueryTag().All(ctx)
 	require.NoError(t, err)
@@ -227,7 +227,7 @@ func TestCSVExportImportPreservesItemParent(t *testing.T) {
 
 	location, err := tRepos.Entities.Create(ctx, src.ID, repo.EntityCreate{
 		ImportRef:    "loc-ref",
-		Name:         "Garage",
+		Name:         defaultLocationGarage,
 		EntityTypeID: locationType.ID,
 	})
 	require.NoError(t, err)
@@ -276,11 +276,11 @@ func TestCSVExportImportPreservesItemParent(t *testing.T) {
 	}
 	require.NotNil(t, childRow)
 	assert.Equal(t, "parent-ref", childRow[parentRefCol])
-	assert.Equal(t, "Garage", childRow[locationCol])
+	assert.Equal(t, defaultLocationGarage, childRow[locationCol])
 
 	importRows := [][]string{header}
 	for _, row := range rows[1:] {
-		if row[nameCol] != "Garage" {
+		if row[nameCol] != defaultLocationGarage {
 			importRows = append(importRows, row)
 		}
 	}
@@ -311,7 +311,7 @@ func TestCSVImportRejectsSelfParentRef(t *testing.T) {
 
 	csvData := strings.Join([]string{
 		"HB.import_ref,HB.parent_import_ref,HB.location,HB.name",
-		"self-ref,self-ref,Garage,Loop",
+		"self-ref,self-ref," + defaultLocationGarage + ",Loop",
 		"",
 	}, "\n")
 
@@ -341,7 +341,7 @@ func TestIsGroupReadyForImport_BlocksUserCreatedRows(t *testing.T) {
 		require.NoError(t, err)
 		locET, err := tRepos.EntityTypes.GetDefault(ctx, g.ID, true)
 		require.NoError(t, err)
-		for _, name := range []string{"Living Room", "Garage", "Kitchen", "Bedroom", "Bathroom", "Office", "Attic", "Basement"} {
+		for _, name := range []string{"Living Room", defaultLocationGarage, "Kitchen", "Bedroom", "Bathroom", "Office", "Attic", "Basement"} {
 			_, err := tRepos.Entities.Create(ctx, g.ID, repo.EntityCreate{Name: name, EntityTypeID: locET.ID})
 			require.NoError(t, err)
 		}

--- a/backend/internal/core/services/service_exports_test.go
+++ b/backend/internal/core/services/service_exports_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"bytes"
 	"context"
+	"encoding/csv"
 	"io"
 	"strings"
 	"testing"
@@ -211,6 +212,95 @@ func TestExportRoundTrip(t *testing.T) {
 	thumbBlob, err := bk.ReadAll(ctx, tRepos.Attachments.GetFullPath(gotThumb.Path))
 	require.NoError(t, err, "thumbnail blob must be present at the rewritten path")
 	assert.Equal(t, "dummy thumbnail body", string(thumbBlob))
+}
+
+func TestCSVExportImportPreservesItemParent(t *testing.T) {
+	ctx := context.Background()
+
+	src, err := tRepos.Groups.GroupCreate(ctx, "csv-parent-src-"+fk.Str(4), uuid.Nil)
+	require.NoError(t, err)
+
+	locationType, err := tRepos.EntityTypes.GetDefault(ctx, src.ID, true)
+	require.NoError(t, err)
+	itemType, err := tRepos.EntityTypes.GetDefault(ctx, src.ID, false)
+	require.NoError(t, err)
+
+	location, err := tRepos.Entities.Create(ctx, src.ID, repo.EntityCreate{
+		ImportRef:    "loc-ref",
+		Name:         "Garage",
+		EntityTypeID: locationType.ID,
+	})
+	require.NoError(t, err)
+
+	parent, err := tRepos.Entities.Create(ctx, src.ID, repo.EntityCreate{
+		ImportRef:    "parent-ref",
+		Name:         "Toolbox",
+		ParentID:     location.ID,
+		EntityTypeID: itemType.ID,
+	})
+	require.NoError(t, err)
+
+	_, err = tRepos.Entities.Create(ctx, src.ID, repo.EntityCreate{
+		ImportRef:    "child-ref",
+		Name:         "Screwdriver",
+		ParentID:     parent.ID,
+		EntityTypeID: itemType.ID,
+	})
+	require.NoError(t, err)
+
+	rows, err := tSvc.Entities.ExportCSV(ctx, src.ID, "https://homebox.example")
+	require.NoError(t, err)
+
+	header := rows[0]
+	col := func(name string) int {
+		t.Helper()
+		for i, h := range header {
+			if h == name {
+				return i
+			}
+		}
+		require.FailNowf(t, "missing CSV column", "column %q not found in %v", name, header)
+		return -1
+	}
+
+	nameCol := col("HB.name")
+	parentRefCol := col("HB.parent_import_ref")
+	locationCol := col("HB.location")
+
+	var childRow []string
+	for _, row := range rows[1:] {
+		if row[nameCol] == "Screwdriver" {
+			childRow = row
+			break
+		}
+	}
+	require.NotNil(t, childRow)
+	assert.Equal(t, "parent-ref", childRow[parentRefCol])
+	assert.Equal(t, "Garage", childRow[locationCol])
+
+	importRows := [][]string{header}
+	for _, row := range rows[1:] {
+		if row[nameCol] != "Garage" {
+			importRows = append(importRows, row)
+		}
+	}
+
+	var csvBuf bytes.Buffer
+	writer := csv.NewWriter(&csvBuf)
+	require.NoError(t, writer.WriteAll(importRows))
+	require.NoError(t, writer.Error())
+
+	dst, err := tRepos.Groups.GroupCreate(ctx, "csv-parent-dst-"+fk.Str(4), uuid.Nil)
+	require.NoError(t, err)
+
+	imported, err := tSvc.Entities.CsvImport(ctx, dst.ID, bytes.NewReader(csvBuf.Bytes()))
+	require.NoError(t, err)
+	require.Equal(t, len(importRows)-1, imported)
+
+	importedChild, err := tRepos.Entities.GetByRef(ctx, dst.ID, "child-ref")
+	require.NoError(t, err)
+	require.NotNil(t, importedChild.Parent)
+	assert.Equal(t, "Toolbox", importedChild.Parent.Name)
 }
 
 // TestIsGroupReadyForImport_BlocksUserCreatedRows asserts that the import

--- a/backend/internal/core/services/service_user_defaults.go
+++ b/backend/internal/core/services/service_user_defaults.go
@@ -4,13 +4,15 @@ import (
 	"github.com/sysadminsmedia/homebox/backend/internal/data/repo"
 )
 
+const defaultLocationGarage = "Garage"
+
 func defaultLocations() []repo.EntityCreate {
 	return []repo.EntityCreate{
 		{
 			Name: "Living Room",
 		},
 		{
-			Name: "Garage",
+			Name: defaultLocationGarage,
 		},
 		{
 			Name: "Kitchen",


### PR DESCRIPTION
Fixes #62.

Summary:
- add `HB.parent_import_ref` to CSV exports so child item rows can reference their parent item
- keep child item `HB.location` as the actual location path instead of flattening the parent item into it
- reconnect imported child items to their referenced parent item in a second import pass after all rows exist
- add a focused export/import round-trip test for an item nested under another item

Verification:
- `go test ./internal/core/services/reporting -run TestSheet_Read -count=1`
- `go test ./internal/core/services -run TestCSVExportImportPreservesItemParent -count=1`
- `git diff --check`