### PR TITLE
linting improvements and apply formatting fixes

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+6c63edb61f434e1641e0bd4986f7d5add7bfbae3 # lint: apply linter fixes (swag fmt + golangci-lint sweep)

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -72,6 +72,7 @@ issues:
 formatters:
   enable:
     - gofmt
+    - swaggo
   exclusions:
     generated: lax
     paths:

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - errcheck
     - errorlint
     - exhaustive
+    - forbidigo
     - gochecknoinits
     - goconst
     - gocritic
@@ -41,6 +42,11 @@ linters:
                 details.
     exhaustive:
       default-signifies-exhaustive: true
+    forbidigo:
+      forbid:
+        - pattern: ^log\.Fatal.*$
+          msg: Do not use log.Fatal - return errors instead
+      analyze-types: true
     goconst:
       min-len: 5
       min-occurrences: 5
@@ -67,6 +73,10 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - path: '(.+)_test\.go'
+        linters:
+          - forbidigo
 issues:
   fix: false
 formatters:

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -68,7 +68,7 @@ linters:
       - builtin$
       - examples$
 issues:
-  fix: true
+  fix: false
 formatters:
   enable:
     - gofmt

--- a/backend/app/api/handlers/v1/v1_ctrl_actions.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_actions.go
@@ -110,8 +110,8 @@ type WipeInventoryOptions struct {
 //	@Description	Deletes all items in the inventory
 //	@Tags			Actions
 //	@Produce		json
-//	@Param			options	body	WipeInventoryOptions	false	"Wipe options"
-//	@Success		200	{object}	ActionAmountResult
+//	@Param			options	body		WipeInventoryOptions	false	"Wipe options"
+//	@Success		200		{object}	ActionAmountResult
 //	@Router			/v1/actions/wipe-inventory [Post]
 //	@Security		Bearer
 func (ctrl *V1Controller) HandleWipeInventory() errchain.HandlerFunc {

--- a/backend/app/api/handlers/v1/v1_ctrl_auth.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_auth.go
@@ -175,11 +175,11 @@ const resetPasswordMinLength = 6
 //	@Tags			Authentication
 //	@Accept			application/json
 //	@Produce		json
-//	@Param			payload	body		ForgotPasswordRequest	true	"Email"
+//	@Param			payload	body	ForgotPasswordRequest	true	"Email"
 //	@Success		204
-//	@Failure		400		{string}	string					"missing or invalid request body, or empty email field"
-//	@Failure		403		{string}	string					"demo mode is enabled or local login is disabled"
-//	@Failure		500		{string}	string					"internal error while processing the request"
+//	@Failure		400	{string}	string	"missing or invalid request body, or empty email field"
+//	@Failure		403	{string}	string	"demo mode is enabled or local login is disabled"
+//	@Failure		500	{string}	string	"internal error while processing the request"
 //	@Router			/v1/users/forgot-password [POST]
 func (ctrl *V1Controller) HandleForgotPassword() errchain.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) error {
@@ -253,11 +253,11 @@ func (ctrl *V1Controller) HandleForgotPassword() errchain.HandlerFunc {
 //	@Tags			Authentication
 //	@Accept			application/json
 //	@Produce		json
-//	@Param			payload	body		ResetPasswordRequest	true	"Token + new password"
+//	@Param			payload	body	ResetPasswordRequest	true	"Token + new password"
 //	@Success		204
-//	@Failure		400		{string}	string					"invalid request body, password shorter than the minimum length, or token that is invalid / expired / already used"
-//	@Failure		403		{string}	string					"demo mode is enabled or local login is disabled"
-//	@Failure		500		{string}	string					"internal error while processing the request"
+//	@Failure		400	{string}	string	"invalid request body, password shorter than the minimum length, or token that is invalid / expired / already used"
+//	@Failure		403	{string}	string	"demo mode is enabled or local login is disabled"
+//	@Failure		500	{string}	string	"internal error while processing the request"
 //	@Router			/v1/users/reset-password [POST]
 func (ctrl *V1Controller) HandleResetPassword() errchain.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) error {

--- a/backend/app/api/handlers/v1/v1_ctrl_entities.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_entities.go
@@ -407,7 +407,7 @@ func (ctrl *V1Controller) HandleEntityDuplicate() errchain.HandlerFunc {
 //	@Summary	Get All Custom Field Names
 //	@Tags		Entities
 //	@Produce	json
-//	@Success	200	{array}		string
+//	@Success	200	{array}	string
 //	@Router		/v1/entities/fields [GET]
 //	@Security	Bearer
 func (ctrl *V1Controller) HandleGetAllCustomFieldNames() errchain.HandlerFunc {
@@ -434,8 +434,8 @@ func (ctrl *V1Controller) HandleGetAllCustomFieldNames() errchain.HandlerFunc {
 //	@Summary	Get All Custom Field Values
 //	@Tags		Entities
 //	@Produce	json
-//	@Param		field	query		string	true	"Field name"
-//	@Success	200		{array}		string
+//	@Param		field	query	string	true	"Field name"
+//	@Success	200		{array}	string
 //	@Router		/v1/entities/fields/values [GET]
 //	@Security	Bearer
 func (ctrl *V1Controller) HandleGetAllCustomFieldValues() errchain.HandlerFunc {

--- a/backend/app/api/handlers/v1/v1_ctrl_entities_attachments.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_entities_attachments.go
@@ -151,9 +151,9 @@ func (ctrl *V1Controller) HandleEntityAttachmentCreate() errchain.HandlerFunc {
 //	@Summary	Get Entity Attachment
 //	@Tags		Entities Attachments
 //	@Produce	application/octet-stream
-//	@Param		id				path		string	true	"Entity ID"
-//	@Param		attachment_id	path		string	true	"Attachment ID"
-//	@Success	200				{file}		file
+//	@Param		id				path	string	true	"Entity ID"
+//	@Param		attachment_id	path	string	true	"Attachment ID"
+//	@Success	200				{file}	file
 //	@Router		/v1/entities/{id}/attachments/{attachment_id} [GET]
 //	@Security	Bearer
 func (ctrl *V1Controller) HandleEntityAttachmentGet() errchain.HandlerFunc {

--- a/backend/app/api/handlers/v1/v1_ctrl_entities_attachments_external.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_entities_attachments_external.go
@@ -62,18 +62,18 @@ func sanitizeExternalURLTitle(raw string) string {
 
 // HandleEntityAttachmentExternalCreate godoc
 //
-//	@Summary	Create External Link Attachment
+//	@Summary		Create External Link Attachment
 //	@Description	Links an entity to a document or URL in an external system without copying
 //				the file into Homebox. The source is identified by source_type.
-//	@Tags		Entities Attachments
-//	@Accept		json
-//	@Produce	json
-//	@Param		id		path		string					true	"Entity ID"
-//	@Param		payload	body		externalAttachmentRequest	true	"External document reference"
-//	@Success	201		{object}	repo.EntityOut
-//	@Failure	400		{object}	validate.ErrorResponse
-//	@Router		/v1/entities/{id}/attachments/external [POST]
-//	@Security	Bearer
+//	@Tags			Entities Attachments
+//	@Accept			json
+//	@Produce		json
+//	@Param			id		path		string						true	"Entity ID"
+//	@Param			payload	body		externalAttachmentRequest	true	"External document reference"
+//	@Success		201		{object}	repo.EntityOut
+//	@Failure		400		{object}	validate.ErrorResponse
+//	@Router			/v1/entities/{id}/attachments/external [POST]
+//	@Security		Bearer
 func (ctrl *V1Controller) HandleEntityAttachmentExternalCreate() errchain.HandlerFunc {
 	fn := func(r *http.Request, id uuid.UUID, body externalAttachmentRequest) (repo.EntityOut, error) {
 		_, span := startEntityCtrlSpan(r.Context(), "controller.V1.HandleEntityAttachmentExternalCreate")

--- a/backend/app/api/handlers/v1/v1_ctrl_entity_templates.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_entity_templates.go
@@ -16,7 +16,7 @@ import (
 //	@Summary	Get All Entity Templates
 //	@Tags		Entity Templates
 //	@Produce	json
-//	@Success	200	{array}		repo.EntityTemplateSummary
+//	@Success	200	{array}	repo.EntityTemplateSummary
 //	@Router		/v1/templates [GET]
 //	@Security	Bearer
 func (ctrl *V1Controller) HandleEntityTemplatesGetAll() errchain.HandlerFunc {
@@ -104,9 +104,9 @@ func (ctrl *V1Controller) HandleEntityTemplatesDelete() errchain.HandlerFunc {
 }
 
 type EntityTemplateCreateItemRequest struct {
-	Name        string    `json:"name"         validate:"required,min=1,max=255"`
-	Description string    `json:"description"  validate:"max=1000"`
-	ParentID    uuid.UUID `json:"parentId"     validate:"required"`
+	Name        string    `json:"name"        validate:"required,min=1,max=255"`
+	Description string    `json:"description" validate:"max=1000"`
+	ParentID    uuid.UUID `json:"parentId"    validate:"required"`
 	// EntityTypeID is the entity type selected by the user. When set it takes
 	// precedence; when empty the repository falls back to the group's default.
 	EntityTypeID uuid.UUID   `json:"entityTypeId"`
@@ -119,8 +119,8 @@ type EntityTemplateCreateItemRequest struct {
 //	@Summary	Create Entity from Template
 //	@Tags		Entity Templates
 //	@Produce	json
-//	@Param		id		path		string								true	"Template ID"
-//	@Param		payload	body		EntityTemplateCreateItemRequest		true	"Entity Data"
+//	@Param		id		path		string							true	"Template ID"
+//	@Param		payload	body		EntityTemplateCreateItemRequest	true	"Entity Data"
 //	@Success	201		{object}	repo.EntityOut
 //	@Router		/v1/templates/{id}/create-item [POST]
 //	@Security	Bearer

--- a/backend/app/api/handlers/v1/v1_ctrl_exports.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_exports.go
@@ -66,13 +66,13 @@ func (ctrl *V1Controller) HandleExportsCreate() errchain.HandlerFunc {
 
 // HandleExportGet godoc
 //
-//	@Summary		Get an Export
-//	@Tags			Group
-//	@Produce		json
-//	@Param			id	path	string	true	"Export ID"
-//	@Success		200	{object}	repo.ExportOut
-//	@Router			/v1/group/exports/{id} [GET]
-//	@Security		Bearer
+//	@Summary	Get an Export
+//	@Tags		Group
+//	@Produce	json
+//	@Param		id	path		string	true	"Export ID"
+//	@Success	200	{object}	repo.ExportOut
+//	@Router		/v1/group/exports/{id} [GET]
+//	@Security	Bearer
 func (ctrl *V1Controller) HandleExportGet() errchain.HandlerFunc {
 	fn := func(r *http.Request, id uuid.UUID) (repo.ExportOut, error) {
 		ctx := services.NewContext(r.Context())
@@ -84,13 +84,13 @@ func (ctrl *V1Controller) HandleExportGet() errchain.HandlerFunc {
 
 // HandleExportDownload godoc
 //
-//	@Summary		Download an Export Artifact
-//	@Tags			Group
-//	@Produce		application/zip
-//	@Param			id	path		string	true	"Export ID"
-//	@Success		200	{file}		file
-//	@Router			/v1/group/exports/{id}/download [GET]
-//	@Security		Bearer
+//	@Summary	Download an Export Artifact
+//	@Tags		Group
+//	@Produce	application/zip
+//	@Param		id	path	string	true	"Export ID"
+//	@Success	200	{file}	file
+//	@Router		/v1/group/exports/{id}/download [GET]
+//	@Security	Bearer
 func (ctrl *V1Controller) HandleExportDownload() errchain.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		ctx := services.NewContext(r.Context())
@@ -195,7 +195,7 @@ func (ctrl *V1Controller) HandleExportDelete() errchain.HandlerFunc {
 //	@Accept			multipart/form-data
 //	@Produce		json
 //	@Param			file	formData	file	true	"Export zip"
-//	@Success		202	{object}	repo.ExportOut
+//	@Success		202		{object}	repo.ExportOut
 //	@Router			/v1/group/import [POST]
 //	@Security		Bearer
 func (ctrl *V1Controller) HandleCollectionImport() errchain.HandlerFunc {

--- a/backend/app/api/handlers/v1/v1_ctrl_group.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_group.go
@@ -232,7 +232,7 @@ func (ctrl *V1Controller) HandleGroupMembersGetAll() errchain.HandlerFunc {
 //	@Summary	Remove User from Group
 //	@Tags		Group
 //	@Produce	json
-//	@Param		user_id	path		string	true	"User ID"
+//	@Param		user_id	path	string	true	"User ID"
 //	@Success	204
 //	@Router		/v1/groups/members/{user_id} [Delete]
 //	@Security	Bearer
@@ -286,7 +286,7 @@ func (ctrl *V1Controller) HandleGroupInvitationsDelete() errchain.HandlerFunc {
 //	@ID			groupInvitationAccept
 //	@Tags		Group
 //	@Produce	json
-//	@Param		id	path	string	true	"Invitation Token"
+//	@Param		id	path		string	true	"Invitation Token"
 //	@Success	200	{object}	GroupAcceptInvitationResponse
 //	@Router		/v1/groups/invitations/{id} [Post]
 //	@Security	Bearer

--- a/backend/app/api/handlers/v1/v1_ctrl_tags.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_tags.go
@@ -15,7 +15,7 @@ import (
 //	@Summary	Get All Tags
 //	@Tags		Tags
 //	@Produce	json
-//	@Success	200	{array}		repo.TagSummary
+//	@Success	200	{array}	repo.TagSummary
 //	@Router		/v1/tags [GET]
 //	@Security	Bearer
 func (ctrl *V1Controller) HandleTagsGetAll() errchain.HandlerFunc {

--- a/backend/app/api/handlers/v1/v1_ctrl_user.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_user.go
@@ -18,13 +18,13 @@ import (
 
 // HandleUserRegistration godoc
 //
-//		@Summary	Register New User
-//		@Tags		User
-//		@Produce	json
-//		@Param		payload	body	services.UserRegistration	true	"User Data"
-//		@Success	204
-//	 @Failure    403 {string} string "Local login is not enabled"
-//		@Router		/v1/users/register [Post]
+//	@Summary	Register New User
+//	@Tags		User
+//	@Produce	json
+//	@Param		payload	body	services.UserRegistration	true	"User Data"
+//	@Success	204
+//	@Failure	403	{string}	string	"Local login is not enabled"
+//	@Router		/v1/users/register [Post]
 func (ctrl *V1Controller) HandleUserRegistration() errchain.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) error {
 		spanCtx, span := startEntityCtrlSpan(r.Context(), "controller.V1.HandleUserRegistration")

--- a/backend/internal/data/migrations/postgres/20250112202302_sync_children.go
+++ b/backend/internal/data/migrations/postgres/20250112202302_sync_children.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
 	"github.com/pressly/goose/v3"
 )
 

--- a/backend/internal/data/migrations/sqlite3/20241226183416_sync_children.go
+++ b/backend/internal/data/migrations/sqlite3/20241226183416_sync_children.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
 	"github.com/pressly/goose/v3"
 )
 

--- a/backend/internal/sys/analytics/analytics.go
+++ b/backend/internal/sys/analytics/analytics.go
@@ -4,9 +4,10 @@ package analytics
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/shirou/gopsutil/v4/host"
 	"net/http"
 	"time"
+
+	"github.com/shirou/gopsutil/v4/host"
 
 	"github.com/rs/zerolog/log"
 )


### PR DESCRIPTION
## What type of PR is this?

cleanup

## What this PR does / why we need it:

This supersedes #1194, which was closed without comment. The branch has been rebased onto the current main and the linter sweep regenerated against it.

- Added the swag formatter to golangci-lint so API doc comments are formatted consistently.
- Disabled autofixing which was giving the false impression everything was fine as it was fixing issues before reporting them
- Add forbidigo linter to prevent log.Fatal usage (see #953)
- Ran golangci-lint across the codebase.

I've also thrown in a git-blame-ignore-revs which can be enabled with
`git config blame.ignoreRevsFile .git-blame-ignore-revs`
GitHub's web blame view also honors this file automatically once merged.

## Which issue(s) this PR fixes:

None, this was done under my own initiative

## Testing

- task go:lint - 0 issues
- task go:test - pass
- Verified git blame with .git-blame-ignore-revs correctly attributes formatted lines to their original authors.
