### PR TITLE
Fix item detail photo grid to load thumbnails instead of originals

### DIFF
--- a/frontend/pages/item/[id]/index.vue
+++ b/frontend/pages/item/[id]/index.vue
@@ -804,10 +804,7 @@
             <template #title> {{ $t("items.photos") }} </template>
             <div class="scroll-bg container mx-auto flex max-h-[500px] flex-wrap gap-2 overflow-y-scroll border-t p-4">
               <button v-for="(img, i) in photos" :key="i" @click="openImageDialog(img, item.id)">
-                <picture>
-                  <source :srcset="img.originalSrc" :type="img.originalType" />
-                  <img class="max-h-[200px] rounded" :src="img.thumbnailSrc" alt="attachment image" />
-                </picture>
+                <img class="max-h-[200px] rounded" :src="img.thumbnailSrc" alt="attachment image" loading="lazy" />
               </button>
             </div>
           </BaseCard>

--- a/frontend/pages/item/[id]/index.vue
+++ b/frontend/pages/item/[id]/index.vue
@@ -804,7 +804,7 @@
             <template #title> {{ $t("items.photos") }} </template>
             <div class="scroll-bg container mx-auto flex max-h-[500px] flex-wrap gap-2 overflow-y-scroll border-t p-4">
               <button v-for="(img, i) in photos" :key="i" @click="openImageDialog(img, item.id)">
-                <img class="max-h-[200px] rounded" :src="img.thumbnailSrc" alt="attachment image" loading="lazy" />
+                <img class="max-h-[200px] rounded" :src="img.thumbnailSrc" :alt="$t('items.photo')" loading="lazy" />
               </button>
             </div>
           </BaseCard>


### PR DESCRIPTION
Fixes #1606

## What

The item detail page photo grid wrapped each thumbnail in a `<picture>` whose
`<source>` pointed at the full-resolution original. Per the `<picture>` spec a
matching `<source>` wins over the `<img>` `src`, so browsers eagerly downloaded
the multi-MB original for every photo on detail-page load and ignored the
already-generated WebP thumbnail.

## Change

Replace the `<picture>`/`<source>` with a plain `<img>` bound to `thumbnailSrc`.
The full-resolution original is still loaded on demand when the user opens the
image dialog. Also added `loading="lazy"` to defer offscreen thumbnails.

## Impact

- Item detail page now uses thumbnails, matching the list/grid behavior.
- Significantly reduces bandwidth for self-hosted instances on constrained uplinks.
- No backend change; thumbnail data and `thumbnailId` were already correct.

## Testing

Verified on a self-hosted 0.26.2 instance: detail page previously fetched a
~4.3 MB JPEG per photo; after the change it fetches the WebP thumbnail, with the
original loaded only when the image dialog is opened.