### PR TITLE
fix: preserve asset ID when re-importing items by import ref (#1100)

### DIFF
--- a/backend/internal/core/services/service_entities.go
+++ b/backend/internal/core/services/service_entities.go
@@ -343,58 +343,13 @@ func (svc *EntityService) CsvImport(ctx context.Context, gid uuid.UUID, data io.
 
 		// ========================================
 		// Pre-Create Locations as necessary
-		path := serializeLocation(row.Location)
-
-		locationID, ok := locationMap[path]
-		if !ok {
-			locsCtx, locsSpan := entityServiceTracer().Start(rowCtx, "service.EntityService.CsvImport.row.locations",
-				trace.WithAttributes(attribute.Int("location.depth", len(row.Location))))
-			locsCreated := 0
-			paths := []string{}
-			for i, pathElement := range row.Location {
-				paths = append(paths, pathElement)
-				path := serializeLocation(paths)
-
-				locationID, ok = locationMap[path]
-				if !ok {
-					parentID := uuid.Nil
-
-					if i > 0 {
-						parentPath := serializeLocation(row.Location[:i])
-						parentID = locationMap[parentPath]
-					}
-
-					newLocation, err := svc.repo.Entities.CreateContainer(locsCtx, gid, repo.EntityCreate{
-						ParentID: parentID,
-						Name:     pathElement,
-					})
-					if err != nil {
-						recordServiceSpanError(locsSpan, err)
-						locsSpan.End()
-						recordServiceSpanError(rowSpan, err)
-						rowSpan.End()
-						recordServiceSpanError(importSpan, err)
-						recordServiceSpanError(span, err)
-						return 0, err
-					}
-					locationID = newLocation.ID
-					locsCreated++
-				}
-
-				locationMap[path] = locationID
-			}
-			locsSpan.SetAttributes(attribute.Int("locations.created.count", locsCreated))
-			locsSpan.End()
-
-			locationID, ok = locationMap[path]
-			if !ok {
-				err := errors.New("failed to create location")
-				recordServiceSpanError(rowSpan, err)
-				rowSpan.End()
-				recordServiceSpanError(importSpan, err)
-				recordServiceSpanError(span, err)
-				return 0, err
-			}
+		locationID, err := svc.csvImportRowLocation(rowCtx, gid, row, locationMap)
+		if err != nil {
+			recordServiceSpanError(rowSpan, err)
+			rowSpan.End()
+			recordServiceSpanError(importSpan, err)
+			recordServiceSpanError(span, err)
+			return 0, err
 		}
 
 		// Auto-incrementing an asset ID is only appropriate when a brand new
@@ -522,6 +477,61 @@ func (svc *EntityService) CsvImport(ctx context.Context, gid uuid.UUID, data io.
 	importSpan.SetAttributes(attribute.Int("rows.imported.count", finished))
 	span.SetAttributes(attribute.Int("rows.imported.count", finished))
 	return finished, nil
+}
+
+// csvImportRowLocation resolves the leaf location for a CSV import row, creating
+// any missing locations in the row's location path as it goes. locationMap acts
+// as a cache of already-known location paths and is updated in place with any
+// locations that are created. It returns the ID of the row's leaf location.
+func (svc *EntityService) csvImportRowLocation(ctx context.Context, gid uuid.UUID, row reporting.ExportCSVRow, locationMap map[string]uuid.UUID) (uuid.UUID, error) {
+	path := serializeLocation(row.Location)
+
+	locationID, ok := locationMap[path]
+	if ok {
+		return locationID, nil
+	}
+
+	locsCtx, locsSpan := entityServiceTracer().Start(ctx, "service.EntityService.CsvImport.row.locations",
+		trace.WithAttributes(attribute.Int("location.depth", len(row.Location))))
+	defer locsSpan.End()
+
+	locsCreated := 0
+	paths := []string{}
+	for i, pathElement := range row.Location {
+		paths = append(paths, pathElement)
+		subPath := serializeLocation(paths)
+
+		locationID, ok = locationMap[subPath]
+		if !ok {
+			parentID := uuid.Nil
+
+			if i > 0 {
+				parentPath := serializeLocation(row.Location[:i])
+				parentID = locationMap[parentPath]
+			}
+
+			newLocation, err := svc.repo.Entities.CreateContainer(locsCtx, gid, repo.EntityCreate{
+				ParentID: parentID,
+				Name:     pathElement,
+			})
+			if err != nil {
+				recordServiceSpanError(locsSpan, err)
+				return uuid.Nil, err
+			}
+			locationID = newLocation.ID
+			locsCreated++
+		}
+
+		locationMap[subPath] = locationID
+	}
+	locsSpan.SetAttributes(attribute.Int("locations.created.count", locsCreated))
+
+	locationID, ok = locationMap[path]
+	if !ok {
+		return uuid.Nil, errors.New("failed to create location")
+	}
+
+	return locationID, nil
 }
 
 func (svc *EntityService) patchCSVParentRefs(ctx context.Context, gid uuid.UUID, rows []reporting.ExportCSVRow) error {

--- a/backend/internal/core/services/service_entities.go
+++ b/backend/internal/core/services/service_entities.go
@@ -397,8 +397,12 @@ func (svc *EntityService) CsvImport(ctx context.Context, gid uuid.UUID, data io.
 			}
 		}
 
+		// Auto-incrementing an asset ID is only appropriate when a brand new
+		// entity is being created. Re-importing a row whose import ref already
+		// exists must not consume a new asset ID, otherwise repeated imports of
+		// the same file keep bumping the item's asset ID (#1100).
 		var effAID repo.AssetID
-		if svc.autoIncrementAssetID && row.AssetID.Nil() {
+		if svc.autoIncrementAssetID && row.AssetID.Nil() && createRequired {
 			effAID = highestAID + 1
 			highestAID++
 		} else {
@@ -447,6 +451,13 @@ func (svc *EntityService) CsvImport(ctx context.Context, gid uuid.UUID, data io.
 			return 0, wrapped
 		}
 		rowSpan.SetAttributes(attribute.String("entity.id", entity.ID.String()))
+
+		// When updating an existing entity that was matched by import ref and the
+		// CSV row does not carry its own asset ID, keep the entity's current asset
+		// ID rather than overwriting it with a zero/reassigned value (#1100).
+		if !createRequired && row.AssetID.Nil() {
+			effAID = entity.AssetID
+		}
 
 		fields := lo.Map(row.Fields, func(f reporting.ExportItemFields, _ int) repo.EntityFieldData {
 			return repo.EntityFieldData{

--- a/backend/internal/core/services/service_entities_test.go
+++ b/backend/internal/core/services/service_entities_test.go
@@ -1,0 +1,76 @@
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEntityService_CsvImport_AssetIDIdempotent verifies that re-importing the
+// same CSV file (rows matched by their existing import ref) does not consume a
+// new auto-incremented asset ID on every run.
+//
+// Regression test for https://github.com/sysadminsmedia/homebox/issues/1100
+// ("Importing a File with import_ref increments asset-id"): the first import
+// assigns an asset ID, and subsequent imports of the unchanged file must leave
+// that asset ID untouched.
+func TestEntityService_CsvImport_AssetIDIdempotent(t *testing.T) {
+	ctx := context.Background()
+
+	grp, err := tRepos.Groups.GroupCreate(ctx, "csv-assetid-"+fk.Str(4), uuid.Nil)
+	require.NoError(t, err)
+
+	csv := "HB.import_ref,HB.location,HB.name,HB.quantity\n" +
+		"ref-1,Loc A,Widget,1\n"
+
+	// First import: creates the item and assigns an auto-incremented asset ID.
+	n, err := tSvc.Entities.CsvImport(ctx, grp.ID, strings.NewReader(csv))
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	first, err := tRepos.Entities.GetByRef(ctx, grp.ID, "ref-1")
+	require.NoError(t, err)
+	require.False(t, first.AssetID.Nil(), "first import should assign an asset ID")
+
+	// Re-import the exact same file. The row is matched by its import ref and
+	// updated in place, so the asset ID must remain stable.
+	n, err = tSvc.Entities.CsvImport(ctx, grp.ID, strings.NewReader(csv))
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	second, err := tRepos.Entities.GetByRef(ctx, grp.ID, "ref-1")
+	require.NoError(t, err)
+
+	require.Equal(t, second.ID, first.ID, "re-import must update the same entity")
+	require.Equal(t, first.AssetID, second.AssetID, "re-import must not change the asset ID")
+}
+
+// TestEntityService_CsvImport_AssetIDAutoIncrement guards the auto-increment
+// path that issue #1100's fix must preserve: genuinely new items imported in a
+// single file still receive distinct, sequential asset IDs.
+func TestEntityService_CsvImport_AssetIDAutoIncrement(t *testing.T) {
+	ctx := context.Background()
+
+	grp, err := tRepos.Groups.GroupCreate(ctx, "csv-assetid-inc-"+fk.Str(4), uuid.Nil)
+	require.NoError(t, err)
+
+	csv := "HB.import_ref,HB.location,HB.name,HB.quantity\n" +
+		"ref-a,Loc A,Widget A,1\n" +
+		"ref-b,Loc A,Widget B,1\n"
+
+	n, err := tSvc.Entities.CsvImport(ctx, grp.ID, strings.NewReader(csv))
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+
+	a, err := tRepos.Entities.GetByRef(ctx, grp.ID, "ref-a")
+	require.NoError(t, err)
+	b, err := tRepos.Entities.GetByRef(ctx, grp.ID, "ref-b")
+	require.NoError(t, err)
+
+	require.False(t, a.AssetID.Nil())
+	require.False(t, b.AssetID.Nil())
+	require.NotEqual(t, a.AssetID, b.AssetID, "distinct new items must get distinct asset IDs")
+}


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

CSV import auto-assigned a new incrementing asset ID for every row whose `import_ref` already existed. Because those rows are updated in place, and `UpdateByGroup` writes the asset ID unconditionally, re-importing an unchanged export kept bumping each item's asset ID on every run.

- `backend/internal/core/services/service_entities.go`: only auto-increment an asset ID when a brand new entity is created (`createRequired`). When updating an entity matched by import ref that carries no asset ID in the CSV, keep the entity's existing asset ID instead of overwriting it with a reassigned value.
- `backend/internal/core/services/service_entities_test.go`: adds regression coverage that a repeated import is idempotent for asset IDs, and that new items in a single import still receive distinct auto-incremented asset IDs.

## Which issue(s) this PR fixes:

Fixes #1100

## Testing

`go test ./internal/core/services/` — new `TestEntityService_CsvImport_AssetIDIdempotent` fails before the change (asset ID 000-001 → 000-002 on re-import) and passes after; full package green. `go vet` and `gofmt` clean.

## Disclosure

Prepared with AI assistance (Claude); authored and reviewed by me. Reflected in the commit's `Co-Authored-By` trailer.
