### PR TITLE
feat(attachments): robust photo uploads — retry, per-photo progress, real XHR progress

### DIFF
--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -195,16 +195,26 @@
         <ButtonGroup>
           <Button :disabled="loading" type="submit" class="group">
             <div class="relative mx-2">
+              <MdiLoading v-if="loading" class="size-5 animate-spin" />
               <div
+                v-else
                 class="absolute inset-0 flex items-center justify-center transition-transform duration-300 group-hover:rotate-[360deg]"
               >
                 <MdiPackageVariant class="size-5 group-hover:hidden" />
                 <MdiPackageVariantClosed class="hidden size-5 group-hover:block" />
               </div>
             </div>
-            {{ $t("global.create") }}
+            <span v-if="loading && uploadProgress">
+              {{
+                $t("components.item.create_modal.uploading_progress", {
+                  current: uploadProgress.current,
+                  total: uploadProgress.total,
+                })
+              }}
+            </span>
+            <span v-else>{{ pendingItemId ? $t("global.retry_upload") : $t("global.create") }}</span>
           </Button>
-          <Button variant="outline" :disabled="loading" type="button" @click="create(false)">
+          <Button v-if="!pendingItemId" variant="outline" :disabled="loading" type="button" @click="create(false)">
             {{ $t("global.create_and_add") }}
           </Button>
         </ButtonGroup>
@@ -304,6 +314,7 @@
   import MdiBarcodeScan from "~icons/mdi/barcode-scan";
   import MdiPackageVariant from "~icons/mdi/package-variant";
   import MdiPackageVariantClosed from "~icons/mdi/package-variant-closed";
+  import MdiLoading from "~icons/mdi/loading";
   import MdiDelete from "~icons/mdi/delete";
   import MdiRotateClockwise from "~icons/mdi/rotate-clockwise";
   import MdiStarOutline from "~icons/mdi/star-outline";
@@ -424,6 +435,12 @@
   const selectedTemplate = ref<EntityTemplateSummary | null>(null);
   const templateData = ref<EntityTemplateOut | null>(null);
   const showTemplateDetails = ref(false);
+  // Set when the item was created but one or more photo uploads failed. While set, the next
+  // submit re-uploads the remaining photos to this item instead of creating a duplicate.
+  const pendingItemId = ref<string | null>(null);
+  // Per-photo progress counter shown on the submit button while photos upload.
+  const uploadProgress = ref<{ current: number; total: number } | null>(null);
+  const { uploadFile } = useAttachmentUpload();
   const form = reactive({
     location: locations.value && locations.value.length > 0 ? locations.value[0] : ({} as EntityOut),
     parentId: null,
@@ -569,6 +586,8 @@
 
   onMounted(() => {
     const cleanup = registerOpenDialogCallback(DialogID.CreateItem, async params => {
+      // Abandon any leftover retry state from a previous session — opening the modal means starting fresh.
+      pendingItemId.value = null;
       // needed since URL will be cleared in the next step => ParentId Selection should stay though
       subItemCreate.value = subItemCreateParam.value === "y";
       let parentItemLocationId = null;
@@ -649,85 +668,98 @@
 
     if (shift?.value) close = false;
 
-    let createResponse;
+    try {
+      let itemId = pendingItemId.value;
 
-    // If a template is selected, use the template creation endpoint
-    if (templateData.value) {
-      const templateRequest = {
-        name: form.name,
-        description: form.description,
-        parentId: form.location.id as string,
-        tagIds: form.tags,
-        quantity: form.quantity,
-      };
-
-      createResponse = await api.templates.createItem(templateData.value.id, templateRequest);
-    } else {
-      // Normal item creation without template
-      const out: EntityCreate = {
-        parentId: form.parentId || (form.location.id as string),
-        name: form.name,
-        quantity: form.quantity,
-        description: form.description,
-        tagIds: form.tags,
-        entityTypeId: selectedEntityType.value?.id,
-      };
-
-      createResponse = await api.items.create(out);
-    }
-
-    const { error, data } = createResponse;
-
-    if (error) {
-      loading.value = false;
-      const reason = extractErrorMessage(createResponse);
-      toast.error(t("components.item.create_modal.toast.create_failed_reason", { reason }));
-      console.error("Item create failed", createResponse);
-      return;
-    }
-
-    toast.success(t("components.item.create_modal.toast.create_success"));
-
-    if (form.photos.length > 0) {
-      toast.info(t("components.item.create_modal.toast.uploading_photos", { count: form.photos.length }));
-      let uploadError = false;
-      for (const photo of form.photos) {
-        const { error: attachError } = await api.items.attachments.add(
-          data.id,
-          photo.file,
-          photo.photoName,
-          AttachmentTypes.Photo,
-          photo.primary
-        );
-
-        if (attachError) {
-          uploadError = true;
-          toast.error(t("components.item.create_modal.toast.upload_failed", { photoName: photo.photoName }));
-          console.error(attachError);
+      // Skip creation when retrying a partial-success state — the item already exists.
+      if (!itemId) {
+        let createResponse;
+        if (templateData.value) {
+          const templateRequest = {
+            name: form.name,
+            description: form.description,
+            parentId: form.location.id as string,
+            tagIds: form.tags,
+            quantity: form.quantity,
+          };
+          createResponse = await api.templates.createItem(templateData.value.id, templateRequest);
+        } else {
+          const out: EntityCreate = {
+            parentId: form.parentId || (form.location.id as string),
+            name: form.name,
+            quantity: form.quantity,
+            description: form.description,
+            tagIds: form.tags,
+            entityTypeId: selectedEntityType.value?.id,
+          };
+          createResponse = await api.items.create(out);
         }
-      }
-      if (uploadError) {
-        toast.warning(t("components.item.create_modal.toast.some_photos_failed", { count: form.photos.length }));
-      } else {
-        toast.success(t("components.item.create_modal.toast.upload_success", { count: form.photos.length }));
-      }
-    }
 
-    form.name = "";
-    form.quantity = 1;
-    form.description = "";
-    form.color = "";
-    form.photos = [];
-    form.tags = [];
-    selectedTemplate.value = null;
-    templateData.value = null;
-    showTemplateDetails.value = false;
-    focused.value = false;
-    loading.value = false;
+        if (createResponse.error || !createResponse.data?.id) {
+          const reason = extractErrorMessage(createResponse);
+          toast.error(t("components.item.create_modal.toast.create_failed_reason", { reason }));
+          console.error("Item create failed", createResponse);
+          return;
+        }
 
-    if (close) {
-      closeDialog(DialogID.CreateItem);
-      navigateTo(`/item/${data.id}`);
+        itemId = createResponse.data.id;
+        toast.success(t("components.item.create_modal.toast.create_success"));
+      }
+
+      if (form.photos.length > 0) {
+        const total = form.photos.length;
+        const failed: PhotoPreview[] = [];
+
+        for (let i = 0; i < total; i++) {
+          const photo = form.photos[i]!;
+          uploadProgress.value = { current: i + 1, total };
+          const result = await uploadFile(itemId, photo.file, photo.photoName, AttachmentTypes.Photo, photo.primary);
+          if (!result.ok) {
+            failed.push(photo);
+            toast.error(
+              t("components.item.create_modal.toast.upload_failed_reason", {
+                photoName: photo.photoName,
+                reason: result.reason,
+              })
+            );
+            console.error("Photo upload failed", result);
+          }
+        }
+
+        if (failed.length > 0) {
+          // Keep only the failed photos so the user retries without re-uploading the successful ones.
+          form.photos = failed;
+          pendingItemId.value = itemId;
+          toast.warning(t("components.item.create_modal.toast.some_photos_failed", { count: failed.length }));
+          return;
+        }
+
+        toast.success(t("components.item.create_modal.toast.upload_success", { count: total }));
+      }
+
+      form.name = "";
+      form.quantity = 1;
+      form.description = "";
+      form.color = "";
+      form.photos = [];
+      form.tags = [];
+      selectedTemplate.value = null;
+      templateData.value = null;
+      showTemplateDetails.value = false;
+      focused.value = false;
+      pendingItemId.value = null;
+
+      if (close) {
+        closeDialog(DialogID.CreateItem);
+        navigateTo(`/item/${itemId}`);
+      }
+    } catch (err: unknown) {
+      const reason = err instanceof Error && err.message ? err.message : String(err);
+      toast.error(t("components.item.create_modal.toast.unexpected_error", { reason }));
+      console.error("Item create flow threw", err);
+    } finally {
+      loading.value = false;
+      uploadProgress.value = null;
     }
   }
 

--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -209,6 +209,7 @@
                 $t("components.item.create_modal.uploading_progress", {
                   current: uploadProgress.current,
                   total: uploadProgress.total,
+                  percent: Math.round(uploadProgress.percent * 100),
                 })
               }}
             </span>
@@ -439,7 +440,8 @@
   // submit re-uploads the remaining photos to this item instead of creating a duplicate.
   const pendingItemId = ref<string | null>(null);
   // Per-photo progress counter shown on the submit button while photos upload.
-  const uploadProgress = ref<{ current: number; total: number } | null>(null);
+  // `percent` is the fraction (0..1) of the current photo's body uploaded.
+  const uploadProgress = ref<{ current: number; total: number; percent: number } | null>(null);
   const { uploadFile } = useAttachmentUpload();
   const form = reactive({
     location: locations.value && locations.value.length > 0 ? locations.value[0] : ({} as EntityOut),
@@ -712,8 +714,17 @@
 
         for (let i = 0; i < total; i++) {
           const photo = form.photos[i]!;
-          uploadProgress.value = { current: i + 1, total };
-          const result = await uploadFile(itemId, photo.file, photo.photoName, AttachmentTypes.Photo, photo.primary);
+          uploadProgress.value = { current: i + 1, total, percent: 0 };
+          const result = await uploadFile(
+            itemId,
+            photo.file,
+            photo.photoName,
+            AttachmentTypes.Photo,
+            photo.primary,
+            fraction => {
+              if (uploadProgress.value) uploadProgress.value.percent = fraction;
+            }
+          );
           if (!result.ok) {
             failed.push(photo);
             toast.error(

--- a/frontend/components/Item/CreateModal.vue
+++ b/frontend/components/Item/CreateModal.vue
@@ -287,6 +287,7 @@
   import { useI18n } from "vue-i18n";
   import { DialogID } from "@/components/ui/dialog-provider/utils";
   import { toast } from "@/components/ui/sonner";
+  import { extractErrorMessage } from "~~/lib/requests/extract-error";
   import { Button, ButtonGroup } from "~/components/ui/button";
   import BaseModal from "@/components/App/CreateModal.vue";
   import { Label } from "@/components/ui/label";
@@ -648,7 +649,7 @@
 
     if (shift?.value) close = false;
 
-    let error, data;
+    let createResponse;
 
     // If a template is selected, use the template creation endpoint
     if (templateData.value) {
@@ -660,9 +661,7 @@
         quantity: form.quantity,
       };
 
-      const result = await api.templates.createItem(templateData.value.id, templateRequest);
-      error = result.error;
-      data = result.data;
+      createResponse = await api.templates.createItem(templateData.value.id, templateRequest);
     } else {
       // Normal item creation without template
       const out: EntityCreate = {
@@ -674,14 +673,16 @@
         entityTypeId: selectedEntityType.value?.id,
       };
 
-      const result = await api.items.create(out);
-      error = result.error;
-      data = result.data;
+      createResponse = await api.items.create(out);
     }
+
+    const { error, data } = createResponse;
 
     if (error) {
       loading.value = false;
-      toast.error(t("components.item.create_modal.toast.create_failed"));
+      const reason = extractErrorMessage(createResponse);
+      toast.error(t("components.item.create_modal.toast.create_failed_reason", { reason }));
+      console.error("Item create failed", createResponse);
       return;
     }
 

--- a/frontend/components/Location/CreateModal.vue
+++ b/frontend/components/Location/CreateModal.vue
@@ -138,7 +138,7 @@
   import { Label } from "@/components/ui/label";
   import { Input } from "@/components/ui/input";
   import BaseModal from "@/components/App/CreateModal.vue";
-  import type { EntityTypeSummary, EntitySummary } from "~~/lib/api/types/data-contracts";
+  import type { EntitySummary } from "~~/lib/api/types/data-contracts";
   import { AttachmentTypes } from "~~/lib/api/types/non-generated";
   import { useDialog, useDialogHotkey } from "~/components/ui/dialog-provider";
   import { useTagStore } from "~/stores/tags";

--- a/frontend/composables/use-attachment-upload.ts
+++ b/frontend/composables/use-attachment-upload.ts
@@ -31,9 +31,18 @@ export function useAttachmentUpload(options: RetryOptions = {}) {
     file: File | Blob,
     filename: string,
     type: AttachmentTypes | null = null,
-    primary?: boolean
+    primary?: boolean,
+    onProgress?: (fraction: number) => void
   ): Promise<UploadResult> {
-    return track(() => withRetries(() => api.items.attachments.add(itemId, file, filename, type, primary), options));
+    return track(() =>
+      withRetries(
+        () =>
+          onProgress
+            ? api.items.attachments.addWithProgress(itemId, file, filename, type, primary, onProgress)
+            : api.items.attachments.add(itemId, file, filename, type, primary),
+        options
+      )
+    );
   }
 
   function uploadExternalLink(

--- a/frontend/composables/use-attachment-upload.ts
+++ b/frontend/composables/use-attachment-upload.ts
@@ -1,0 +1,55 @@
+import { computed, ref } from "vue";
+import { withRetries, type RetryOptions, type RetryResult } from "~~/lib/requests/retry";
+import type { EntityOut } from "~~/lib/api/types/data-contracts";
+import type { AttachmentTypes } from "~~/lib/api/types/non-generated";
+
+export type UploadResult = RetryResult<EntityOut>;
+
+/**
+ * Wraps the attachments API with retry-on-transient-failure (see `lib/requests/retry`)
+ * and exposes a reactive `uploading` flag for UI state. Errors are returned as a
+ * tagged-union result with a human-readable reason — call sites just check `result.ok`.
+ */
+export function useAttachmentUpload(options: RetryOptions = {}) {
+  const api = useUserApi();
+
+  // Counter (not boolean) so concurrent uploads each keep the flag true while in flight.
+  const inFlight = ref(0);
+  const uploading = computed(() => inFlight.value > 0);
+
+  async function track<T>(call: () => Promise<T>): Promise<T> {
+    inFlight.value++;
+    try {
+      return await call();
+    } finally {
+      inFlight.value--;
+    }
+  }
+
+  function uploadFile(
+    itemId: string,
+    file: File | Blob,
+    filename: string,
+    type: AttachmentTypes | null = null,
+    primary?: boolean
+  ): Promise<UploadResult> {
+    return track(() => withRetries(() => api.items.attachments.add(itemId, file, filename, type, primary), options));
+  }
+
+  function uploadExternalLink(
+    itemId: string,
+    sourceType: string,
+    externalId: string,
+    title: string,
+    attachmentType?: string
+  ): Promise<UploadResult> {
+    return track(() =>
+      withRetries(
+        () => api.items.attachments.addExternalLink(itemId, sourceType, externalId, title, attachmentType),
+        options
+      )
+    );
+  }
+
+  return { uploading, uploadFile, uploadExternalLink };
+}

--- a/frontend/lib/api/classes/items.ts
+++ b/frontend/lib/api/classes/items.ts
@@ -39,21 +39,45 @@ export type TreeQuery = {
   withItems: boolean;
 };
 
+function buildAttachmentForm(
+  file: File | Blob,
+  filename: string,
+  type: AttachmentTypes | null,
+  primary: boolean | undefined
+): FormData {
+  const formData = new FormData();
+  formData.append("file", file);
+  if (type) formData.append("type", type);
+  formData.append("name", filename);
+  if (primary !== undefined) formData.append("primary", primary.toString());
+  return formData;
+}
+
 export class AttachmentsAPI extends BaseAPI {
   add(id: string, file: File | Blob, filename: string, type: AttachmentTypes | null = null, primary?: boolean) {
-    const formData = new FormData();
-    formData.append("file", file);
-    if (type) {
-      formData.append("type", type);
-    }
-    formData.append("name", filename);
-    if (primary !== undefined) {
-      formData.append("primary", primary.toString());
-    }
-
     return this.http.post<FormData, EntityOut>({
       url: route(`/entities/${id}/attachments`),
-      data: formData,
+      data: buildAttachmentForm(file, filename, type, primary),
+    });
+  }
+
+  /**
+   * Same payload as `add`, but uses an XHR transport so the caller can subscribe to
+   * real upload progress via `onProgress(fraction)`. Use this when the UI needs to
+   * render a percentage; otherwise `add` is fine.
+   */
+  addWithProgress(
+    id: string,
+    file: File | Blob,
+    filename: string,
+    type: AttachmentTypes | null = null,
+    primary: boolean | undefined,
+    onProgress: (fraction: number) => void
+  ) {
+    return this.http.postWithProgress<EntityOut>({
+      url: route(`/entities/${id}/attachments`),
+      data: buildAttachmentForm(file, filename, type, primary),
+      onProgress,
     });
   }
 

--- a/frontend/lib/api/classes/items.ts
+++ b/frontend/lib/api/classes/items.ts
@@ -227,7 +227,7 @@ export class ItemsApi extends BaseAPI {
     return {
       ...resp,
       data: resp.data?.items ?? [],
-    } as { data: EntitySummary[]; error: any; status: number };
+    };
   }
 
   getTree(tq: TreeQuery = { withItems: false }) {

--- a/frontend/lib/requests/extract-error.test.ts
+++ b/frontend/lib/requests/extract-error.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "vitest";
+import type { TResponse } from "./requests";
+import { extractErrorMessage } from "./extract-error";
+
+function resp(status: number, data: unknown, statusText = ""): TResponse<unknown> {
+  return {
+    status,
+    error: status >= 400,
+    data,
+    response: { statusText } as Response,
+  };
+}
+
+describe("extractErrorMessage", () => {
+  test("returns thrown Error message when provided", () => {
+    expect(extractErrorMessage(undefined, new Error("network timed out"))).toBe("network timed out");
+  });
+
+  test("falls back to String() for non-Error throws", () => {
+    expect(extractErrorMessage(undefined, "boom")).toBe("boom");
+  });
+
+  test("returns Unknown error when nothing is given", () => {
+    expect(extractErrorMessage(undefined)).toBe("Unknown error");
+  });
+
+  test("extracts top-level error key from backend ErrorResponse", () => {
+    expect(extractErrorMessage(resp(400, { error: "failed to parse multipart form" }))).toBe(
+      "failed to parse multipart form"
+    );
+  });
+
+  test("formats validation fields and strips Go validator boilerplate", () => {
+    const data = {
+      error: "Validation Error",
+      fields: {
+        Name: "Key: 'ItemCreate.Name' Error:Field validation for 'Name' failed on the 'required' tag",
+        Quantity: "Key: 'ItemCreate.Quantity' Error:Field validation for 'Quantity' failed on the 'min' tag",
+      },
+    };
+    const msg = extractErrorMessage(resp(422, data));
+    expect(msg).toContain("Name: Name is required");
+    expect(msg).toContain("Quantity: Quantity failed validation (min)");
+  });
+
+  test("prefers fields over the generic top-level error when both are present", () => {
+    const data = {
+      error: "Validation Error",
+      fields: { Name: "Field validation for 'Name' failed on the 'required' tag" },
+    };
+    expect(extractErrorMessage(resp(422, data))).toBe("Name: Name is required");
+  });
+
+  test("handles legacy [{ field, error }] array shape", () => {
+    const data = [
+      { field: "Name", error: "Field validation for 'Name' failed on the 'required' tag" },
+      { field: "Quantity", error: "must be positive" },
+    ];
+    const msg = extractErrorMessage(resp(422, data));
+    expect(msg).toContain("Name: Name is required");
+    expect(msg).toContain("Quantity: must be positive");
+  });
+
+  test("falls back to message / detail / title keys", () => {
+    expect(extractErrorMessage(resp(500, { message: "boom" }))).toBe("boom");
+    expect(extractErrorMessage(resp(500, { detail: "internal" }))).toBe("internal");
+    expect(extractErrorMessage(resp(500, { title: "Server Error" }))).toBe("Server Error");
+  });
+
+  test("falls back to statusText when no body fields match", () => {
+    expect(extractErrorMessage(resp(503, {}, "Service Unavailable"))).toBe("Service Unavailable (HTTP 503)");
+  });
+
+  test("falls back to HTTP status when neither body nor statusText is useful", () => {
+    expect(extractErrorMessage(resp(418, null))).toBe("HTTP 418");
+  });
+
+  test("ignores empty fields map", () => {
+    const data = { error: "Bad Request", fields: {} };
+    expect(extractErrorMessage(resp(400, data))).toBe("Bad Request");
+  });
+
+  test("ignores empty strings in fields map", () => {
+    const data = { error: "Validation Error", fields: { Name: "" } };
+    expect(extractErrorMessage(resp(422, data))).toBe("Validation Error");
+  });
+});

--- a/frontend/lib/requests/extract-error.ts
+++ b/frontend/lib/requests/extract-error.ts
@@ -1,0 +1,68 @@
+import type { TResponse } from "./requests";
+
+// Strip Go validator boilerplate so messages like
+// "Key: 'ItemCreate.Name' Error:Field validation for 'Name' failed on the 'required' tag"
+// become "Name is required" / "Name failed validation (min)".
+function cleanValidatorMessage(raw: string): string {
+  const match = raw.match(/Field validation for '([^']+)' failed on the '([^']+)' tag/);
+  if (!match) return raw;
+  const [, field, tag] = match;
+  return tag === "required" ? `${field} is required` : `${field} failed validation (${tag})`;
+}
+
+function formatFields(fields: Record<string, unknown>): string {
+  const parts: string[] = [];
+  for (const [field, value] of Object.entries(fields)) {
+    if (typeof value === "string" && value.length > 0) {
+      parts.push(`${field}: ${cleanValidatorMessage(value)}`);
+    }
+  }
+  return parts.join("; ");
+}
+
+/**
+ * Extract a human-readable error message from an API response or a thrown exception.
+ * Knows the HomeBox backend's `ErrorResponse { error, fields? }` shape and tolerates
+ * non-JSON bodies, validation-error arrays, and unexpected payloads.
+ */
+export function extractErrorMessage(resp: TResponse<unknown> | undefined, thrown?: unknown): string {
+  if (thrown !== undefined) {
+    return thrown instanceof Error && thrown.message ? thrown.message : String(thrown);
+  }
+  if (!resp) return "Unknown error";
+
+  const data = resp.data as unknown;
+
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    const obj = data as Record<string, unknown>;
+    const fields = obj.fields;
+    if (fields && typeof fields === "object" && Object.keys(fields).length > 0) {
+      const formatted = formatFields(fields as Record<string, unknown>);
+      if (formatted) return formatted;
+    }
+    for (const key of ["error", "message", "detail", "title"]) {
+      const value = obj[key];
+      if (typeof value === "string" && value.length > 0) return value;
+    }
+  }
+
+  // Legacy/array shape some endpoints emit: [{ field, error }]
+  if (Array.isArray(data) && data.length > 0) {
+    const parts: string[] = [];
+    for (const entry of data) {
+      if (entry && typeof entry === "object") {
+        const e = entry as Record<string, unknown>;
+        if (typeof e.field === "string" && typeof e.error === "string") {
+          parts.push(`${e.field}: ${cleanValidatorMessage(e.error)}`);
+        } else if (typeof e.error === "string") {
+          parts.push(e.error);
+        }
+      }
+    }
+    if (parts.length > 0) return parts.join("; ");
+  }
+
+  const statusText = resp.response?.statusText;
+  if (statusText) return `${statusText} (HTTP ${resp.status})`;
+  return `HTTP ${resp.status}`;
+}

--- a/frontend/lib/requests/requests.ts
+++ b/frontend/lib/requests/requests.ts
@@ -22,6 +22,14 @@ export type RequestArgs<T> = {
   headers?: Record<string, string>;
 };
 
+export type ProgressUploadArgs = {
+  url: string;
+  data: FormData;
+  headers?: Record<string, string>;
+  /** Called with the fraction (0..1) of the body uploaded. The final call is always 1. */
+  onProgress?: (fraction: number) => void;
+};
+
 export class Requests {
   private baseUrl: string;
   private token: () => string;
@@ -64,6 +72,28 @@ export class Requests {
 
   public delete<T>(args: RequestArgs<T>): Promise<TResponse<T>> {
     return this.do<T>(Method.DELETE, args);
+  }
+
+  /**
+   * POST a FormData body with real upload progress via XHR. Mirrors `post`'s `TResponse<U>`
+   * shape so call sites can opt in to progress without restructuring their result handling.
+   * Resolves on every HTTP status (the `error` flag distinguishes 2xx from 4xx/5xx); rejects
+   * only when the transport itself fails (network drop, abort) — same as `post()`.
+   */
+  public async postWithProgress<U>(args: ProgressUploadArgs): Promise<TResponse<U>> {
+    const { xhrUpload } = await import("./xhr-upload");
+    const headers: Record<string, string> = { ...args.headers, ...this.headers };
+    const token = this.token();
+    if (token !== "") headers["Authorization"] = token;
+
+    const result = await xhrUpload<U>({
+      url: this.url(args.url),
+      data: args.data,
+      headers,
+      onProgress: args.onProgress,
+    });
+    this.callResponseInterceptors(result.response);
+    return result;
   }
 
   private methodSupportsBody(method: Method): boolean {

--- a/frontend/lib/requests/retry.test.ts
+++ b/frontend/lib/requests/retry.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "vitest";
+import type { TResponse } from "./requests";
+import { isRetryableStatus, withRetries } from "./retry";
+
+function ok<T>(data: T): TResponse<T> {
+  return { status: 200, error: false, data, response: {} as Response };
+}
+
+function fail(status: number, data: unknown = null, statusText = ""): TResponse<unknown> {
+  return { status, error: true, data, response: { statusText } as Response };
+}
+
+const noSleep = () => Promise.resolve();
+
+describe("isRetryableStatus", () => {
+  test("treats status 0 (thrown / no response) as retryable", () => {
+    expect(isRetryableStatus(0)).toBe(true);
+  });
+
+  test("retries on 408, 429, and all 5xx", () => {
+    expect(isRetryableStatus(408)).toBe(true);
+    expect(isRetryableStatus(429)).toBe(true);
+    expect(isRetryableStatus(500)).toBe(true);
+    expect(isRetryableStatus(503)).toBe(true);
+  });
+
+  test("does not retry on 2xx, 3xx, or other 4xx", () => {
+    expect(isRetryableStatus(200)).toBe(false);
+    expect(isRetryableStatus(304)).toBe(false);
+    expect(isRetryableStatus(400)).toBe(false);
+    expect(isRetryableStatus(404)).toBe(false);
+    expect(isRetryableStatus(422)).toBe(false);
+  });
+});
+
+describe("withRetries", () => {
+  test("returns ok immediately on success", async () => {
+    let calls = 0;
+    const result = await withRetries(
+      async () => {
+        calls++;
+        return ok({ id: "abc" });
+      },
+      { sleep: noSleep }
+    );
+    expect(result).toEqual({ ok: true, data: { id: "abc" } });
+    expect(calls).toBe(1);
+  });
+
+  test("retries thrown errors then succeeds", async () => {
+    let calls = 0;
+    const result = await withRetries(
+      async () => {
+        calls++;
+        if (calls < 3) throw new Error("network down");
+        return ok({ id: "abc" });
+      },
+      { sleep: noSleep }
+    );
+    expect(result).toEqual({ ok: true, data: { id: "abc" } });
+    expect(calls).toBe(3);
+  });
+
+  test("retries on 5xx then succeeds", async () => {
+    let calls = 0;
+    const result = await withRetries(
+      async () => {
+        calls++;
+        if (calls < 2) return fail(503, { error: "upstream down" });
+        return ok({ id: "abc" });
+      },
+      { sleep: noSleep }
+    );
+    expect(result.ok).toBe(true);
+    expect(calls).toBe(2);
+  });
+
+  test("does NOT retry on 4xx — returns the failure with extracted reason", async () => {
+    let calls = 0;
+    const result = await withRetries(
+      async () => (
+        calls++,
+        fail(422, {
+          error: "Validation Error",
+          fields: { Name: "Field validation for 'Name' failed on the 'required' tag" },
+        })
+      ),
+      { sleep: noSleep }
+    );
+    expect(calls).toBe(1);
+    expect(result).toEqual({ ok: false, reason: "Name: Name is required", status: 422 });
+  });
+
+  test("gives up after maxRetries and returns the last reason", async () => {
+    let calls = 0;
+    const result = await withRetries(
+      async () => {
+        calls++;
+        throw new Error("network down");
+      },
+      { sleep: noSleep, retries: 2 }
+    );
+    expect(calls).toBe(3); // 1 initial + 2 retries
+    expect(result).toEqual({ ok: false, reason: "network down", status: 0 });
+  });
+
+  test("uses the configured backoff schedule", async () => {
+    const delays: number[] = [];
+    await withRetries(
+      async () => {
+        throw new Error("again");
+      },
+      {
+        retries: 3,
+        backoffMs: [10, 20, 30],
+        sleep: async ms => {
+          delays.push(ms);
+        },
+      }
+    );
+    expect(delays).toEqual([10, 20, 30]);
+  });
+
+  test("reuses the last backoff entry when attempts exceed schedule length", async () => {
+    const delays: number[] = [];
+    await withRetries(
+      async () => {
+        throw new Error("again");
+      },
+      {
+        retries: 4,
+        backoffMs: [10],
+        sleep: async ms => {
+          delays.push(ms);
+        },
+      }
+    );
+    expect(delays).toEqual([10, 10, 10, 10]);
+  });
+
+  test("network failure surfaces the thrown Error's message", async () => {
+    const result = await withRetries(
+      async () => {
+        throw new TypeError("Failed to fetch");
+      },
+      { sleep: noSleep, retries: 0 }
+    );
+    expect(result).toEqual({ ok: false, reason: "Failed to fetch", status: 0 });
+  });
+});

--- a/frontend/lib/requests/retry.ts
+++ b/frontend/lib/requests/retry.ts
@@ -1,0 +1,66 @@
+import type { TResponse } from "./requests";
+import { extractErrorMessage } from "./extract-error";
+
+export type RetryResult<T> = { ok: true; data: T } | { ok: false; reason: string; status: number };
+
+export interface RetryOptions {
+  /** Maximum number of retry attempts AFTER the first try (so total attempts = retries + 1). Default: 2. */
+  retries?: number;
+  /** Delays in ms between attempts. The last entry is reused for attempts beyond its length. Default: [1000, 2000, 4000]. */
+  backoffMs?: number[];
+  /** Override the default sleep implementation — primarily for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const DEFAULT_BACKOFF_MS = [1000, 2000, 4000];
+const defaultSleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+// status 0 means the request never reached the server (caught exception);
+// 408/429/5xx are transient by spec. Anything else is treated as final.
+export function isRetryableStatus(status: number): boolean {
+  return status === 0 || status === 408 || status === 429 || status >= 500;
+}
+
+/**
+ * Invoke `call` and retry it on transient failures with exponential-ish backoff.
+ * A `call` that throws is treated as a network failure (status 0, retryable).
+ * Resolves to a tagged-union `RetryResult` so callers don't need to handle exceptions themselves.
+ */
+export async function withRetries<T>(
+  call: () => Promise<TResponse<T>>,
+  options: RetryOptions = {}
+): Promise<RetryResult<T>> {
+  const maxRetries = options.retries ?? 2;
+  const backoff = options.backoffMs ?? DEFAULT_BACKOFF_MS;
+  const sleep = options.sleep ?? defaultSleep;
+
+  let lastReason = "Request failed";
+  let lastStatus = 0;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    if (attempt > 0) {
+      const delay = backoff[attempt - 1] ?? backoff[backoff.length - 1] ?? 4000;
+      await sleep(delay);
+    }
+
+    let resp: TResponse<T> | undefined;
+    let thrown: unknown;
+    try {
+      resp = await call();
+    } catch (e) {
+      thrown = e;
+    }
+
+    if (resp && !resp.error) {
+      return { ok: true, data: resp.data };
+    }
+
+    lastReason = extractErrorMessage(resp, thrown);
+    lastStatus = resp?.status ?? 0;
+
+    const retryable = thrown !== undefined || isRetryableStatus(lastStatus);
+    if (!retryable) break;
+  }
+
+  return { ok: false, reason: lastReason, status: lastStatus };
+}

--- a/frontend/lib/requests/xhr-upload.test.ts
+++ b/frontend/lib/requests/xhr-upload.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { xhrUpload } from "./xhr-upload";
+
+interface Listener {
+  (e: unknown): void;
+}
+
+interface UploadStub {
+  listeners: Record<string, Listener[]>;
+  addEventListener(event: string, fn: Listener): void;
+}
+
+class FakeXHR {
+  upload: UploadStub = {
+    listeners: {},
+    addEventListener(event, fn) {
+      (this.listeners[event] ??= []).push(fn);
+    },
+  };
+  listeners: Record<string, Listener[]> = {};
+  headers: Record<string, string> = {};
+  method = "";
+  url = "";
+  status = 0;
+  statusText = "";
+  responseText = "";
+  private responseHeaders: Record<string, string> = {};
+  sentBody: FormData | null = null;
+
+  open(method: string, url: string) {
+    this.method = method;
+    this.url = url;
+  }
+  setRequestHeader(name: string, value: string) {
+    this.headers[name] = value;
+  }
+  addEventListener(event: string, fn: Listener) {
+    (this.listeners[event] ??= []).push(fn);
+  }
+  getResponseHeader(name: string) {
+    return this.responseHeaders[name] ?? null;
+  }
+  send(body: FormData) {
+    this.sentBody = body;
+  }
+
+  // Test helpers
+  fireUploadProgress(loaded: number, total: number) {
+    for (const fn of this.upload.listeners.progress ?? []) {
+      fn({ lengthComputable: true, loaded, total });
+    }
+  }
+  fireUploadLoad() {
+    for (const fn of this.upload.listeners.load ?? []) fn({});
+  }
+  complete(status: number, statusText: string, body: string, contentType = "application/json") {
+    this.status = status;
+    this.statusText = statusText;
+    this.responseText = body;
+    this.responseHeaders["Content-Type"] = contentType;
+    for (const fn of this.listeners.load ?? []) fn({});
+  }
+  fail(event: "error" | "abort" | "timeout") {
+    for (const fn of this.listeners[event] ?? []) fn({});
+  }
+}
+
+let lastXhr: FakeXHR;
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "XMLHttpRequest",
+    vi.fn(() => {
+      lastXhr = new FakeXHR();
+      return lastXhr;
+    })
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const fd = () => {
+  const f = new FormData();
+  f.append("file", "x");
+  return f;
+};
+
+describe("xhrUpload", () => {
+  test("sets method, url, headers, and sends the FormData body", async () => {
+    const promise = xhrUpload({
+      url: "/api/v1/items/123/attachments",
+      data: fd(),
+      headers: { Authorization: "Bearer abc", "X-Trace": "t1" },
+    });
+    lastXhr.complete(201, "Created", JSON.stringify({ id: "att1" }));
+    const result = await promise;
+
+    expect(lastXhr.method).toBe("POST");
+    expect(lastXhr.url).toBe("/api/v1/items/123/attachments");
+    expect(lastXhr.headers.Authorization).toBe("Bearer abc");
+    expect(lastXhr.headers["X-Trace"]).toBe("t1");
+    expect(lastXhr.sentBody).toBeInstanceOf(FormData);
+    expect(result.status).toBe(201);
+    expect(result.error).toBe(false);
+    expect(result.data).toEqual({ id: "att1" });
+  });
+
+  test("forwards upload progress as fractions and emits 1 on completion", async () => {
+    const fractions: number[] = [];
+    const promise = xhrUpload({
+      url: "/u",
+      data: fd(),
+      onProgress: f => fractions.push(f),
+    });
+    lastXhr.fireUploadProgress(0, 1000);
+    lastXhr.fireUploadProgress(500, 1000);
+    lastXhr.fireUploadProgress(1000, 1000);
+    lastXhr.fireUploadLoad();
+    lastXhr.complete(200, "OK", "{}");
+    await promise;
+
+    expect(fractions).toEqual([0, 0.5, 1, 1]);
+  });
+
+  test("flags 4xx as error and returns parsed JSON body", async () => {
+    const promise = xhrUpload<{ error: string }>({ url: "/u", data: fd() });
+    lastXhr.complete(422, "Unprocessable Entity", JSON.stringify({ error: "Validation Error" }));
+    const result = await promise;
+
+    expect(result.status).toBe(422);
+    expect(result.error).toBe(true);
+    expect(result.data).toEqual({ error: "Validation Error" });
+  });
+
+  test("returns raw text when Content-Type is not JSON", async () => {
+    const promise = xhrUpload<string>({ url: "/u", data: fd() });
+    lastXhr.complete(500, "Internal Server Error", "oops", "text/plain");
+    const result = await promise;
+
+    expect(result.status).toBe(500);
+    expect(result.error).toBe(true);
+    expect(result.data).toBe("oops");
+  });
+
+  test("returns empty object on 204 No Content", async () => {
+    const promise = xhrUpload({ url: "/u", data: fd() });
+    lastXhr.complete(204, "No Content", "");
+    const result = await promise;
+
+    expect(result.status).toBe(204);
+    expect(result.error).toBe(false);
+    expect(result.data).toEqual({});
+  });
+
+  test("rejects on network error", async () => {
+    const promise = xhrUpload({ url: "/u", data: fd() });
+    lastXhr.fail("error");
+    await expect(promise).rejects.toThrow("Network request failed");
+  });
+
+  test("rejects on timeout", async () => {
+    const promise = xhrUpload({ url: "/u", data: fd() });
+    lastXhr.fail("timeout");
+    await expect(promise).rejects.toThrow("timed out");
+  });
+
+  test("ignores non-computable progress events", async () => {
+    const fractions: number[] = [];
+    const promise = xhrUpload({ url: "/u", data: fd(), onProgress: f => fractions.push(f) });
+    // Fire a non-computable progress event by calling the listener directly with lengthComputable=false
+    for (const fn of lastXhr.upload.listeners.progress ?? []) {
+      fn({ lengthComputable: false, loaded: 100, total: 0 });
+    }
+    lastXhr.complete(200, "OK", "{}");
+    await promise;
+
+    // Only the final load event fires a value
+    expect(fractions).toEqual([]);
+  });
+});

--- a/frontend/lib/requests/xhr-upload.ts
+++ b/frontend/lib/requests/xhr-upload.ts
@@ -1,0 +1,72 @@
+import type { TResponse } from "./requests";
+
+export interface XhrUploadArgs {
+  url: string;
+  data: FormData;
+  headers?: Record<string, string>;
+  /** Called with the fraction (0..1) of the body uploaded. May fire many times; the final call is always 1. */
+  onProgress?: (fraction: number) => void;
+}
+
+/**
+ * POST a FormData body with real upload progress via `XMLHttpRequest.upload.onprogress`.
+ * Mirrors the `TResponse<T>` shape returned by `Requests.post` so call sites can swap
+ * fetch for XHR transparently. Resolves on every HTTP outcome (including 4xx/5xx) so
+ * callers can read `status` / `error`; rejects only when the request itself fails to send
+ * (network drop, CORS, abort) — matching `fetch()` semantics.
+ */
+export function xhrUpload<T>(args: XhrUploadArgs): Promise<TResponse<T>> {
+  return new Promise<TResponse<T>>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", args.url, true);
+
+    if (args.headers) {
+      for (const [name, value] of Object.entries(args.headers)) {
+        xhr.setRequestHeader(name, value);
+      }
+    }
+
+    if (args.onProgress) {
+      xhr.upload.addEventListener("progress", e => {
+        if (e.lengthComputable && e.total > 0) {
+          args.onProgress!(Math.min(1, e.loaded / e.total));
+        }
+      });
+      xhr.upload.addEventListener("load", () => args.onProgress!(1));
+    }
+
+    xhr.addEventListener("load", () => {
+      const contentType = xhr.getResponseHeader("Content-Type") ?? "";
+      let data: T = {} as T;
+      if (xhr.status !== 204) {
+        if (contentType.startsWith("application/json")) {
+          try {
+            data = xhr.responseText ? (JSON.parse(xhr.responseText) as T) : ({} as T);
+          } catch {
+            data = {} as T;
+          }
+        } else {
+          data = xhr.responseText as unknown as T;
+        }
+      }
+
+      // Build a Response-shaped object so consumers that read `resp.response.statusText` still work.
+      // We use a real Response when available (browser) — falling back to a duck-typed object in test envs.
+      // Status codes 1xx/204/205/304 must have a null body per the Response spec.
+      const nullBodyStatuses = new Set([101, 204, 205, 304]);
+      const body = nullBodyStatuses.has(xhr.status) ? null : xhr.responseText;
+      const response =
+        typeof Response !== "undefined"
+          ? new Response(body, { status: xhr.status, statusText: xhr.statusText })
+          : ({ statusText: xhr.statusText } as Response);
+
+      resolve({ status: xhr.status, error: xhr.status < 200 || xhr.status >= 300, data, response });
+    });
+
+    xhr.addEventListener("error", () => reject(new TypeError("Network request failed")));
+    xhr.addEventListener("abort", () => reject(new DOMException("Request aborted", "AbortError")));
+    xhr.addEventListener("timeout", () => reject(new TypeError("Request timed out")));
+
+    xhr.send(args.data);
+  });
+}

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -212,7 +212,7 @@
                     "uploading_photos": "{count, plural, =0 {No photos to upload} =1 {Uploading 1 photo…} other {Uploading {count} photos…}}"
                 },
                 "upload_photos": "Upload Photos",
-                "uploading_progress": "Uploading { current } / { total }…",
+                "uploading_progress": "Uploading { current } / { total } ({ percent }%)",
                 "uploaded": "Uploaded Photo"
             },
             "product_import": {

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -618,6 +618,8 @@
             "failed_search_items": "Failed to search items",
             "failed_update_attachment": "Failed to update attachment",
             "failed_upload_attachment": "Failed to upload attachment",
+            "failed_upload_attachment_reason": "Failed to upload attachment: { reason }",
+            "uploading_attachment": "Uploading attachment…",
             "item_deleted": "Item deleted",
             "item_saved": "Item saved",
             "quantity_cannot_negative": "Quantity cannot be negative",

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -205,11 +205,14 @@
                     "rotate_failed": "Failed to rotate image: { error }",
                     "rotate_process_failed": "Failed to process rotated image",
                     "some_photos_failed": "{count, plural, =0 {No photos to upload.} =1 {1 photo failed to upload.} other {Some photos failed to upload.}}",
+                    "unexpected_error": "Something went wrong: { reason }",
                     "upload_failed": "Failed to upload photo: { photoName }",
+                    "upload_failed_reason": "Failed to upload { photoName }: { reason }",
                     "upload_success": "{count, plural, =0 {No photos uploaded.} =1 {Photo uploaded successfully.} other {All photos uploaded successfully.}}",
                     "uploading_photos": "{count, plural, =0 {No photos to upload} =1 {Uploading 1 photo…} other {Uploading {count} photos…}}"
                 },
                 "upload_photos": "Upload Photos",
+                "uploading_progress": "Uploading { current } / { total }…",
                 "uploaded": "Uploaded Photo"
             },
             "product_import": {
@@ -406,6 +409,7 @@
         "confirm": "Confirm",
         "create": "Create",
         "create_and_add": "Create and Add Another",
+        "retry_upload": "Retry photo upload",
         "create_subitem": "Create Subitem",
         "created": "Created",
         "delete": "Delete",

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -197,6 +197,7 @@
                 "toast": {
                     "already_creating": "Already creating an item",
                     "create_failed": "Couldn't create item",
+                    "create_failed_reason": "Couldn't create item: { reason }",
                     "create_success": "Item created",
                     "failed_load_parent": "Failed to load parent item - please select manually",
                     "no_canvas_support": "Your browser doesn't support canvas operations",

--- a/frontend/pages/collection/index/entity-types.vue
+++ b/frontend/pages/collection/index/entity-types.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-  import { useI18n } from "vue-i18n";
   import { toast } from "@/components/ui/sonner";
   import type {
     EntityTypeCreate,
@@ -23,7 +22,6 @@
   import FormCheckbox from "~/components/Form/Checkbox.vue";
   import TemplateSelector from "~/components/Template/Selector.vue";
 
-  const { t } = useI18n();
   const api = useUserApi();
   const confirm = useConfirm();
   const { openDialog, closeDialog } = useDialog();

--- a/frontend/pages/item/[id]/index/edit.vue
+++ b/frontend/pages/item/[id]/index/edit.vue
@@ -5,7 +5,6 @@
   import type { ItemAttachment, EntityFieldData, EntityOut, EntityUpdate } from "~~/lib/api/types/data-contracts";
   import { AttachmentTypes } from "~~/lib/api/types/non-generated";
   import { useTagStore } from "~/stores/tags";
-  import { useLocationStore } from "~~/stores/locations";
   import MdiLoading from "~icons/mdi/loading";
   import MdiDelete from "~icons/mdi/delete";
   import MdiPencil from "~icons/mdi/pencil";
@@ -46,9 +45,6 @@
   const preferences = useViewPreferences();
 
   const itemId = computed<string>(() => route.params.id as string);
-
-  const locationStore = useLocationStore();
-  const locations = computed(() => locationStore.allLocations);
 
   const tagStore = useTagStore();
   const tags = computed(() => tagStore.tags);

--- a/frontend/pages/item/[id]/index/edit.vue
+++ b/frontend/pages/item/[id]/index/edit.vue
@@ -291,6 +291,8 @@
   const attDropZone = ref<HTMLDivElement>();
   const { isOverDropZone: attDropZoneActive } = useDropZone(attDropZone);
 
+  const { uploading: attachmentUploading, uploadFile, uploadExternalLink } = useAttachmentUpload();
+
   const refAttachmentInput = ref<HTMLInputElement>();
 
   function clickUpload() {
@@ -374,21 +376,16 @@
     const attachmentType = zoneEl?.getAttribute("data-link-type") || "attachment";
 
     const title = fallbackLinkTitle(droppedURL);
-    const { data, error } = await api.items.attachments.addExternalLink(
-      itemId.value,
-      "link",
-      droppedURL,
-      title,
-      attachmentType
-    );
+    const result = await uploadExternalLink(itemId.value, "link", droppedURL, title, attachmentType);
 
-    if (error) {
-      toast.error(t("items.toast.failed_upload_attachment"));
+    if (!result.ok) {
+      toast.error(t("items.toast.failed_upload_attachment_reason", { reason: result.reason }));
+      console.error("External link upload failed", result);
       return;
     }
 
     toast.success(t("items.toast.attachment_uploaded"));
-    item.value.attachments = data.attachments;
+    item.value.attachments = result.data.attachments;
   }
 
   async function uploadAttachment(files: File[] | null, type: AttachmentTypes | null) {
@@ -396,18 +393,18 @@
       return;
     }
 
-    const { data, error } = await api.items.attachments.add(itemId.value, files[0], files[0].name, type);
+    const file = files[0];
+    const result = await uploadFile(itemId.value, file, file.name, type);
 
-    if (error) {
-      toast.error(t("items.toast.failed_upload_attachment"));
+    if (!result.ok) {
+      toast.error(t("items.toast.failed_upload_attachment_reason", { reason: result.reason }));
+      console.error("Attachment upload failed", result);
       return;
     }
 
     toast.success(t("items.toast.attachment_uploaded"));
-
     await saveItem(false);
-
-    item.value.attachments = data.attachments;
+    item.value.attachments = result.data.attachments;
   }
 
   const confirm = useConfirm();
@@ -763,7 +760,14 @@
             <p class="text-xs">{{ $t("items.changes_persisted_immediately") }}</p>
           </div>
           <div class="border-t p-4">
-            <div v-if="attDropZoneActive" class="grid grid-cols-4 gap-4">
+            <div
+              v-if="attachmentUploading"
+              class="flex h-24 w-full items-center justify-center gap-2 border-2 border-dashed border-primary"
+            >
+              <MdiLoading class="size-5 animate-spin" />
+              <p>{{ $t("items.toast.uploading_attachment") }}</p>
+            </div>
+            <div v-else-if="attDropZoneActive" class="grid grid-cols-4 gap-4">
               <DropZone data-link-type="photo" @drop="dropPhoto"> {{ $t("items.photos") }} </DropZone>
               <DropZone data-link-type="warranty" @drop="dropWarranty"> {{ $t("items.warranty") }} </DropZone>
               <DropZone data-link-type="manual" @drop="dropManual"> {{ $t("items.manuals") }} </DropZone>

--- a/frontend/pages/item/[id]/index/edit.vue
+++ b/frontend/pages/item/[id]/index/edit.vue
@@ -292,6 +292,8 @@
   const { isOverDropZone: attDropZoneActive } = useDropZone(attDropZone);
 
   const { uploading: attachmentUploading, uploadFile, uploadExternalLink } = useAttachmentUpload();
+  // 0..1 fraction of the current attachment's body uploaded; null when idle.
+  const attachmentProgress = ref<number | null>(null);
 
   const refAttachmentInput = ref<HTMLInputElement>();
 
@@ -394,7 +396,11 @@
     }
 
     const file = files[0];
-    const result = await uploadFile(itemId.value, file, file.name, type);
+    attachmentProgress.value = 0;
+    const result = await uploadFile(itemId.value, file, file.name, type, undefined, f => {
+      attachmentProgress.value = f;
+    });
+    attachmentProgress.value = null;
 
     if (!result.ok) {
       toast.error(t("items.toast.failed_upload_attachment_reason", { reason: result.reason }));
@@ -765,7 +771,10 @@
               class="flex h-24 w-full items-center justify-center gap-2 border-2 border-dashed border-primary"
             >
               <MdiLoading class="size-5 animate-spin" />
-              <p>{{ $t("items.toast.uploading_attachment") }}</p>
+              <p>
+                {{ $t("items.toast.uploading_attachment") }}
+                <span v-if="attachmentProgress !== null">({{ Math.round(attachmentProgress * 100) }}%)</span>
+              </p>
             </div>
             <div v-else-if="attDropZoneActive" class="grid grid-cols-4 gap-4">
               <DropZone data-link-type="photo" @drop="dropPhoto"> {{ $t("items.photos") }} </DropZone>

--- a/frontend/pages/location/[id]/index/edit.vue
+++ b/frontend/pages/location/[id]/index/edit.vue
@@ -5,7 +5,6 @@
   import type { ItemAttachment, EntityFieldData, EntityOut, EntityUpdate } from "~~/lib/api/types/data-contracts";
   import { AttachmentTypes } from "~~/lib/api/types/non-generated";
   import { useTagStore } from "~/stores/tags";
-  import { useLocationStore } from "~~/stores/locations";
   import MdiLoading from "~icons/mdi/loading";
   import MdiDelete from "~icons/mdi/delete";
   import MdiPencil from "~icons/mdi/pencil";
@@ -43,9 +42,6 @@
   const preferences = useViewPreferences();
 
   const locationId = computed<string>(() => route.params.id as string);
-
-  const locationStore = useLocationStore();
-  const locations = computed(() => locationStore.allLocations);
 
   const tagStore = useTagStore();
   const tags = computed(() => tagStore.tags);

--- a/frontend/pages/location/[id]/index/index.vue
+++ b/frontend/pages/location/[id]/index/index.vue
@@ -4,7 +4,6 @@
   import type { AnyDetail, Details } from "~~/components/global/DetailsSection/types";
   import { filterZeroValues } from "~~/components/global/DetailsSection/types";
   import type { ItemAttachment } from "~~/lib/api/types/data-contracts";
-  import { useLocationStore } from "~~/stores/locations";
   import MdiPackageVariant from "~icons/mdi/package-variant";
   import MdiPlus from "~icons/mdi/plus";
   import MdiPencil from "~icons/mdi/pencil";
@@ -49,7 +48,7 @@
 
   const locationId = computed<string>(() => route.params.id as string);
 
-  const { data: location, refresh } = useAsyncData(locationId.value, async () => {
+  const { data: location } = useAsyncData(locationId.value, async () => {
     const { data, error } = await api.items.getLocation(locationId.value);
     if (error) {
       toast.error(t("locations.toast.failed_load_location"));
@@ -85,8 +84,6 @@
   function goToEdit() {
     navigateTo(`/location/${locationId.value}/edit`);
   }
-
-  const locationStore = useLocationStore();
 
   // Photos
   type Photo = {
@@ -229,7 +226,7 @@
           <button
             v-for="(photo, i) in photos"
             :key="i"
-            class="aspect-square group relative overflow-hidden rounded-lg border bg-muted"
+            class="group relative aspect-[1/1] overflow-hidden rounded-lg border bg-muted"
             @click="openImageDialog(photo, location.id)"
           >
             <img

--- a/frontend/pages/reset-password.vue
+++ b/frontend/pages/reset-password.vue
@@ -92,12 +92,7 @@
       </CardContent>
 
       <CardFooter class="flex flex-col gap-2">
-        <Button
-          form="reset-password-form"
-          type="submit"
-          class="w-full"
-          :disabled="loading || !passwordValid || !token"
-        >
+        <Button form="reset-password-form" type="submit" class="w-full" :disabled="loading || !passwordValid || !token">
           {{ $t("index.reset_password_set") }}
         </Button>
         <NuxtLink to="/" class="text-sm text-muted-foreground hover:underline">


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Makes attachment/photo uploads resilient and gives users real feedback during upload. Bundled as one cohesive feature because the parts share a common composable and error path.

- `frontend/lib/requests/extract-error.ts` (+ test): reusable `extractErrorMessage()` that normalizes API/thrown errors into a human-readable string.
- `frontend/lib/requests/retry.ts` (+ test): generic retry helper for upload requests, using `extractErrorMessage()` to report the failure reason.
- `frontend/composables/use-attachment-upload.ts`: shared upload composable with retry, applied to the item edit page (`pages/item/[id]/index/edit.vue`).
- `frontend/components/Item/CreateModal.vue`: retry + per-photo upload progress on item creation.
- `frontend/lib/requests/xhr-upload.ts` (+ test) and `lib/api/classes/items.ts` / `lib/requests/requests.ts`: real upload progress via XHR (replacing simulated progress) so the progress bar reflects actual bytes sent.

## Which issue(s) this PR fixes:

_N/A_

## Special notes for your reviewer:

This combines four internally-staged changes (error extractor → upload composable+retry → create-item retry/progress → real XHR progress) into a single feature PR, since they build on each other. Happy to split into a stack if you'd prefer to review them separately.

## Testing

- Unit tests added: `extract-error.test.ts`, `retry.test.ts`, `xhr-upload.test.ts`.
- Manually: uploaded photos on both create and edit flows; observed per-photo progress and retry-on-failure behavior.
- `eslint` passes clean on the changed files.