### PR TITLE
fix: a few random crash fixes

### DIFF
--- a/backend/internal/data/repo/repo_group.go
+++ b/backend/internal/data/repo/repo_group.go
@@ -326,29 +326,34 @@ func (r *GroupRepository) GroupByID(ctx context.Context, id uuid.UUID) (Group, e
 }
 
 func (r *GroupRepository) GroupDelete(ctx context.Context, id uuid.UUID) error {
-	// Delete attachments (and their blobs) before opening the tx: AttachmentRepo.Delete
-	// runs on the base connection, so calling it while the tx holds the write lock
-	// deadlocks on single-writer SQLite. The rows also cascade with the entity delete.
-	itm, err := r.db.Entity.Query().
+	tx, err := r.db.Tx(ctx)
+	if err != nil {
+		return err
+	}
+
+	itm, err := tx.Entity.Query().
 		Where(entity.HasGroupWith(group.ID(id))).
 		WithAttachments().
 		All(ctx)
 	if err != nil {
+		if rerr := tx.Rollback(); rerr != nil {
+			log.Error().Err(rerr).Msg("failed to rollback transaction")
+		}
 		return err
 	}
 
+	// Keep attachment row operations on the same transaction.
+	attachments := *r.attachments
+	attachments.db = tx.Client()
+
+	// Delete all attachments (and their files) before deleting the entities.
 	for _, it := range itm {
 		for _, att := range it.Edges.Attachments {
-			if err := r.attachments.Delete(ctx, id, att.ID); err != nil {
+			if err := attachments.Delete(ctx, id, att.ID); err != nil {
 				log.Err(err).Str("attachment_id", att.ID.String()).Msg("failed to delete attachment during group deletion")
 				// Continue with other attachments even if one fails.
 			}
 		}
-	}
-
-	tx, err := r.db.Tx(ctx)
-	if err != nil {
-		return err
 	}
 
 	// Delete all entities from the database

--- a/backend/internal/data/repo/repo_group.go
+++ b/backend/internal/data/repo/repo_group.go
@@ -28,7 +28,7 @@ type GroupRepository struct {
 	attachments      *AttachmentRepo
 }
 
-func NewGroupRepository(db *ent.Client) *GroupRepository {
+func NewGroupRepository(db *ent.Client, attachments *AttachmentRepo) *GroupRepository {
 	gmap := func(g *ent.Group) Group {
 		return Group{
 			ID:        g.ID,
@@ -52,6 +52,7 @@ func NewGroupRepository(db *ent.Client) *GroupRepository {
 		db:               db,
 		groupMapper:      gmap,
 		invitationMapper: imap,
+		attachments:      attachments,
 	}
 }
 
@@ -325,28 +326,29 @@ func (r *GroupRepository) GroupByID(ctx context.Context, id uuid.UUID) (Group, e
 }
 
 func (r *GroupRepository) GroupDelete(ctx context.Context, id uuid.UUID) error {
-	tx, err := r.db.Tx(ctx)
-	if err != nil {
-		return err
-	}
-
-	itm, err := tx.Entity.Query().
+	// Delete attachments (and their blobs) before opening the tx: AttachmentRepo.Delete
+	// runs on the base connection, so calling it while the tx holds the write lock
+	// deadlocks on single-writer SQLite. The rows also cascade with the entity delete.
+	itm, err := r.db.Entity.Query().
 		Where(entity.HasGroupWith(group.ID(id))).
-		WithGroup().
 		WithAttachments().
 		All(ctx)
 	if err != nil {
 		return err
 	}
 
-	// Delete all attachments (and their files) before deleting the entities
 	for _, it := range itm {
 		for _, att := range it.Edges.Attachments {
 			if err := r.attachments.Delete(ctx, id, att.ID); err != nil {
-				log.Err(err).Str("attachment_id", att.ID.String()).Msg("failed to delete attachment during entity deletion")
-				// Continue with other attachments even if one fails
+				log.Err(err).Str("attachment_id", att.ID.String()).Msg("failed to delete attachment during group deletion")
+				// Continue with other attachments even if one fails.
 			}
 		}
+	}
+
+	tx, err := r.db.Tx(ctx)
+	if err != nil {
+		return err
 	}
 
 	// Delete all entities from the database

--- a/backend/internal/data/repo/repo_item_attachments.go
+++ b/backend/internal/data/repo/repo_item_attachments.go
@@ -322,7 +322,7 @@ func (r *AttachmentRepo) Create(ctx context.Context, itemID uuid.UUID, doc ItemC
 
 	if typ == attachment.TypePhoto && primary {
 		bldr = bldr.SetPrimary(true)
-		err := r.db.Attachment.Update().
+		err := tx.Attachment.Update().
 			Where(
 				attachment.HasEntityWith(entity.ID(itemID)),
 				attachment.IDNEQ(bldrId),

--- a/backend/internal/data/repo/repos_all.go
+++ b/backend/internal/data/repo/repos_all.go
@@ -31,7 +31,7 @@ func New(db *ent.Client, bus *eventbus.EventBus, storage config.Storage, pubSubC
 		AuthTokens:          &TokenRepository{db},
 		PasswordResetTokens: &PasswordResetTokenRepository{db},
 		APIKeys:             NewAPIKeyRepository(db),
-		Groups:              NewGroupRepository(db),
+		Groups:              NewGroupRepository(db, attachments),
 		Entities:            &EntityRepository{db, bus, attachments},
 		EntityTypes:         &EntityTypeRepository{db, bus},
 		EntityTemplates:     &EntityTemplatesRepository{db, bus},

--- a/backend/internal/sys/validate/errors.go
+++ b/backend/internal/sys/validate/errors.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 )
 
 type UnauthorizedError struct {
@@ -59,7 +60,10 @@ func NewRequestError(err error, status int) error {
 }
 
 func (err *RequestError) Error() string {
-	return err.Err.Error()
+	if err.Err != nil {
+		return err.Err.Error()
+	}
+	return http.StatusText(err.Status)
 }
 
 // IsRequestError checks if an error of type RequestError exists.

--- a/backend/internal/web/mid/errors.go
+++ b/backend/internal/web/mid/errors.go
@@ -25,7 +25,7 @@ func Errors(log zerolog.Logger) errchain.ErrorHandler {
 				var resp ErrorResponse
 				var code int
 
-				traceID := r.Context().Value(middleware.RequestIDKey).(string)
+				traceID, _ := r.Context().Value(middleware.RequestIDKey).(string)
 				log.Err(err).
 					Ctx(r.Context()).
 					Stack().

--- a/backend/internal/web/mid/logger.go
+++ b/backend/internal/web/mid/logger.go
@@ -20,6 +20,18 @@ func (s *spy) WriteHeader(status int) {
 	s.ResponseWriter.WriteHeader(status)
 }
 
+// Write implicitly sends a 200 status if the handler hasn't called
+// WriteHeader yet, matching how http.ResponseWriter behaves. Without this
+// override, a handler that writes a body without an explicit WriteHeader
+// call leaves s.status at its zero value.
+func (s *spy) Write(b []byte) (int, error) {
+	if s.status == 0 {
+		s.status = http.StatusOK
+	}
+
+	return s.ResponseWriter.Write(b)
+}
+
 func (s *spy) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	hj, ok := s.ResponseWriter.(http.Hijacker)
 	if !ok {
@@ -31,7 +43,7 @@ func (s *spy) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 func Logger(l zerolog.Logger) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			reqID := r.Context().Value(middleware.RequestIDKey).(string)
+			reqID, _ := r.Context().Value(middleware.RequestIDKey).(string)
 
 			l.Info().Ctx(r.Context()).Str("method", r.Method).Str("path", r.URL.Path).Str("rid", reqID).Msg("request received")
 


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Four fixes found while writing tests, one commit each.

validate — `RequestError.Error()` panicked when `Err` was nil. Guard it, fall back to status text.

middleware — bare `.(string)` on the request-ID key panics if chi's `RequestID` middleware didn't run; switched to comma-ok. Also the logger spy didn't override `Write`, so implicit-200 responses logged as status 0.

repo — `NewGroupRepository` never set attachments, so deleting a group with attachments panicked. Wired it through the constructor. Attachment deletes now use the transaction-bound client, avoiding the SQLite deadlock while keeping the database work in one transaction.

attachments — clearing the previous primary photo during attachment creation used the base client instead of the existing transaction. Run it through the transaction too.

## Which issue(s) this PR fixes:

None.

## Testing

- `go test`
