### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@
     <img src="https://img.shields.io/lemmy/homebox%40lemmy.world?label=lemmy"/>
 </p>
 <p align="center" style="width: 100%;">
+  <a href="https://zenith.hosting/host/homebox"><img src="https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg" alt="Deploy with Zenith"/></a>
+</p>
+<p align="center" style="width: 100%;">
   <a href="https://www.pikapods.com/pods?run=homebox"><img src="https://www.pikapods.com/static/run-button.svg"/></a>
 </p>
 


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added
HomeBox to our marketplace, so this PR adds a small "Deploy with Zenith" badge in the README
header, just above the existing PikaPods run button (links to https://zenith.hosting/host/homebox).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

## What type of PR is this?

- documentation

## What this PR does / why we need it:

- Adds a single centered "Deploy with Zenith" badge to the README header, above the PikaPods run button, giving users another one-click managed hosting option. Additions-only, one line of markup.

## Which issue(s) this PR fixes:

N/A

## Special notes for your reviewer:

Docs-only change, no code touched. Placed directly above the PikaPods badge to match the existing centered header style. Happy to adjust placement or wording.

## Testing

N/A (documentation only).
