### PR TITLE
fix: resolve golangci-lint failures in Go CI

### DIFF
--- a/backend/internal/core/services/service_user_login_test.go
+++ b/backend/internal/core/services/service_user_login_test.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,12 +32,12 @@ func TestLogin_EndToEnd(t *testing.T) {
 	t.Run("wrong password is rejected with generic error", func(t *testing.T) {
 		_, err := tSvc.User.Login(ctx, reg.Email, "wrong-password", false)
 		require.Error(t, err)
-		assert.True(t, errors.Is(err, ErrorInvalidLogin))
+		assert.ErrorIs(t, err, ErrorInvalidLogin)
 	})
 
 	t.Run("nonexistent user is rejected with the same generic error", func(t *testing.T) {
 		_, err := tSvc.User.Login(ctx, "does-not-exist@example.test", "any-password", false)
 		require.Error(t, err)
-		assert.True(t, errors.Is(err, ErrorInvalidLogin))
+		assert.ErrorIs(t, err, ErrorInvalidLogin)
 	})
 }

--- a/backend/internal/data/repo/repo_entities.go
+++ b/backend/internal/data/repo/repo_entities.go
@@ -111,15 +111,15 @@ type (
 		PurchaseDate types.Date `json:"purchaseDate"`
 		// Sold
 		SoldDate    types.Date `json:"soldDate"`
-		Name        string     `json:"name"                     validate:"required,min=1,max=255"`
-		Description string     `json:"description"              validate:"max=1000"`
+		Name        string     `json:"name"        validate:"required,min=1,max=255"`
+		Description string     `json:"description" validate:"max=1000"`
 		// Identifications
 		SerialNumber    string `json:"serialNumber"`
 		ModelNumber     string `json:"modelNumber"`
 		Manufacturer    string `json:"manufacturer"`
 		WarrantyDetails string `json:"warrantyDetails"`
-		PurchaseFrom    string `json:"purchaseFrom"  validate:"max=255"`
-		SoldTo          string `json:"soldTo"    validate:"max=255"`
+		PurchaseFrom    string `json:"purchaseFrom"    validate:"max=255"`
+		SoldTo          string `json:"soldTo"          validate:"max=255"`
 		SoldNotes       string `json:"soldNotes"`
 		// Extras
 		Notes string `json:"notes"`
@@ -128,8 +128,8 @@ type (
 		Fields                   []EntityFieldData `json:"fields"`
 		AssetID                  AssetID           `json:"assetId"                  swaggertype:"string"`
 		Quantity                 float64           `json:"quantity"`
-		PurchasePrice            float64           `json:"purchasePrice" extensions:"x-nullable,x-omitempty"`
-		SoldPrice                float64           `json:"soldPrice" extensions:"x-nullable,x-omitempty"`
+		PurchasePrice            float64           `json:"purchasePrice"            extensions:"x-nullable,x-omitempty"`
+		SoldPrice                float64           `json:"soldPrice"                extensions:"x-nullable,x-omitempty"`
 		ParentID                 uuid.UUID         `json:"parentId"                 extensions:"x-nullable,x-omitempty"`
 		ID                       uuid.UUID         `json:"id"`
 		EntityTypeID             uuid.UUID         `json:"entityTypeId"`

--- a/backend/internal/data/repo/repo_entity_templates.go
+++ b/backend/internal/data/repo/repo_entity_templates.go
@@ -44,15 +44,15 @@ type (
 	EntityTemplateCreate struct {
 		// Default values for entities
 		DefaultQuantity        *float64     `json:"defaultQuantity,omitempty"        extensions:"x-nullable"`
-		DefaultName            *string      `json:"defaultName,omitempty"            validate:"omitempty,max=255"  extensions:"x-nullable"`
-		DefaultDescription     *string      `json:"defaultDescription,omitempty"     validate:"omitempty,max=1000" extensions:"x-nullable"`
-		DefaultManufacturer    *string      `json:"defaultManufacturer,omitempty"    validate:"omitempty,max=255"  extensions:"x-nullable"`
-		DefaultModelNumber     *string      `json:"defaultModelNumber,omitempty"     validate:"omitempty,max=255"  extensions:"x-nullable"`
-		DefaultWarrantyDetails *string      `json:"defaultWarrantyDetails,omitempty" validate:"omitempty,max=1000" extensions:"x-nullable"`
-		DefaultTagIDs          *[]uuid.UUID `json:"defaultTagIds,omitempty"     extensions:"x-nullable"`
-		Name                   string       `json:"name"        validate:"required,min=1,max=255"`
-		Description            string       `json:"description" validate:"max=1000"`
-		Notes                  string       `json:"notes"       validate:"max=1000"`
+		DefaultName            *string      `json:"defaultName,omitempty"            validate:"omitempty,max=255"      extensions:"x-nullable"`
+		DefaultDescription     *string      `json:"defaultDescription,omitempty"     validate:"omitempty,max=1000"     extensions:"x-nullable"`
+		DefaultManufacturer    *string      `json:"defaultManufacturer,omitempty"    validate:"omitempty,max=255"      extensions:"x-nullable"`
+		DefaultModelNumber     *string      `json:"defaultModelNumber,omitempty"     validate:"omitempty,max=255"      extensions:"x-nullable"`
+		DefaultWarrantyDetails *string      `json:"defaultWarrantyDetails,omitempty" validate:"omitempty,max=1000"     extensions:"x-nullable"`
+		DefaultTagIDs          *[]uuid.UUID `json:"defaultTagIds,omitempty"          extensions:"x-nullable"`
+		Name                   string       `json:"name"                             validate:"required,min=1,max=255"`
+		Description            string       `json:"description"                      validate:"max=1000"`
+		Notes                  string       `json:"notes"                            validate:"max=1000"`
 		// Custom fields
 		Fields []TemplateField `json:"fields"`
 		// Default location and tags
@@ -68,15 +68,15 @@ type (
 	EntityTemplateUpdate struct {
 		// Default values for entities
 		DefaultQuantity        *float64     `json:"defaultQuantity,omitempty"        extensions:"x-nullable"`
-		DefaultName            *string      `json:"defaultName,omitempty"            validate:"omitempty,max=255"  extensions:"x-nullable"`
-		DefaultDescription     *string      `json:"defaultDescription,omitempty"     validate:"omitempty,max=1000" extensions:"x-nullable"`
-		DefaultManufacturer    *string      `json:"defaultManufacturer,omitempty"    validate:"omitempty,max=255"  extensions:"x-nullable"`
-		DefaultModelNumber     *string      `json:"defaultModelNumber,omitempty"     validate:"omitempty,max=255"  extensions:"x-nullable"`
-		DefaultWarrantyDetails *string      `json:"defaultWarrantyDetails,omitempty" validate:"omitempty,max=1000" extensions:"x-nullable"`
-		DefaultTagIDs          *[]uuid.UUID `json:"defaultTagIds,omitempty"     extensions:"x-nullable"`
-		Name                   string       `json:"name"        validate:"required,min=1,max=255"`
-		Description            string       `json:"description" validate:"max=1000"`
-		Notes                  string       `json:"notes"       validate:"max=1000"`
+		DefaultName            *string      `json:"defaultName,omitempty"            validate:"omitempty,max=255"      extensions:"x-nullable"`
+		DefaultDescription     *string      `json:"defaultDescription,omitempty"     validate:"omitempty,max=1000"     extensions:"x-nullable"`
+		DefaultManufacturer    *string      `json:"defaultManufacturer,omitempty"    validate:"omitempty,max=255"      extensions:"x-nullable"`
+		DefaultModelNumber     *string      `json:"defaultModelNumber,omitempty"     validate:"omitempty,max=255"      extensions:"x-nullable"`
+		DefaultWarrantyDetails *string      `json:"defaultWarrantyDetails,omitempty" validate:"omitempty,max=1000"     extensions:"x-nullable"`
+		DefaultTagIDs          *[]uuid.UUID `json:"defaultTagIds,omitempty"          extensions:"x-nullable"`
+		Name                   string       `json:"name"                             validate:"required,min=1,max=255"`
+		Description            string       `json:"description"                      validate:"max=1000"`
+		Notes                  string       `json:"notes"                            validate:"max=1000"`
 		// Custom fields
 		Fields []TemplateField `json:"fields"`
 		ID     uuid.UUID       `json:"id"`


### PR DESCRIPTION
## What type of PR is this?

- bug
- cleanup

## What this PR does / why we need it:

Fixes the failing Go CI lint stage. `golangci-lint` was reporting 26 issues (24 `tagalign`, 2 `testifylint`) that broke the build.

All changes were produced by `golangci-lint run --fix`; no logic was altered.

## Which issue(s) this PR fixes:

<!-- none -->

## Testing

- `golangci-lint run` reports 0 issues
- `go build ./...` passes clean
- `go vet ./internal/core/services/ ./internal/data/repo/` passes clean