### PR TITLE
fix: infinite preference sync feedback loop and default item page size

### DIFF
--- a/frontend/composables/use-preferences.ts
+++ b/frontend/composables/use-preferences.ts
@@ -90,6 +90,10 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+function isPrototypeKey(key: string): boolean {
+  return key === "__proto__" || key === "constructor" || key === "prototype";
+}
+
 function mergeSyncedValue(serverValue: unknown, localValue: unknown, localChange?: PreferenceChange): unknown {
   if (localChange === undefined) {
     return serverValue;
@@ -99,17 +103,23 @@ function mergeSyncedValue(serverValue: unknown, localValue: unknown, localChange
     return localValue;
   }
 
-  const mergedValue: Record<string, unknown> = { ...serverValue };
+  const mergedValue: Record<string, unknown> = {};
   const keys = new Set([...Object.keys(serverValue), ...Object.keys(localValue)]);
 
   for (const key of keys) {
+    if (isPrototypeKey(key)) {
+      continue;
+    }
+
     const nestedChange = localChange[key];
     if (nestedChange !== undefined) {
       mergedValue[key] = mergeSyncedValue(serverValue[key], localValue[key], nestedChange);
       continue;
     }
 
-    if (!(key in mergedValue)) {
+    if (Object.hasOwn(serverValue, key)) {
+      mergedValue[key] = serverValue[key];
+    } else {
       mergedValue[key] = localValue[key];
     }
   }
@@ -147,6 +157,10 @@ function getPreferenceChange(previousValue: unknown, nextValue: unknown): Prefer
     const keys = new Set([...Object.keys(previousValue), ...Object.keys(nextValue)]);
 
     for (const key of keys) {
+      if (isPrototypeKey(key)) {
+        continue;
+      }
+
       const nestedChange = getPreferenceChange(previousValue[key], nextValue[key]);
       if (nestedChange !== null) {
         changedFields[key] = nestedChange;

--- a/frontend/composables/use-preferences.ts
+++ b/frontend/composables/use-preferences.ts
@@ -41,7 +41,7 @@ const DEFAULT_PREFERENCES: LocationViewPreferences = {
   editorAdvancedView: false,
   itemDisplayView: "card",
   theme: "homebox",
-  itemsPerTablePage: 10,
+  itemsPerTablePage: 12,
   displayLegacyHeader: false,
   legacyImageFit: false,
   language: null,

--- a/frontend/composables/use-preferences.ts
+++ b/frontend/composables/use-preferences.ts
@@ -34,6 +34,8 @@ export type LocationViewPreferences = {
   };
 };
 export type PreferenceSyncConfig = Partial<Record<keyof LocationViewPreferences, boolean>>;
+type PreferenceChange = true | Record<string, PreferenceChange>;
+type PreferenceChanges = Partial<Record<keyof LocationViewPreferences, PreferenceChange>>;
 
 const DEFAULT_PREFERENCES: LocationViewPreferences = {
   showDetails: true,
@@ -84,19 +86,95 @@ function buildSyncedSettings(preferences: LocationViewPreferences): Record<strin
   return payload;
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function mergeSyncedValue(serverValue: unknown, localValue: unknown, localChange?: PreferenceChange): unknown {
+  if (localChange === undefined) {
+    return serverValue;
+  }
+
+  if (localChange === true || !isPlainObject(serverValue) || !isPlainObject(localValue)) {
+    return localValue;
+  }
+
+  const mergedValue: Record<string, unknown> = { ...serverValue };
+  const keys = new Set([...Object.keys(serverValue), ...Object.keys(localValue)]);
+
+  for (const key of keys) {
+    const nestedChange = localChange[key];
+    if (nestedChange !== undefined) {
+      mergedValue[key] = mergeSyncedValue(serverValue[key], localValue[key], nestedChange);
+      continue;
+    }
+
+    if (!(key in mergedValue)) {
+      mergedValue[key] = localValue[key];
+    }
+  }
+
+  return mergedValue;
+}
+
 function mergeSyncedSettings(
   settings: Record<string, unknown>,
-  preferences: LocationViewPreferences
+  preferences: LocationViewPreferences,
+  localChanges: PreferenceChanges = {}
 ): LocationViewPreferences {
   const nextPreferences = { ...preferences };
 
   forEachSyncedPreference(key => {
     if (key in settings) {
-      nextPreferences[key] = settings[key] as never;
+      nextPreferences[key] = mergeSyncedValue(settings[key], preferences[key], localChanges[key]) as never;
     }
   });
 
   return nextPreferences;
+}
+
+function cloneSyncedSettings(settings: Record<string, unknown>): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(settings)) as Record<string, unknown>;
+}
+
+function getPreferenceChange(previousValue: unknown, nextValue: unknown): PreferenceChange | null {
+  if (JSON.stringify(previousValue) === JSON.stringify(nextValue)) {
+    return null;
+  }
+
+  if (isPlainObject(previousValue) && isPlainObject(nextValue)) {
+    const changedFields: Record<string, PreferenceChange> = {};
+    const keys = new Set([...Object.keys(previousValue), ...Object.keys(nextValue)]);
+
+    for (const key of keys) {
+      const nestedChange = getPreferenceChange(previousValue[key], nextValue[key]);
+      if (nestedChange !== null) {
+        changedFields[key] = nestedChange;
+      }
+    }
+
+    if (Object.keys(changedFields).length > 0) {
+      return changedFields;
+    }
+  }
+
+  return true;
+}
+
+function getChangedPreferences(
+  previousSettings: Record<string, unknown>,
+  preferences: LocationViewPreferences
+): PreferenceChanges {
+  const changedPreferences: PreferenceChanges = {};
+
+  forEachSyncedPreference(key => {
+    const change = getPreferenceChange(previousSettings[key], preferences[key]);
+    if (change !== null) {
+      changedPreferences[key] = change;
+    }
+  });
+
+  return changedPreferences;
 }
 
 export function configureViewPreferenceSync(config: PreferenceSyncConfig) {
@@ -106,19 +184,19 @@ export function configureViewPreferenceSync(config: PreferenceSyncConfig) {
   };
 }
 
-async function refreshViewPreferencesFromServer(preferences: Ref<LocationViewPreferences>) {
+async function fetchViewPreferencesFromServer(): Promise<Record<string, unknown> | null> {
   const auth = useAuthContext();
   if (!auth.isAuthorized()) {
-    return;
+    return null;
   }
 
   const api = useUserApi();
   const { data, error } = await api.user.getSettings();
   if (error || !data?.item) {
-    return;
+    return null;
   }
 
-  preferences.value = mergeSyncedSettings(data.item, preferences.value);
+  return data.item;
 }
 export function useViewPreferencesSync() {
   if (syncInitialized || !import.meta.client) {
@@ -155,7 +233,7 @@ export function useViewPreferencesSync() {
   };
 
   const saveToServer = async () => {
-    if (saveInFlight || pauseServerSaves || !auth.isAuthorized()) {
+    if (saveInFlight || retryTimer !== null || pauseServerSaves || !auth.isAuthorized()) {
       return;
     }
 
@@ -165,7 +243,14 @@ export function useViewPreferencesSync() {
     try {
       while (syncedRevision < localRevision && !pauseServerSaves && auth.isAuthorized()) {
         const targetRevision = localRevision;
-        const { error } = await api.user.setSettings(buildSyncedSettings(preferences.value));
+        let error = false;
+        try {
+          ({ error } = await api.user.setSettings(buildSyncedSettings(preferences.value)));
+        } catch {
+          scheduleRetry();
+          return;
+        }
+
         if (error) {
           scheduleRetry();
           return;
@@ -176,7 +261,7 @@ export function useViewPreferencesSync() {
     } finally {
       saveInFlight = false;
 
-      if (syncedRevision < localRevision && !pauseServerSaves) {
+      if (syncedRevision < localRevision && retryTimer === null && !pauseServerSaves) {
         void saveToServer();
       }
     }
@@ -196,15 +281,22 @@ export function useViewPreferencesSync() {
     try {
       while (refreshRequested) {
         refreshRequested = false;
+        const refreshRevision = localRevision;
+        const refreshSettings = cloneSyncedSettings(buildSyncedSettings(preferences.value));
 
         pauseServerSaves = true;
-        applyingServerSnapshot = true;
         try {
-          await refreshViewPreferencesFromServer(preferences);
+          const settings = await fetchViewPreferencesFromServer();
+          if (settings) {
+            const localChanges =
+              localRevision === refreshRevision ? {} : getChangedPreferences(refreshSettings, preferences.value);
+            applyingServerSnapshot = true;
+            preferences.value = mergeSyncedSettings(settings, preferences.value, localChanges);
+          }
         } finally {
           applyingServerSnapshot = false;
+          pauseServerSaves = false;
         }
-        pauseServerSaves = false;
 
         if (syncedRevision < localRevision) {
           await saveToServer();
@@ -224,7 +316,7 @@ export function useViewPreferencesSync() {
 
       markDirty();
     },
-    { deep: true }
+    { deep: true, flush: "sync" }
   );
 
   watch(


### PR DESCRIPTION
## What type of PR is this?

- bug
- cleanup

## What this PR does / why we need it:

This PR fixes the infinite loop issue involving requests to `v1/users/self/settings`, which  occurs when settings are modified under poor network conditions (when the request takes longer than 1s). It can be reproduced by setting the network throttling to 3G in Chrome DevTools. 

It also sets default item page size to 12. The default page size is 10 but the available options are 12/24/48/96. Also, setting the page size to 10 leaves empty space at the end when each row displays 3 or 4 cards.

- `frontend/composables/use-preferences.ts`: 
   - Changes the default item page size from 10 to 12.
   - Uses a synchronous watcher so server snapshots are not treated as local changes, preventing an infinite preference sync feedback loop.
   
## Which issue(s) this PR fixes:

Fixes a  bug related to #1617 

## Special notes for your reviewer:

This PR fixes another bug mentioned in #1617 , but not the main one.
