### PR TITLE
feat: allow to search only for locations

### DIFF
--- a/frontend/lib/api/classes/items.ts
+++ b/frontend/lib/api/classes/items.ts
@@ -27,6 +27,7 @@ export type ItemsQuery = {
   negateTags?: boolean;
   onlyWithoutPhoto?: boolean;
   onlyWithPhoto?: boolean;
+  isLocation?: boolean;
   q?: string;
   fields?: string[];
 };

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -610,6 +610,7 @@
         "notes": "Notes",
         "only_with_photo": "Only items with photo",
         "only_without_photo": "Only items without photo",
+        "is_location": "Only locations",
         "options": "Options",
         "order_by": "Order By",
         "pages": "Page { page } of { totalPages }",

--- a/frontend/pages/items.vue
+++ b/frontend/pages/items.vue
@@ -18,6 +18,7 @@
   import SearchFilter from "~/components/Search/Filter.vue";
   import ItemViewSelectable from "~/components/Item/View/Selectable.vue";
   import type { LocationQueryRaw } from "vue-router";
+  import type { WatchSource } from "vue";
 
   const { t } = useI18n();
 
@@ -87,6 +88,7 @@
   const negateTags = useOptionalRouteQuery("negateTags", false);
   const onlyWithoutPhoto = useOptionalRouteQuery("onlyWithoutPhoto", false);
   const onlyWithPhoto = useOptionalRouteQuery("onlyWithPhoto", false);
+  const isLocation = useOptionalRouteQuery("isLocation", false);
   const orderBy = useOptionalRouteQuery("orderBy", "name");
   const qLoc = useOptionalRouteQuery("loc", []);
   const qTag = useOptionalRouteQuery("tag", []);
@@ -189,21 +191,19 @@
     return data;
   });
 
-  watch(includeArchived, (newV, oldV) => {
-    if (newV !== oldV) {
-      search();
-    }
-  });
+  const watchSearch = (source: WatchSource<boolean | string>) => {
+    watch(source, (newV, oldV) => {
+      if (newV !== oldV) {
+        search();
+      }
+    });
+  };
+
+  [includeArchived, negateTags, isLocation, orderBy].map(watchSearch);
 
   watch(fieldSelector, (newV, oldV) => {
     if (newV === false && oldV === true) {
       fieldTuples.value = [];
-    }
-  });
-
-  watch(negateTags, (newV, oldV) => {
-    if (newV !== oldV) {
-      search();
     }
   });
 
@@ -221,12 +221,6 @@
       // this triggers the watch on onlyWithoutPhoto
       onlyWithoutPhoto.value = false;
     } else if (newV !== oldV) {
-      search();
-    }
-  });
-
-  watch(orderBy, (newV, oldV) => {
-    if (newV !== oldV) {
       search();
     }
   });
@@ -277,6 +271,7 @@
       negateTags: negateTags.value,
       onlyWithoutPhoto: onlyWithoutPhoto.value,
       onlyWithPhoto: onlyWithPhoto.value,
+      isLocation: isLocation.value,
       orderBy: orderBy.value,
       page: page.value,
       q: query.value,
@@ -314,6 +309,7 @@
       negateTags: negateTags.value,
       onlyWithoutPhoto: onlyWithoutPhoto.value,
       onlyWithPhoto: onlyWithPhoto.value,
+      isLocation: isLocation.value,
       includeArchived: includeArchived.value,
       page: page.value,
       pageSize: pageSize.value,
@@ -435,6 +431,11 @@
               <Switch v-model="onlyWithPhoto" class="ml-auto" />
               <div class="grow" />
               <span class="text-right"> {{ $t("items.only_with_photo") }} </span>
+            </Label>
+            <Label class="flex cursor-pointer items-center">
+              <Switch v-model="isLocation" class="ml-auto" />
+              <div class="grow" />
+              <span class="text-right"> {{ $t("items.is_location") }} </span>
             </Label>
             <Label class="flex cursor-pointer flex-col gap-2">
               <span class="text-right">


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- feature

## What this PR does / why we need it:

This feature adds a switch to search only for locations. There is already handling in the backend, but it was never propagated.

This is useful, because now with extendable entity types, we can create stuff like boxes, which are more dynamic in their nature. Having that different entity types it's beneficial to search for them.

<img width="290" height="346" alt="Screenshot 2026-07-10 at 06 33 33" src="https://github.com/user-attachments/assets/44d79625-8d61-456f-b938-e2511f653fb7" />


## Which issue(s) this PR fixes:

There is no issue.
