### PR TITLE
feat: runtime-configurable sub-path serving

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,8 +90,10 @@ EXPOSE 7745
 WORKDIR /app
 
 # Healthcheck configuration
+# Shell logic normalizes HBOX_WEB_APP_BASE to always have leading+trailing
+# slash (e.g. "homebox" -> "/homebox/") to match Go's normalizePath().
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD [ "wget", "--no-verbose", "--tries=1", "-O", "-", "http://localhost:7745/api/v1/status" ]
+    CMD sh -c 'B="${HBOX_WEB_APP_BASE:-/}"; B="/${B#/}"; B="${B%/}/"; wget --no-verbose --tries=1 -O - "http://localhost:7745${B}api/v1/status"'
 
 # Persist volume
 VOLUME [ "/data" ]

--- a/backend/app/api/handlers/v1/controller.go
+++ b/backend/app/api/handlers/v1/controller.go
@@ -147,7 +147,7 @@ func NewControllerV1(svc *services.AllServices, repos *repo.AllRepos, bus *event
 
 func (ctrl *V1Controller) initOIDCProvider() {
 	if ctrl.config.OIDC.Enabled {
-		oidcProvider, err := providers.NewOIDCProvider(ctrl.svc.User, &ctrl.config.OIDC, &ctrl.config.Options, ctrl.cookieSecure)
+		oidcProvider, err := providers.NewOIDCProvider(ctrl.svc.User, &ctrl.config.OIDC, &ctrl.config.Options, &ctrl.config.Web, ctrl.cookieSecure)
 		if err != nil {
 			log.Err(err).Msg("failed to initialize OIDC provider at startup")
 		} else {

--- a/backend/app/api/handlers/v1/v1_ctrl_auth.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_auth.go
@@ -412,7 +412,7 @@ func (ctrl *V1Controller) setCookies(w http.ResponseWriter, domain, token string
 		Domain:   domain,
 		Secure:   ctrl.cookieSecure,
 		HttpOnly: true,
-		Path:     "/",
+		Path:     ctrl.config.Web.AppBase,
 		SameSite: http.SameSiteLaxMode,
 	})
 
@@ -424,7 +424,7 @@ func (ctrl *V1Controller) setCookies(w http.ResponseWriter, domain, token string
 		Domain:   domain,
 		Secure:   ctrl.cookieSecure,
 		HttpOnly: true,
-		Path:     "/",
+		Path:     ctrl.config.Web.AppBase,
 		SameSite: http.SameSiteLaxMode,
 	})
 
@@ -436,7 +436,7 @@ func (ctrl *V1Controller) setCookies(w http.ResponseWriter, domain, token string
 		Domain:   domain,
 		Secure:   ctrl.cookieSecure,
 		HttpOnly: false,
-		Path:     "/",
+		Path:     ctrl.config.Web.AppBase,
 		SameSite: http.SameSiteLaxMode,
 	})
 
@@ -449,7 +449,7 @@ func (ctrl *V1Controller) setCookies(w http.ResponseWriter, domain, token string
 			Domain:   domain,
 			Secure:   ctrl.cookieSecure,
 			HttpOnly: false,
-			Path:     "/",
+			Path:     ctrl.config.Web.AppBase,
 			SameSite: http.SameSiteLaxMode,
 		})
 	}
@@ -463,7 +463,7 @@ func (ctrl *V1Controller) unsetCookies(w http.ResponseWriter, domain string) {
 		Domain:   domain,
 		Secure:   ctrl.cookieSecure,
 		HttpOnly: true,
-		Path:     "/",
+		Path:     ctrl.config.Web.AppBase,
 		SameSite: http.SameSiteLaxMode,
 	})
 
@@ -474,7 +474,7 @@ func (ctrl *V1Controller) unsetCookies(w http.ResponseWriter, domain string) {
 		Domain:   domain,
 		Secure:   ctrl.cookieSecure,
 		HttpOnly: true,
-		Path:     "/",
+		Path:     ctrl.config.Web.AppBase,
 		SameSite: http.SameSiteLaxMode,
 	})
 
@@ -486,7 +486,7 @@ func (ctrl *V1Controller) unsetCookies(w http.ResponseWriter, domain string) {
 		Domain:   domain,
 		Secure:   ctrl.cookieSecure,
 		HttpOnly: false,
-		Path:     "/",
+		Path:     ctrl.config.Web.AppBase,
 		SameSite: http.SameSiteLaxMode,
 	})
 
@@ -498,7 +498,7 @@ func (ctrl *V1Controller) unsetCookies(w http.ResponseWriter, domain string) {
 		Domain:   domain,
 		Secure:   ctrl.cookieSecure,
 		HttpOnly: false,
-		Path:     "/",
+		Path:     ctrl.config.Web.AppBase,
 		SameSite: http.SameSiteLaxMode,
 	})
 }
@@ -569,7 +569,7 @@ func (ctrl *V1Controller) HandleOIDCCallback() errchain.HandlerFunc {
 			recordCtrlSpanError(span, err)
 			span.SetAttributes(attribute.String("oidc.outcome", "callback_failed"))
 			log.Err(err).Msg("OIDC callback failed")
-			http.Redirect(w, r, "/?oidc_error=oidc_auth_failed", http.StatusFound)
+			http.Redirect(w, r, ctrl.config.Web.AppBase+"?oidc_error=oidc_auth_failed", http.StatusFound)
 			return nil
 		}
 
@@ -578,7 +578,7 @@ func (ctrl *V1Controller) HandleOIDCCallback() errchain.HandlerFunc {
 			attribute.String("session.expires_at", newToken.ExpiresAt.Format(time.RFC3339)),
 		)
 		ctrl.setCookies(w, noPort(r.Host), newToken.Raw, newToken.ExpiresAt, true, newToken.AttachmentToken)
-		http.Redirect(w, r, "/home", http.StatusFound)
+		http.Redirect(w, r, ctrl.config.Web.AppBase+"home", http.StatusFound)
 		return nil
 	}
 }

--- a/backend/app/api/providers/oidc.go
+++ b/backend/app/api/providers/oidc.go
@@ -24,6 +24,7 @@ type OIDCProvider struct {
 	service      *services.UserService
 	config       *config.OIDCConf
 	options      *config.Options
+	webConfig    *config.WebConfig
 	cookieSecure bool
 	provider     *oidc.Provider
 	verifier     *oidc.IDTokenVerifier
@@ -39,7 +40,7 @@ type OIDCClaims struct {
 	EmailVerified *bool
 }
 
-func NewOIDCProvider(service *services.UserService, config *config.OIDCConf, options *config.Options, cookieSecure bool) (*OIDCProvider, error) {
+func NewOIDCProvider(service *services.UserService, config *config.OIDCConf, options *config.Options, webConfig *config.WebConfig, cookieSecure bool) (*OIDCProvider, error) {
 	if !config.Enabled {
 		return nil, fmt.Errorf("OIDC is not enabled")
 	}
@@ -106,6 +107,7 @@ func NewOIDCProvider(service *services.UserService, config *config.OIDCConf, opt
 		service:      service,
 		config:       config,
 		options:      options,
+		webConfig:    webConfig,
 		cookieSecure: cookieSecure,
 		provider:     provider,
 		verifier:     verifier,
@@ -361,8 +363,10 @@ func (p *OIDCProvider) GetAuthURL(baseURL, state, nonce, pkceVerifier string) st
 }
 
 func (p *OIDCProvider) getOAuth2Config(baseURL string) oauth2.Config {
-	// Construct full redirect URL with dedicated callback endpoint
-	redirectURL, err := url.JoinPath(baseURL, "/api/v1/users/login/oidc/callback")
+	// Construct full redirect URL with dedicated callback endpoint.
+	// Note: baseURL from getBaseURL() is scheme://host only (no path),
+	// so AppBase must be added separately to form the correct callback path.
+	redirectURL, err := url.JoinPath(baseURL, p.webConfig.AppBase, "api/v1/users/login/oidc/callback")
 	if err != nil {
 		log.Err(err).Msg("failed to construct redirect URL")
 		return oauth2.Config{}
@@ -416,7 +420,7 @@ func (p *OIDCProvider) initiateOIDCFlow(w http.ResponseWriter, r *http.Request) 
 		Domain:   domain,
 		Secure:   p.isSecure(r),
 		HttpOnly: true,
-		Path:     "/",
+		Path:     p.webConfig.AppBase,
 		SameSite: http.SameSiteLaxMode,
 	})
 
@@ -428,7 +432,7 @@ func (p *OIDCProvider) initiateOIDCFlow(w http.ResponseWriter, r *http.Request) 
 		Domain:   domain,
 		Secure:   p.isSecure(r),
 		HttpOnly: true,
-		Path:     "/",
+		Path:     p.webConfig.AppBase,
 		SameSite: http.SameSiteLaxMode,
 	})
 
@@ -440,7 +444,7 @@ func (p *OIDCProvider) initiateOIDCFlow(w http.ResponseWriter, r *http.Request) 
 		Domain:   domain,
 		Secure:   p.isSecure(r),
 		HttpOnly: true,
-		Path:     "/",
+		Path:     p.webConfig.AppBase,
 		SameSite: http.SameSiteLaxMode,
 	})
 
@@ -470,7 +474,7 @@ func (p *OIDCProvider) handleCallback(w http.ResponseWriter, r *http.Request) (s
 			MaxAge:   -1,
 			Secure:   p.isSecure(r),
 			HttpOnly: true,
-			Path:     "/",
+			Path:     p.webConfig.AppBase,
 			SameSite: http.SameSiteLaxMode,
 		})
 		http.SetCookie(w, &http.Cookie{
@@ -481,7 +485,7 @@ func (p *OIDCProvider) handleCallback(w http.ResponseWriter, r *http.Request) (s
 			MaxAge:   -1,
 			Secure:   p.isSecure(r),
 			HttpOnly: true,
-			Path:     "/",
+			Path:     p.webConfig.AppBase,
 			SameSite: http.SameSiteLaxMode,
 		})
 		http.SetCookie(w, &http.Cookie{
@@ -492,7 +496,7 @@ func (p *OIDCProvider) handleCallback(w http.ResponseWriter, r *http.Request) (s
 			MaxAge:   -1,
 			Secure:   p.isSecure(r),
 			HttpOnly: true,
-			Path:     "/",
+			Path:     p.webConfig.AppBase,
 			SameSite: http.SameSiteLaxMode,
 		})
 	}

--- a/backend/app/api/routes.go
+++ b/backend/app/api/routes.go
@@ -4,14 +4,17 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"mime"
 	"net/http"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/hay-kot/httpkit/errchain"
+	"github.com/rs/zerolog/log"
 	httpSwagger "github.com/swaggo/http-swagger/v2" // http-swagger middleware
 	"github.com/sysadminsmedia/homebox/backend/app/api/handlers/debughandlers"
 	v1 "github.com/sysadminsmedia/homebox/backend/app/api/handlers/v1"
@@ -41,9 +44,11 @@ func (a *app) debugRouter() *http.ServeMux {
 func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllRepos) {
 	registerMimes()
 
+	base := a.conf.Web.AppBase
+
 	// Serve doc.json dynamically so the Swagger UI "Base URL" reflects the
 	// actual host of the user's instance rather than a hardcoded value.
-	r.Get("/swagger/doc.json", func(w http.ResponseWriter, r *http.Request) {
+	r.Get(base+"swagger/doc.json", func(w http.ResponseWriter, r *http.Request) {
 		host := r.Host
 		if fwdHost := r.Header.Get("X-Forwarded-Host"); fwdHost != "" {
 			host = fwdHost
@@ -55,8 +60,8 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 		_, _ = w.Write([]byte(doc))
 	})
 
-	r.Get("/swagger/*", httpSwagger.Handler(
-		httpSwagger.URL("/swagger/doc.json"),
+	r.Get(base+"swagger/*", httpSwagger.Handler(
+		httpSwagger.URL(base+"swagger/doc.json"),
 	))
 
 	// =========================================================================
@@ -75,7 +80,7 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 		v1.WithURL(fmt.Sprintf("%s:%s", a.conf.Web.Host, a.conf.Web.Port)),
 	)
 
-	r.Route(prefix+"/v1", func(r chi.Router) {
+	r.Route(strings.TrimRight(base, "/") + prefix + "/v1", func(r chi.Router) {
 		r.Get("/status", chain.ToHandlerFunc(v1Ctrl.HandleBase(func() bool { return true }, v1.Build{
 			Version:   version,
 			Commit:    commit,
@@ -253,7 +258,7 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 		r.NotFound(http.NotFound)
 	})
 
-	r.NotFound(chain.ToHandlerFunc(notFoundHandler()))
+	r.NotFound(chain.ToHandlerFunc(notFoundHandler(base)))
 }
 
 func registerMimes() {
@@ -270,7 +275,7 @@ func registerMimes() {
 
 // notFoundHandler perform the main logic around handling the internal SPA embed and ensuring that
 // the client side routing is handled correctly.
-func notFoundHandler() errchain.HandlerFunc {
+func notFoundHandler(base string) errchain.HandlerFunc {
 	tryRead := func(fs embed.FS, prefix, requestedPath string, w http.ResponseWriter) error {
 		f, err := fs.Open(path.Join(prefix, requestedPath))
 		if err != nil {
@@ -289,15 +294,64 @@ func notFoundHandler() errchain.HandlerFunc {
 		return err
 	}
 
-	return func(w http.ResponseWriter, r *http.Request) error {
-		err := tryRead(public, "static/public", r.URL.Path, w)
-		if err != nil {
-			// Fallback to the index.html file.
-			// should succeed in all cases.
-			err = tryRead(public, "static/public", "index.html", w)
-			if err != nil {
-				return err
+	// Pre-build the patched index.html with <base href> and config script.
+	// Safety: base is validated by normalizePath (alphanumeric + /.-_ only),
+	// but we HTML-escape anyway as defense in depth.
+	var indexHTML []byte
+	if f, err := public.Open("static/public/index.html"); err == nil {
+		raw, _ := io.ReadAll(f)
+		_ = f.Close()
+		escaped := html.EscapeString(base)
+		injection := `<base href="` + escaped + `"><script>window.__HOMEBOX_BASE__="` + escaped + `";</script>`
+		content := strings.Replace(string(raw), "<head>", "<head>"+injection, 1)
+		if base != "/" && !strings.Contains(content, `baseURL:"`+base+`"`) {
+			// Patch Nuxt's runtime config so Vue Router knows the app's base path.
+			// Without this, client-side routing breaks on page reload (router sees
+			// /homebox/home but expects /home). This relies on the exact string format
+			// Nuxt produces — if it changes, the warning below fires.
+			content = strings.Replace(content, `baseURL:"/"`, `baseURL:"`+base+`"`, 1)
+			if !strings.Contains(content, `baseURL:"`+base+`"`) {
+				log.Warn().Msg("could not patch baseURL in index.html — Nuxt router may not work under subpath")
 			}
+		}
+		indexHTML = []byte(content)
+	} else {
+		log.Error().Err(err).Msg("failed to open embedded index.html — SPA fallback will not work")
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) error {
+		// Redirect root to app base when running under a subpath
+		if base != "/" && (r.URL.Path == "/" || r.URL.Path == strings.TrimSuffix(base, "/")) {
+			http.Redirect(w, r, base, http.StatusFound)
+			return nil
+		}
+
+		// Reject requests outside the base path with 404
+		if base != "/" && !strings.HasPrefix(r.URL.Path, base) {
+			http.NotFound(w, r)
+			return nil
+		}
+
+		// Strip the base prefix for file lookups
+		filePath := r.URL.Path
+		if base != "/" && strings.HasPrefix(filePath, base) {
+			filePath = "/" + strings.TrimPrefix(filePath, base)
+		}
+
+		// Try to serve the actual file
+		err := tryRead(public, "static/public", filePath, w)
+		if err != nil {
+			// SPA fallback: serve patched index.html
+			if indexHTML == nil {
+				http.Error(w, "index.html not available", http.StatusInternalServerError)
+				return nil
+			}
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(indexHTML)))
+			_, err = w.Write(indexHTML)
+			return err
 		}
 		return nil
 	}

--- a/backend/app/api/routes.go
+++ b/backend/app/api/routes.go
@@ -80,7 +80,7 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 		v1.WithURL(fmt.Sprintf("%s:%s", a.conf.Web.Host, a.conf.Web.Port)),
 	)
 
-	r.Route(strings.TrimRight(base, "/") + prefix + "/v1", func(r chi.Router) {
+	r.Route(strings.TrimRight(base, "/")+prefix+"/v1", func(r chi.Router) {
 		r.Get("/status", chain.ToHandlerFunc(v1Ctrl.HandleBase(func() bool { return true }, v1.Build{
 			Version:   version,
 			Commit:    commit,

--- a/backend/internal/sys/config/conf.go
+++ b/backend/internal/sys/config/conf.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/ardanlabs/conf/v3"
@@ -89,6 +91,7 @@ type DebugConf struct {
 type WebConfig struct {
 	Port string `yaml:"port" conf:"default:7745"`
 	Host string `yaml:"host"`
+	AppBase string `yaml:"app_base" conf:"default:/"`
 	// MaxUploadSize is the body cap (in MB) applied to ordinary upload
 	// endpoints (attachments, item imports, etc.). Defaults to 10 MB.
 	MaxUploadSize int64 `yaml:"max_file_upload" conf:"default:10"`
@@ -208,7 +211,33 @@ func New(buildstr string, description string) (*Config, error) {
 		return &cfg, fmt.Errorf("parsing config: %w", err)
 	}
 
+	cfg.Web.AppBase, err = normalizePath(cfg.Web.AppBase)
+	if err != nil {
+		return &cfg, err
+	}
+
 	return &cfg, nil
+}
+
+var validPathRe = regexp.MustCompile(`^[a-zA-Z0-9/\-_.]+$`)
+
+// normalizePath ensures the path always has a leading and trailing slash,
+// so it can safely be used as a URL path prefix.
+// Only allows alphanumeric characters, hyphens, underscores, dots, and slashes.
+func normalizePath(p string) (string, error) {
+	if p == "" {
+		return "/", nil
+	}
+	if !validPathRe.MatchString(p) {
+		return "", fmt.Errorf("HBOX_WEB_APP_BASE contains invalid characters (%q); only a-z, 0-9, /, -, _, . are allowed", p)
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	if !strings.HasSuffix(p, "/") {
+		p = p + "/"
+	}
+	return p, nil
 }
 
 // Print prints the configuration to stdout as an indented JSON document.

--- a/backend/internal/sys/config/conf.go
+++ b/backend/internal/sys/config/conf.go
@@ -89,8 +89,8 @@ type DebugConf struct {
 }
 
 type WebConfig struct {
-	Port string `yaml:"port" conf:"default:7745"`
-	Host string `yaml:"host"`
+	Port    string `yaml:"port"     conf:"default:7745"`
+	Host    string `yaml:"host"`
 	AppBase string `yaml:"app_base" conf:"default:/"`
 	// MaxUploadSize is the body cap (in MB) applied to ordinary upload
 	// endpoints (attachments, item imports, etc.). Defaults to 10 MB.
@@ -235,7 +235,7 @@ func normalizePath(p string) (string, error) {
 		p = "/" + p
 	}
 	if !strings.HasSuffix(p, "/") {
-		p = p + "/"
+		p += "/"
 	}
 	return p, nil
 }

--- a/backend/internal/sys/config/conf_normalize_test.go
+++ b/backend/internal/sys/config/conf_normalize_test.go
@@ -2,6 +2,8 @@ package config
 
 import "testing"
 
+const testHomebox = "/homebox/"
+
 func Test_normalizePath(t *testing.T) {
 	tests := []struct {
 		input string
@@ -9,10 +11,10 @@ func Test_normalizePath(t *testing.T) {
 	}{
 		{"", "/"},
 		{"/", "/"},
-		{"homebox", "/homebox/"},
-		{"/homebox", "/homebox/"},
-		{"homebox/", "/homebox/"},
-		{"/homebox/", "/homebox/"},
+		{"homebox", testHomebox},
+		{"/homebox", testHomebox},
+		{"homebox/", testHomebox},
+		{"/homebox/", testHomebox},
 		{"/app/inventory", "/app/inventory/"},
 		{"app/inventory/", "/app/inventory/"},
 	}

--- a/backend/internal/sys/config/conf_normalize_test.go
+++ b/backend/internal/sys/config/conf_normalize_test.go
@@ -1,0 +1,47 @@
+package config
+
+import "testing"
+
+func Test_normalizePath(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", "/"},
+		{"/", "/"},
+		{"homebox", "/homebox/"},
+		{"/homebox", "/homebox/"},
+		{"homebox/", "/homebox/"},
+		{"/homebox/", "/homebox/"},
+		{"/app/inventory", "/app/inventory/"},
+		{"app/inventory/", "/app/inventory/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := normalizePath(tt.input)
+			if err != nil {
+				t.Fatalf("normalizePath(%q) returned unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("normalizePath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_normalizePath_rejectsInvalidChars(t *testing.T) {
+	invalids := []string{
+		"<script>",
+		"path with spaces",
+		"path?query",
+		"path#fragment",
+	}
+	for _, input := range invalids {
+		t.Run(input, func(t *testing.T) {
+			_, err := normalizePath(input)
+			if err == nil {
+				t.Errorf("normalizePath(%q) did not return error", input)
+			}
+		})
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,6 @@ services:
             - linux/arm
     environment:
       - HBOX_LOGGER_LEVEL=-1
+      # - HBOX_WEB_APP_BASE=/homebox  # Serve under a sub-path (default: /, trailing slash auto-added)
     ports:
       - 3100:7745

--- a/frontend/app.vue
+++ b/frontend/app.vue
@@ -6,11 +6,11 @@
 
     <NuxtLayout>
       <Html :lang="locale" :data-theme="theme || 'homebox'" />
-      <Link rel="icon" type="image/svg" href="/favicon.svg" />
-      <Link rel="apple-touch-icon" href="/apple-touch-icon.png" size="180x180" />
-      <Link rel="mask-icon" href="/mask-icon.svg" color="#5b7f67" />
+      <Link rel="icon" type="image/svg" href="./favicon.svg" />
+      <Link rel="apple-touch-icon" href="./apple-touch-icon.png" size="180x180" />
+      <Link rel="mask-icon" href="./mask-icon.svg" color="#5b7f67" />
       <Meta name="theme-color" content="#5b7f67" />
-      <Link rel="manifest" href="/manifest.webmanifest" />
+      <Link rel="manifest" href="./manifest.webmanifest" />
       <NuxtPage />
     </NuxtLayout>
   </DialogProvider>

--- a/frontend/components/Collection/JoinModal.vue
+++ b/frontend/components/Collection/JoinModal.vue
@@ -54,7 +54,7 @@
   const api = useUserApi();
   const collections = useCollections();
 
-  const domain = window.location.protocol + "//" + window.location.host;
+  const domain = new URL(useAppBase(), `${window.location.protocol}//${window.location.host}`).toString();
 
   const redirectTo = ref("");
   // Holds invite code from dialog params until the watcher applies it on open

--- a/frontend/composables/use-app-base.ts
+++ b/frontend/composables/use-app-base.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns the app's base URL, injected by the Go backend at runtime
+ * via window.__HOMEBOX_BASE__ in the served index.html.
+ *
+ * Named with "use" prefix to follow Nuxt composable conventions (auto-imported
+ * from composables/), though it is not reactive — the base path never changes
+ * during the lifetime of the app.
+ *
+ * Note: This composable requires a browser environment (window). It returns "/"
+ * if window is unavailable. SSR is not supported.
+ */
+export function useAppBase(): string {
+  if (typeof window === "undefined") return "/";
+  return (window as any).__HOMEBOX_BASE__ || "/";
+}

--- a/frontend/composables/use-app-base.ts
+++ b/frontend/composables/use-app-base.ts
@@ -11,5 +11,6 @@
  */
 export function useAppBase(): string {
   if (typeof window === "undefined") return "/";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (window as any).__HOMEBOX_BASE__ || "/";
 }

--- a/frontend/composables/use-server-events.ts
+++ b/frontend/composables/use-server-events.ts
@@ -72,8 +72,10 @@ function connect(onmessage: (m: EventMessage) => void) {
   const dev = import.meta.dev;
 
   const host = dev ? window.location.host.replace("3000", "7745") : window.location.host;
+  // In dev mode, the backend runs without subpath config; base only applies in production.
+  const base = dev ? "/" : useAppBase();
 
-  let url = `${protocol}://${host}/api/v1/ws/events`;
+  let url = `${protocol}://${host}${base}api/v1/ws/events`;
   if (currentTenantId) {
     url += `?tenant=${currentTenantId}`;
   }

--- a/frontend/lib/api/base/index.test.ts
+++ b/frontend/lib/api/base/index.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { route } from ".";
+import { beforeEach, describe, expect, it } from "vitest";
+import { overrideParts, route } from ".";
 
 describe("UrlBuilder", () => {
+  beforeEach(() => {
+    overrideParts("http://localhost.com", "/api/v1", "/");
+  });
+
   it("basic query parameter", () => {
     const result = route("/test", { a: "b" });
     expect(result).toBe("/api/v1/test?a=b");
@@ -20,5 +24,11 @@ describe("UrlBuilder", () => {
   it("list-like query parameters", () => {
     const result = route("/test", { a: ["b", "c"] });
     expect(result).toBe("/api/v1/test?a=b&a=c");
+  });
+
+  it("respects custom base path", () => {
+    overrideParts("http://localhost.com", "/api/v1", "/homebox/");
+    const result = route("/test");
+    expect(result).toBe("/homebox/api/v1/test");
   });
 });

--- a/frontend/lib/api/base/index.ts
+++ b/frontend/lib/api/base/index.ts
@@ -1,2 +1,2 @@
 export { BaseAPI } from "./base-api";
-export { route } from "./urls";
+export { overrideParts, route } from "./urls";

--- a/frontend/lib/api/base/urls.ts
+++ b/frontend/lib/api/base/urls.ts
@@ -1,9 +1,11 @@
 const parts = {
+  base: "/",
   host: "http://localhost.com",
   prefix: "/api/v1",
 };
 
-export function overrideParts(host: string, prefix: string) {
+export function overrideParts(host: string, prefix: string, base: string = "/") {
+  parts.base = base;
   parts.host = host;
   parts.prefix = prefix;
 }
@@ -20,7 +22,8 @@ export type QueryValue = string | string[] | number | number[] | boolean | null 
  * relative URLs in production because the API and client bundle are served from the same server/host.
  */
 export function route(rest: string, params: Record<string, QueryValue> = {}): string {
-  const url = new URL(parts.prefix + rest, parts.host);
+  const base = parts.base.replace(/\/$/, "");
+  const url = new URL(base + parts.prefix + rest, parts.host);
 
   for (const [key, value] of Object.entries(params)) {
     if (Array.isArray(value)) {

--- a/frontend/lib/otel/index.ts
+++ b/frontend/lib/otel/index.ts
@@ -14,6 +14,7 @@ import type { Span, Attributes } from "@opentelemetry/api";
 import { trace, context, propagation, SpanKind, SpanStatusCode } from "@opentelemetry/api";
 import { ExportResultCode } from "@opentelemetry/core";
 import type { ExportResult } from "@opentelemetry/core";
+import { route } from "~~/lib/api/base/urls";
 
 // Types for the telemetry configuration
 export interface OTelConfig {
@@ -151,8 +152,6 @@ class BackendProxyExporter implements SpanExporter {
     return result;
   }
 }
-
-import { route } from "~~/lib/api/base/urls";
 
 /**
  * Initialize OpenTelemetry tracing for the frontend.

--- a/frontend/lib/otel/index.ts
+++ b/frontend/lib/otel/index.ts
@@ -152,6 +152,8 @@ class BackendProxyExporter implements SpanExporter {
   }
 }
 
+import { route } from "~~/lib/api/base/urls";
+
 /**
  * Initialize OpenTelemetry tracing for the frontend.
  * Should be called once during app startup.
@@ -178,7 +180,7 @@ export function initializeOTel(config: Partial<OTelConfig> = {}): void {
   });
 
   // Configure exporter - always use backend proxy for authentication
-  const exporter: SpanExporter = new BackendProxyExporter("/api/v1/telemetry", finalConfig.debug);
+  const exporter: SpanExporter = new BackendProxyExporter(route("/telemetry"), finalConfig.debug);
 
   // Use batch processor for better performance
   const batchProcessor = new BatchSpanProcessor(exporter);

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -64,11 +64,11 @@ export default defineNuxtConfig({
 
   pwa: {
     workbox: {
-      navigateFallbackDenylist: [/\/api\/v\d/],
+      navigateFallbackDenylist: [/\/api\/v\d+/],
       cleanupOutdatedCaches: true,
       runtimeCaching: [
         {
-          urlPattern: /\/api\/v\d/,
+          urlPattern: /\/api\/v\d+/,
           handler: "NetworkFirst",
           method: "GET",
           options: {

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -40,6 +40,8 @@ export default defineNuxtConfig({
   },
 
   nitro: {
+    // Dev proxy always runs at root — subpath is only relevant in production
+    // where the Go backend handles it.
     devProxy: {
       "/api": {
         target: "http://localhost:7745/api",
@@ -50,8 +52,11 @@ export default defineNuxtConfig({
   },
 
   app: {
+    // cdnURL "./" produces relative asset paths in the built HTML (e.g. ./_nuxt/app.js).
+    // These are resolved by the <base href> tag that the Go backend injects at runtime.
+    cdnURL: "./",
     head: {
-      script: [{ src: "/set-theme.js" }],
+      script: [{ src: "./set-theme.js" }],
     },
   },
 
@@ -59,11 +64,11 @@ export default defineNuxtConfig({
 
   pwa: {
     workbox: {
-      navigateFallbackDenylist: [/^\/api/],
+      navigateFallbackDenylist: [/\/api\/v\d/],
       cleanupOutdatedCaches: true,
       runtimeCaching: [
         {
-          urlPattern: /^\/api/,
+          urlPattern: /\/api\/v\d/,
           handler: "NetworkFirst",
           method: "GET",
           options: {
@@ -88,7 +93,7 @@ export default defineNuxtConfig({
       short_name: "Homebox",
       description: "Home Inventory App",
       theme_color: "#5b7f67",
-      start_url: "/home",
+      start_url: "./home",
       icons: [
         {
           src: "pwa-192x192.png",

--- a/frontend/pages/collection/index/invites.vue
+++ b/frontend/pages/collection/index/invites.vue
@@ -27,7 +27,7 @@
   const { openDialog } = useDialog();
   const confirm = useConfirm();
   const localInvites = ref<Invitation[]>([]);
-  const baseUrl = `${window.location.protocol}//${window.location.host}`;
+  const baseUrl = new URL(useAppBase(), `${window.location.protocol}//${window.location.host}`).toString();
   const loading = ref(true);
   const invites = ref<Invitation[]>([]);
   const error = ref<string | null>(null);

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -214,7 +214,8 @@
   }
 
   function loginWithOIDC() {
-    window.location.href = "/api/v1/users/login/oidc";
+    const base = useAppBase();
+    window.location.href = base + "api/v1/users/login/oidc";
   }
 
   const [registerForm, toggleLogin] = useToggle();

--- a/frontend/plugins/api-base.ts
+++ b/frontend/plugins/api-base.ts
@@ -1,0 +1,17 @@
+import { overrideParts } from "~~/lib/api/base/urls";
+
+// This plugin runs early (order: -20) to configure the API URL builder
+// before any other plugin or composable makes API calls.
+// It depends on window.__HOMEBOX_BASE__ which is set via an inline <script>
+// in <head> (injected by the Go backend), so it's available before any
+// module-type scripts execute.
+export default defineNuxtPlugin({
+  name: "api-base",
+  order: -20,
+  setup() {
+    const base = useAppBase();
+    // "http://localhost.com" is a dummy host required by the URL() constructor
+    // in route(). It gets stripped from the output — only the path is used.
+    overrideParts("http://localhost.com", "/api/v1", base);
+  },
+});


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Adds sub-path support. You can now serve HomeBox under a path like `/homebox/` by setting one env var at runtime. No rebuild needed.

```bash
podman run -e HBOX_WEB_APP_BASE=/homebox homebox
podman run -e HBOX_WEB_APP_BASE=/apps/inventory homebox                                                                                                     
podman run homebox  # default: serves at /     
```

Without setting the var, everything works as before (served at `/`).

This is similar to what #1430 does, but #1430 requires rebuilding the image for each path. Here it's runtime only.

### How it works

The frontend uses `cdnURL: "./"` so assets get relative paths. On startup the backend reads `HBOX_WEB_APP_BASE` and patches the `index.html` in memory — injects `<base href>` so the browser resolves assets correctly, sets `window.__HOMEBOX_BASE__` for the JS side, and patches `baseURL` in the Nuxt config so Vue Router works with the sub-path.

Routes (API, Swagger, static files) are all mounted under the base. Paths outside the base get 404.

### What changed

#### Backend:

- `conf.go` — new `AppBase` field, validated with regex, normalized to `/path/` form
- `routes.go` — mounting under base, index.html patching at startup, root redirect, 404 for wrong paths
- `oidc.go`, `v1_ctrl_auth.go` — cookie paths and redirects use AppBase
- `controller.go` — passes web config to OIDC provider

#### Frontend:

- `nuxt.config.ts` — `cdnURL: "./"`, PWA denylist fix
- New `useAppBase()` composable + plugin that configures the URL builder
- WebSocket URL, login redirect, invite links all use `useAppBase()`
- `app.vue` — links to favicon/icons/manifest made relative
- otel endpoint uses `route()` now

#### Tests:

- `conf_normalize_test.go` — normalization + invalid input
- `index.test.ts` — URL builder with custom base

#### Infra:

- Dockerfile healthcheck adapted for sub-path
- docker-compose.yml documents the new var

## Which issue(s) this PR fixes:

- Supersedes #1430
- Addresses #322
- Addresses #1047

## Special notes for your reviewer:

The `baseURL:"/"` string replace is not great — it depends on exact Nuxt output format. But Vue Router needs this value before hydration and there is no other way to set it at runtime. There is a warning log if the pattern is not found.

Input is validated strictly (only `[a-zA-Z0-9/\-_.]` allowed) and html-escaped before injection.

Cookies use AppBase as path so multiple instances on same domain don't conflict.

Reverse proxy should NOT strip the prefix. Backend expects the full path.

## Testing

- `go vet` passes, unit tests pass
- Tested with podman: `/`, `/homebox`, `/app/inventory` all from same image
- Checked login, navigation, websocket, swagger, assets, redirects, 404
- Without the env var: same behavior as before
