### PR TITLE
feat: tokenized item search — all terms must match, quoted phrases supported

### DIFF
--- a/backend/internal/data/repo/repo_entities.go
+++ b/backend/internal/data/repo/repo_entities.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/predicate"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/tag"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/types"
+	"github.com/sysadminsmedia/homebox/backend/pkgs/textutils"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -583,16 +584,23 @@ func (r *EntityRepository) QueryByGroup(ctx context.Context, gid uuid.UUID, q En
 	}
 
 	if q.Search != "" {
-		qb.Where(
-			entity.Or(
-				entity.NameContainsFold(q.Search),
-				entity.DescriptionContainsFold(q.Search),
-				entity.SerialNumberContainsFold(q.Search),
-				entity.ModelNumberContainsFold(q.Search),
-				entity.ManufacturerContainsFold(q.Search),
-				entity.NotesContainsFold(q.Search),
-			),
-		)
+		// Tokenized search: every token (or quoted phrase) must match at
+		// least one of the searchable fields, so "item blue" finds an item
+		// named "Item, long description, blue".
+		tokens := textutils.TokenizeSearchQuery(q.Search)
+		if len(tokens) > 0 {
+			tokenPredicates := lo.Map(tokens, func(tok string, _ int) predicate.Entity {
+				return entity.Or(
+					entity.NameContainsFold(tok),
+					entity.DescriptionContainsFold(tok),
+					entity.SerialNumberContainsFold(tok),
+					entity.ModelNumberContainsFold(tok),
+					entity.ManufacturerContainsFold(tok),
+					entity.NotesContainsFold(tok),
+				)
+			})
+			qb = qb.Where(entity.And(tokenPredicates...))
+		}
 	}
 
 	if !q.AssetID.Nil() {

--- a/backend/internal/data/repo/repo_entities.go
+++ b/backend/internal/data/repo/repo_entities.go
@@ -543,6 +543,29 @@ func entityQuerySpanAttrs(gid uuid.UUID, q EntityQuery) []attribute.KeyValue {
 	}
 }
 
+// entitySearchPredicate builds a predicate for a tokenized search query.
+// Every token (or double-quoted phrase) must match at least one searchable
+// field, so "item blue" finds an item named "Item, long description, blue".
+// Returns nil when the query contains no tokens.
+func entitySearchPredicate(search string) predicate.Entity {
+	tokens := textutils.TokenizeSearchQuery(search)
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	tokenPredicates := lo.Map(tokens, func(tok string, _ int) predicate.Entity {
+		return entity.Or(
+			entity.NameContainsFold(tok),
+			entity.DescriptionContainsFold(tok),
+			entity.SerialNumberContainsFold(tok),
+			entity.ModelNumberContainsFold(tok),
+			entity.ManufacturerContainsFold(tok),
+			entity.NotesContainsFold(tok),
+		)
+	})
+	return entity.And(tokenPredicates...)
+}
+
 // QueryByGroup returns a list of entities that belong to a specific group based on the provided query.
 func (r *EntityRepository) QueryByGroup(ctx context.Context, gid uuid.UUID, q EntityQuery) (PaginationResult[EntitySummary], error) {
 	ctx, span := entityTracer().Start(ctx, "repo.EntityRepository.QueryByGroup",
@@ -583,24 +606,8 @@ func (r *EntityRepository) QueryByGroup(ctx context.Context, gid uuid.UUID, q En
 		qb = qb.Where(entity.Archived(false))
 	}
 
-	if q.Search != "" {
-		// Tokenized search: every token (or quoted phrase) must match at
-		// least one of the searchable fields, so "item blue" finds an item
-		// named "Item, long description, blue".
-		tokens := textutils.TokenizeSearchQuery(q.Search)
-		if len(tokens) > 0 {
-			tokenPredicates := lo.Map(tokens, func(tok string, _ int) predicate.Entity {
-				return entity.Or(
-					entity.NameContainsFold(tok),
-					entity.DescriptionContainsFold(tok),
-					entity.SerialNumberContainsFold(tok),
-					entity.ModelNumberContainsFold(tok),
-					entity.ManufacturerContainsFold(tok),
-					entity.NotesContainsFold(tok),
-				)
-			})
-			qb = qb.Where(entity.And(tokenPredicates...))
-		}
+	if searchPredicate := entitySearchPredicate(q.Search); searchPredicate != nil {
+		qb = qb.Where(searchPredicate)
 	}
 
 	if !q.AssetID.Nil() {

--- a/backend/internal/data/repo/repo_items_search_test.go
+++ b/backend/internal/data/repo/repo_items_search_test.go
@@ -1,9 +1,12 @@
 package repo
 
 import (
+	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/sysadminsmedia/homebox/backend/pkgs/textutils"
 )
 
@@ -211,6 +214,128 @@ func TestNormalizeSearchQueryIntegration(t *testing.T) {
 		t.Run(tc.input, func(t *testing.T) {
 			result := textutils.NormalizeSearchQuery(tc.input)
 			assert.Equal(t, tc.expected, result, "Normalization should work correctly")
+		})
+	}
+}
+
+// useNamedEntity creates an item entity with a fixed name (and optional
+// manufacturer) for search tests, cleaning it up when the test ends.
+func useNamedEntity(t *testing.T, name string, manufacturer string) EntityOut {
+	t.Helper()
+	ctx := context.Background()
+
+	create := entityFactory()
+	create.Name = name
+	create.EntityTypeID = useItemEntityType(t).ID
+
+	e, err := tRepos.Entities.Create(ctx, tGroup.ID, create)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tRepos.Entities.Delete(ctx, e.ID)
+	})
+
+	if manufacturer != "" {
+		update := EntityUpdate{
+			ID:           e.ID,
+			Name:         e.Name,
+			Description:  e.Description,
+			EntityTypeID: create.EntityTypeID,
+			Manufacturer: manufacturer,
+		}
+		_, err = tRepos.Entities.UpdateByGroup(ctx, tGroup.ID, update)
+		require.NoError(t, err)
+	}
+
+	return e
+}
+
+func TestEntityRepository_TokenizedSearch(t *testing.T) {
+	blueItem := useNamedEntity(t, "Item, long description, blue", "")
+	redItem := useNamedEntity(t, "Item, long description, red", "")
+	blueObject := useNamedEntity(t, "Object, long description, blue", "")
+	drill := useNamedEntity(t, "Cordless Drill", "Acme")
+
+	searchIDs := func(t *testing.T, search string) map[uuid.UUID]bool {
+		t.Helper()
+		res, err := tRepos.Entities.QueryByGroup(context.Background(), tGroup.ID, EntityQuery{
+			Page:     -1,
+			PageSize: -1,
+			Search:   search,
+		})
+		require.NoError(t, err)
+
+		ids := make(map[uuid.UUID]bool, len(res.Items))
+		for _, item := range res.Items {
+			ids[item.ID] = true
+		}
+		return ids
+	}
+
+	testCases := []struct {
+		name     string
+		search   string
+		contains []EntityOut
+		excludes []EntityOut
+	}{
+		{
+			name:     "single token matches substring as before",
+			search:   "blue",
+			contains: []EntityOut{blueItem, blueObject},
+			excludes: []EntityOut{redItem, drill},
+		},
+		{
+			name:     "all tokens must match (issue 397 example)",
+			search:   "Item blue",
+			contains: []EntityOut{blueItem},
+			excludes: []EntityOut{redItem, blueObject, drill},
+		},
+		{
+			name:     "token order does not matter",
+			search:   "blue Item",
+			contains: []EntityOut{blueItem},
+			excludes: []EntityOut{redItem, blueObject, drill},
+		},
+		{
+			name:     "tokens are case-insensitive",
+			search:   "ITEM BLUE",
+			contains: []EntityOut{blueItem},
+			excludes: []EntityOut{redItem, blueObject, drill},
+		},
+		{
+			name:     "tokens may match different fields",
+			search:   "drill acme",
+			contains: []EntityOut{drill},
+			excludes: []EntityOut{blueItem, redItem, blueObject},
+		},
+		{
+			name:     "quoted phrase matches exact substring",
+			search:   `"long description, blue"`,
+			contains: []EntityOut{blueItem, blueObject},
+			excludes: []EntityOut{redItem, drill},
+		},
+		{
+			name:     "quoted phrase requires contiguous match",
+			search:   `"blue Item"`,
+			contains: nil,
+			excludes: []EntityOut{blueItem, redItem, blueObject, drill},
+		},
+		{
+			name:     "no tokens match nothing relevant",
+			search:   "doesnotexistanywhere",
+			contains: nil,
+			excludes: []EntityOut{blueItem, redItem, blueObject, drill},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ids := searchIDs(t, tc.search)
+			for _, e := range tc.contains {
+				assert.True(t, ids[e.ID], "expected %q to match search %q", e.Name, tc.search)
+			}
+			for _, e := range tc.excludes {
+				assert.False(t, ids[e.ID], "expected %q to NOT match search %q", e.Name, tc.search)
+			}
 		})
 	}
 }

--- a/backend/pkgs/textutils/tokenize.go
+++ b/backend/pkgs/textutils/tokenize.go
@@ -1,0 +1,44 @@
+package textutils
+
+import (
+	"strings"
+	"unicode"
+)
+
+// TokenizeSearchQuery splits a search query into tokens for multi-term matching.
+// Tokens are separated by Unicode whitespace. A double-quoted segment is kept
+// as a single token with the quotes stripped and inner whitespace preserved,
+// allowing exact-phrase searches. An unbalanced quote consumes the remainder
+// of the query as one token. Empty tokens are dropped.
+//
+// Example:
+// - `item blue` becomes ["item", "blue"]
+// - `red "blue box"` becomes ["red", "blue box"]
+// - `  ` becomes []
+func TokenizeSearchQuery(query string) []string {
+	var tokens []string
+	var current strings.Builder
+	inQuotes := false
+
+	flush := func() {
+		if current.Len() > 0 {
+			tokens = append(tokens, current.String())
+			current.Reset()
+		}
+	}
+
+	for _, r := range query {
+		switch {
+		case r == '"':
+			inQuotes = !inQuotes
+			flush()
+		case unicode.IsSpace(r) && !inQuotes:
+			flush()
+		default:
+			current.WriteRune(r)
+		}
+	}
+	flush()
+
+	return tokens
+}

--- a/backend/pkgs/textutils/tokenize_test.go
+++ b/backend/pkgs/textutils/tokenize_test.go
@@ -1,0 +1,88 @@
+package textutils_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/sysadminsmedia/homebox/backend/pkgs/textutils"
+)
+
+func TestTokenizeSearchQuery(t *testing.T) {
+	testCases := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{
+			name:  "empty string",
+			query: "",
+			want:  nil,
+		},
+		{
+			name:  "whitespace only",
+			query: "   \t\n ",
+			want:  nil,
+		},
+		{
+			name:  "single token",
+			query: "item",
+			want:  []string{"item"},
+		},
+		{
+			name:  "multiple tokens",
+			query: "item blue",
+			want:  []string{"item", "blue"},
+		},
+		{
+			name:  "extra whitespace between tokens",
+			query: "  item \t blue  ",
+			want:  []string{"item", "blue"},
+		},
+		{
+			name:  "quoted phrase",
+			query: `"blue box"`,
+			want:  []string{"blue box"},
+		},
+		{
+			name:  "quoted phrase mixed with tokens",
+			query: `red "blue box" large`,
+			want:  []string{"red", "blue box", "large"},
+		},
+		{
+			name:  "quoted phrase preserves inner punctuation",
+			query: `"long description, blue"`,
+			want:  []string{"long description, blue"},
+		},
+		{
+			name:  "unbalanced quote consumes remainder",
+			query: `red "blue box`,
+			want:  []string{"red", "blue box"},
+		},
+		{
+			name:  "empty quotes are dropped",
+			query: `red "" blue`,
+			want:  []string{"red", "blue"},
+		},
+		{
+			name:  "adjacent quoted phrases",
+			query: `"red box""blue box"`,
+			want:  []string{"red box", "blue box"},
+		},
+		{
+			name:  "unicode tokens",
+			query: "electrónica café",
+			want:  []string{"electrónica", "café"},
+		},
+		{
+			name:  "unicode whitespace separator",
+			query: "item\u00a0blue",
+			want:  []string{"item", "blue"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, textutils.TokenizeSearchQuery(tc.query))
+		})
+	}
+}

--- a/docs/src/content/docs/en/user-guide/tips-tricks.mdx
+++ b/docs/src/content/docs/en/user-guide/tips-tricks.mdx
@@ -20,6 +20,16 @@ Custom fields are appended to the main details section of your item.
 > automatically converted to a clickable link in the UI. Optionally, you can also use Markdown syntax to add a custom
 > text to the button. `[Google](https://google.com)`
 
+## Search Syntax
+
+The search bar splits your input into individual terms, and every term must match somewhere in the item (name,
+description, serial number, model number, manufacturer, or notes). Each additional term narrows the results: searching
+`drill cordless` only returns items that match both `drill` and `cordless`, even if the words appear in different
+fields or in a different order.
+
+To match an exact phrase, wrap it in double quotes: `"blue storage box"` only matches items containing that exact
+text. Quoted phrases and plain terms can be combined, e.g. `drill "18 V"`.
+
 ## Managing Asset IDs
 
 Homebox provides the option to auto-set asset IDs; this is the default behavior. These can be used for tracking assets


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Item search currently treats the whole query as one literal substring, so
`blue chair` only matches items containing that exact phrase. This PR tokenizes
the query and requires **every** token to match at least one of the six searched
fields (AND across tokens, OR across fields), with double-quoted phrases kept as
single tokens.

- `backend/pkgs/textutils/tokenize.go` (new): `TokenizeSearchQuery()` splits on
  Unicode whitespace; double-quoted segments become single tokens (quotes
  stripped, inner whitespace preserved); an unbalanced quote degrades gracefully
  to a plain token. 13 table-driven unit tests in `tokenize_test.go`.
- `backend/internal/data/repo/repo_entities.go`: `QueryByGroup` now builds its
  search predicate via a new `entitySearchPredicate()` helper — AND over
  per-token six-field `ContainsFold` ORs (previously a single six-field OR over
  the raw query). Extracted as a helper to stay under the gocyclo limit.
- `backend/internal/data/repo/repo_items_search_test.go`: 8 DB-backed
  integration subtests (`TestEntityRepository_TokenizedSearch`).
- `docs/src/content/docs/en/user-guide/tips-tricks.mdx`: new "Search Syntax"
  section documenting the behavior.

Design decisions: AND semantics across tokens; tokens + quoted phrases only (no
boolean operators in this iteration). The `#<assetID>` search shortcut is
intentionally untouched.

## Which issue(s) this PR fixes:

Implements the tokenized-search part of #438 (originally requested in #397).

## Special notes for your reviewer:

`QueryByGroup` sits exactly at the gocyclo limit, which is why the predicate
lives in a separate helper. No API surface change, so swagger/typescript-types
were not regenerated.

## Testing

- `go test ./pkgs/textutils/... ./internal/data/repo/...` — all pass (unit +
  DB-backed integration tests).
- `golangci-lint run ./...` — no issues in changed files (one pre-existing
  staticcheck hit in `app/api/main.go` unrelated to this PR).
- Full build (frontend embed + backend binary) and manual smoke run on a fresh
  SQLite DB.
