### PR TITLE
fix: handle entity type selection on mobile

### DIFF
--- a/frontend/components/Entity/CreateModal.vue
+++ b/frontend/components/Entity/CreateModal.vue
@@ -514,6 +514,8 @@
 
   onMounted(() => {
     const cleanup = registerOpenDialogCallback(DialogID.CreateEntity, async params => {
+      await entityTypeStore.ensureFetched();
+
       subItemCreate.value = false;
       let parentItemLocationId = null;
       parent.value = {};

--- a/frontend/components/Entity/Selector.vue
+++ b/frontend/components/Entity/Selector.vue
@@ -1,10 +1,14 @@
 <template>
-  <Select :model-value="selectedEntityType" @update:model-value="id => onEntityTypeChanged(id as string)">
+  <Select
+    v-model:open="open"
+    :model-value="selectedEntityType"
+    @update:model-value="id => selectEntityType(id as string)"
+  >
     <SelectTrigger :class="{ 'h-7 p-1': size === 'sm' }">
       <SelectValue :class="{ 'text-xl': size === 'sm' }" :placeholder="$t('components.entity.selector.placeholder')" />
     </SelectTrigger>
     <SelectContent>
-      <SelectItem v-for="type in entityTypes" :key="type.id" :value="type.id">
+      <SelectItem v-for="type in entityTypes" :key="type.id" :value="type.id" @click="selectEntityType(type.id)">
         <div class="flex items-center gap-2">
           <MdiMapMarkerOutline v-if="type.isLocation" class="size-4" />
           <MdiPackageVariantClosed v-else class="size-4" />
@@ -24,10 +28,31 @@
 
   const { t } = useI18n();
 
-  defineProps<{
+  const props = defineProps<{
     entityTypes: EntityTypeSummary[];
     selectedEntityType?: string;
     onEntityTypeChanged: (id: string) => void;
     size?: "sm" | "md";
   }>();
+
+  const open = ref(false);
+  const handledEntityTypeId = ref(props.selectedEntityType);
+
+  watch(
+    () => props.selectedEntityType,
+    id => {
+      handledEntityTypeId.value = id;
+    }
+  );
+
+  function selectEntityType(id: string) {
+    open.value = false;
+
+    if (handledEntityTypeId.value === id) {
+      return;
+    }
+
+    handledEntityTypeId.value = id;
+    props.onEntityTypeChanged(id);
+  }
 </script>


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

This PR fixes entity type selection in the create and edit page on mobile browsers, where selecting a type could revert to the first type.

- `frontend/components/Entity/CreateModal.vue`: Waits for entity types to finish loading before initializing the create dialog.
- `frontend/components/Entity/Selector.vue`: Handles both item click and model update events to support mobile selection behavior. Deduplicates selection events when the change callback invoked twice.


## Which issue(s) this PR fixes:

Fixes #1617
