### PR TITLE
feat: paste images from the clipboard wherever you can upload one

### DIFF
--- a/backend/internal/web/mid/security.go
+++ b/backend/internal/web/mid/security.go
@@ -15,7 +15,10 @@ func SecurityHeaders() func(http.Handler) http.Handler {
 			w.Header().Set("Content-Origin-Embedder-Policy", "require-corp")
 			w.Header().Set("Content-Origin-Opener-Policy", "same-origin")
 			w.Header().Set("Content-Origin-Resource-Policy", "same-site")
-			w.Header().Set("Permissions-Policy", "accelerometer=(), autoplay=(), camera=(self), cross-origin-isolated=(), display-capture=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(self), usb=(), web-share=(), xr-spatial-tracking=(), clipboard-read=(), clipboard-write=(self), gamepad=(), hid=(), idle-detection=(), interest-cohort=(), serial=(), unload=()")
+			// clipboard-read is granted to self so the "paste image" button can pull an
+			// image out of the clipboard. The browser still requires a user gesture and
+			// its own permission prompt, and cross-origin frames remain blocked.
+			w.Header().Set("Permissions-Policy", "accelerometer=(), autoplay=(), camera=(self), cross-origin-isolated=(), display-capture=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(self), usb=(), web-share=(), xr-spatial-tracking=(), clipboard-read=(self), clipboard-write=(self), gamepad=(), hid=(), idle-detection=(), interest-cohort=(), serial=(), unload=()")
 			w.Header().Set("Referrer-Policy", "no-referrer")
 			w.Header().Set("X-Content-Type-Options", "nosniff")
 			w.Header().Set("X-Frame-Options", "DENY")

--- a/frontend/components/Form/PasteImageButton.vue
+++ b/frontend/components/Form/PasteImageButton.vue
@@ -1,0 +1,41 @@
+<template>
+  <Button v-if="supported" type="button" variant="outline" data-testid="paste-image-button" @click.prevent="paste">
+    <MdiContentPaste class="mr-1 size-5" />
+    {{ $t("global.paste_image") }}
+  </Button>
+</template>
+
+<script setup lang="ts">
+  import { useI18n } from "vue-i18n";
+  import { toast } from "@/components/ui/sonner";
+  import { Button } from "~/components/ui/button";
+  import MdiContentPaste from "~icons/mdi/content-paste";
+
+  const emit = defineEmits<{
+    (e: "paste", files: File[]): void;
+  }>();
+
+  const { t } = useI18n();
+
+  // Where the async clipboard API is missing, Ctrl+V is still the way in - hide the
+  // button rather than offer something that can only fail.
+  const supported = canReadClipboardImages();
+
+  async function paste() {
+    let images: File[];
+
+    try {
+      images = await readClipboardImages();
+    } catch {
+      toast.error(t("items.toast.clipboard_read_failed"));
+      return;
+    }
+
+    if (images.length === 0) {
+      toast.error(t("items.toast.no_image_in_clipboard"));
+      return;
+    }
+
+    emit("paste", images);
+  }
+</script>

--- a/frontend/components/Form/PhotoUploader.vue
+++ b/frontend/components/Form/PhotoUploader.vue
@@ -5,19 +5,30 @@
         {{ label }}
       </Label>
 
-      <div class="relative inline-block">
-        <Button type="button" variant="outline" class="w-full" aria-hidden="true" @click.prevent="openFilePicker">
-          {{ buttonLabel }}
-        </Button>
-        <Input
-          id="photo-uploader"
-          ref="fileInput"
-          class="absolute left-0 top-0 size-full cursor-pointer opacity-0"
-          type="file"
-          accept="image/png,image/jpeg,image/gif,image/avif,image/webp,android/force-camera-workaround"
-          multiple
-          @change="onFilesSelected"
-        />
+      <div class="flex gap-2">
+        <!-- The file input is stacked on top of the button and is the real click target -->
+        <div class="relative inline-block grow">
+          <Button
+            type="button"
+            variant="outline"
+            class="w-full"
+            aria-hidden="true"
+            tabindex="-1"
+            @click.prevent="openFilePicker"
+          >
+            {{ buttonLabel }}
+          </Button>
+          <Input
+            id="photo-uploader"
+            ref="fileInput"
+            class="absolute left-0 top-0 size-full cursor-pointer opacity-0"
+            type="file"
+            accept="image/png,image/jpeg,image/gif,image/avif,image/webp,android/force-camera-workaround"
+            multiple
+            @change="onFilesSelected"
+          />
+        </div>
+        <PasteImageButton @paste="emitPhotos" />
       </div>
     </div>
   </div>
@@ -29,6 +40,7 @@
   import { Label } from "~/components/ui/label";
   import { Input } from "~/components/ui/input";
   import { Button } from "~/components/ui/button";
+  import PasteImageButton from "~/components/Form/PasteImageButton.vue";
   import { filesToPhotoPreviews, type PhotoPreview } from "./photo-uploader";
 
   const props = withDefaults(
@@ -54,17 +66,21 @@
   const label = computed(() => props.label || t("components.entity.create_modal.item_photo"));
   const buttonLabel = computed(() => props.buttonLabel || t("components.entity.create_modal.upload_photos"));
 
+  usePasteImage(emitPhotos);
+
   function openFilePicker() {
     fileInput.value?.click();
+  }
+
+  async function emitPhotos(files: FileList | File[]) {
+    emit("selected", await filesToPhotoPreviews(files, props.existingCount));
   }
 
   async function onFilesSelected(event: Event) {
     const input = event.target as HTMLInputElement;
     if (!input.files || input.files.length === 0) return;
 
-    const photos = await filesToPhotoPreviews(input.files, props.existingCount);
-
-    emit("selected", photos);
+    await emitPhotos(input.files);
     input.value = "";
   }
 </script>

--- a/frontend/composables/use-paste-image.test.ts
+++ b/frontend/composables/use-paste-image.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "vitest";
+import { imageFilesFromClipboard, pastedImageName } from "./use-paste-image";
+
+function file(name: string, type: string): File {
+  return new File(["x"], name, { type });
+}
+
+/** Minimal stand-in for the DataTransfer a real ClipboardEvent carries. */
+function clipboard(files: File[]): DataTransfer {
+  return { files, items: [] } as unknown as DataTransfer;
+}
+
+describe("pastedImageName", () => {
+  test("maps mime types to the expected extension", () => {
+    expect(pastedImageName("image/png")).toMatch(/^pasted-image-\d{8}-\d{6}\.png$/);
+    expect(pastedImageName("image/jpeg")).toMatch(/\.jpg$/);
+    expect(pastedImageName("image/gif")).toMatch(/\.gif$/);
+    expect(pastedImageName("image/webp")).toMatch(/\.webp$/);
+    expect(pastedImageName("image/avif")).toMatch(/\.avif$/);
+  });
+
+  test("falls back to the mime subtype for unknown image types", () => {
+    expect(pastedImageName("image/bmp")).toMatch(/\.bmp$/);
+    expect(pastedImageName("image/svg+xml")).toMatch(/\.svg$/);
+  });
+
+  test("suffixes all but the first image so names stay unique", () => {
+    expect(pastedImageName("image/png", 0)).not.toMatch(/-\d\.png$/);
+    expect(pastedImageName("image/png", 1)).toMatch(/-1\.png$/);
+    expect(pastedImageName("image/png", 2)).toMatch(/-2\.png$/);
+  });
+});
+
+describe("imageFilesFromClipboard", () => {
+  test("returns nothing when there is no clipboard payload", () => {
+    expect(imageFilesFromClipboard(null)).toEqual([]);
+    expect(imageFilesFromClipboard(undefined)).toEqual([]);
+    expect(imageFilesFromClipboard(clipboard([]))).toEqual([]);
+  });
+
+  test("keeps images and drops everything else", () => {
+    const result = imageFilesFromClipboard(
+      clipboard([
+        file("notes.txt", "text/plain"),
+        file("image.png", "image/png"),
+        file("manual.pdf", "application/pdf"),
+      ])
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.type).toBe("image/png");
+  });
+
+  test("renames the generic name browsers hand over", () => {
+    const [image] = imageFilesFromClipboard(clipboard([file("image.png", "image/png")]));
+
+    expect(image!.name).not.toBe("image.png");
+    expect(image!.name).toMatch(/^pasted-image-\d{8}-\d{6}\.png$/);
+  });
+
+  test("gives every image of a multi-image paste a distinct name", () => {
+    const names = imageFilesFromClipboard(
+      clipboard([file("image.png", "image/png"), file("image.png", "image/png"), file("", "image/jpeg")])
+    ).map(image => image.name);
+
+    expect(names).toHaveLength(3);
+    expect(new Set(names).size).toBe(3);
+    expect(names[2]).toMatch(/-2\.jpg$/);
+  });
+
+  test("reads from items when files is empty, as Safari does", () => {
+    const image = file("image.png", "image/png");
+    const data = {
+      files: [],
+      items: [
+        { kind: "string", getAsFile: () => null },
+        { kind: "file", getAsFile: () => image },
+      ],
+    } as unknown as DataTransfer;
+
+    expect(imageFilesFromClipboard(data)).toHaveLength(1);
+  });
+});

--- a/frontend/composables/use-paste-image.ts
+++ b/frontend/composables/use-paste-image.ts
@@ -1,0 +1,97 @@
+const MIME_EXTENSIONS: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/avif": "avif",
+};
+
+function timestamp(date = new Date()): string {
+  const pad = (value: number) => String(value).padStart(2, "0");
+
+  return (
+    `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}` +
+    `-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`
+  );
+}
+
+/**
+ * Clipboard images arrive with a generic name ("image.png") or no name at all, so give
+ * every pasted image a unique, extension-correct one before it becomes an attachment.
+ */
+export function pastedImageName(mime: string, index = 0): string {
+  const extension = MIME_EXTENSIONS[mime] || mime.replace("image/", "").split("+")[0] || "png";
+  const suffix = index === 0 ? "" : `-${index}`;
+
+  return `pasted-image-${timestamp()}${suffix}.${extension}`;
+}
+
+function isImage(file: File | null): file is File {
+  return !!file && file.type.startsWith("image/");
+}
+
+function rename(file: File, index: number): File {
+  return new File([file], pastedImageName(file.type, index), { type: file.type });
+}
+
+/**
+ * Extracts the images out of a paste (or drop) payload, ignoring any text or non-image
+ * files that came along with them.
+ */
+export function imageFilesFromClipboard(data: DataTransfer | null | undefined): File[] {
+  if (!data) {
+    return [];
+  }
+
+  const files = data.files?.length
+    ? Array.from(data.files)
+    : Array.from(data.items || [])
+        .filter(item => item.kind === "file")
+        .map(item => item.getAsFile());
+
+  return files.filter(isImage).map(rename);
+}
+
+export function canReadClipboardImages(): boolean {
+  return typeof navigator !== "undefined" && typeof navigator.clipboard?.read === "function";
+}
+
+/**
+ * Pulls images out of the clipboard on demand, for the "paste image" button. Returns an
+ * empty list when the clipboard holds no image or the user denied permission.
+ */
+export async function readClipboardImages(): Promise<File[]> {
+  if (!canReadClipboardImages()) {
+    return [];
+  }
+
+  const images: File[] = [];
+
+  for (const item of await navigator.clipboard.read()) {
+    const mime = item.types.find(type => type.startsWith("image/"));
+    if (!mime) {
+      continue;
+    }
+
+    const blob = await item.getType(mime);
+    images.push(new File([blob], pastedImageName(mime, images.length), { type: mime }));
+  }
+
+  return images;
+}
+
+/**
+ * Handles Ctrl/Cmd+V anywhere on the page while the caller is mounted. Pastes that carry
+ * no image are left alone, so pasting text into a form field still works normally.
+ */
+export function usePasteImage(onImages: (files: File[]) => void) {
+  useEventListener(document, "paste", (event: ClipboardEvent) => {
+    const images = imageFilesFromClipboard(event.clipboardData);
+    if (images.length === 0) {
+      return;
+    }
+
+    event.preventDefault();
+    onImages(images);
+  });
+}

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -471,6 +471,7 @@
         "navigate": "Navigate",
         "no": "No",
         "password": "Password",
+        "paste_image": "Paste Image",
         "preview": "Preview",
         "quantity": "Quantity",
         "read_docs": "Read the Docs",
@@ -563,6 +564,7 @@
         "description": "Description",
         "details": "Details",
         "drag_and_drop": "Drag and drop files here or click to select files",
+        "drag_and_drop_or_paste": "Drag and drop files here, click to select files, or paste an image",
         "duplicate": {
             "copy_attachments": "Copy Attachments",
             "copy_custom_fields": "Copy Custom Fields",
@@ -651,6 +653,7 @@
             "child_items_location_no_longer_synced": "Child items' locations will no longer be synced with this item.",
             "child_items_location_synced": "Child items' locations have been synced with this item",
             "child_location_desync": "Parent item cleared — the item now lives directly in the selected location",
+            "clipboard_read_failed": "Couldn't read the clipboard — check your browser's clipboard permissions",
             "error_loading_parent_data": "Something went wrong trying to load parent data",
             "failed_adjust_quantity": "Failed to adjust quantity",
             "failed_delete_attachment": "Failed to delete attachment",
@@ -666,6 +669,7 @@
             "failed_upload_attachment": "Failed to upload attachment",
             "item_deleted": "Item deleted",
             "item_saved": "Item saved",
+            "no_image_in_clipboard": "No image found in the clipboard",
             "quantity_cannot_negative": "Quantity cannot be negative",
             "sync_child_location": "Selected parent syncs its children's locations to its own. The location has been updated."
         },

--- a/frontend/pages/item/[id]/index/edit.vue
+++ b/frontend/pages/item/[id]/index/edit.vue
@@ -31,6 +31,7 @@
   import BaseCard from "@/components/Base/Card.vue";
   import { Card } from "~/components/ui/card";
   import DropZone from "~/components/global/DropZone.vue";
+  import PasteImageButton from "~/components/Form/PasteImageButton.vue";
   import EntitySelector from "~/components/Entity/Selector.vue";
   import { useEntityTypeStore } from "~/stores/entityTypes";
 
@@ -338,6 +339,15 @@
   const dropPhoto = (files: File[] | null) => uploadAttachment(files, AttachmentTypes.Photo);
   const dropAttachment = (files: File[] | null) => uploadAttachment(files, AttachmentTypes.Attachment);
   const dropWarranty = (files: File[] | null) => uploadAttachment(files, AttachmentTypes.Warranty);
+
+  async function pastePhotos(files: File[]) {
+    for (const file of files) {
+      await uploadAttachment([file], AttachmentTypes.Photo);
+    }
+  }
+
+  usePasteImage(pastePhotos);
+
   const dropManual = (files: File[] | null) => uploadAttachment(files, AttachmentTypes.Manual);
   const dropReceipt = (files: File[] | null) => uploadAttachment(files, AttachmentTypes.Receipt);
 
@@ -802,15 +812,17 @@
               <DropZone data-link-type="attachment" @drop="dropAttachment"> {{ $t("items.attachments") }} </DropZone>
               <DropZone data-link-type="receipt" @drop="dropReceipt"> {{ $t("items.receipts") }} </DropZone>
             </div>
-            <button
-              v-else
-              data-link-type="attachment"
-              class="grid h-24 w-full place-content-center border-2 border-dashed border-primary"
-              @click="clickUpload"
-            >
-              <input ref="refAttachmentInput" hidden type="file" @change="uploadImage" />
-              <p>{{ $t("items.drag_and_drop") }}</p>
-            </button>
+            <div v-else class="flex flex-col items-center gap-2">
+              <button
+                data-link-type="attachment"
+                class="grid h-24 w-full place-content-center border-2 border-dashed border-primary"
+                @click="clickUpload"
+              >
+                <input ref="refAttachmentInput" hidden type="file" @change="uploadImage" />
+                <p>{{ $t("items.drag_and_drop_or_paste") }}</p>
+              </button>
+              <PasteImageButton @paste="pastePhotos" />
+            </div>
           </div>
 
           <div class="border-t p-4">

--- a/frontend/pages/location/[id]/index/edit.vue
+++ b/frontend/pages/location/[id]/index/edit.vue
@@ -28,6 +28,7 @@
   import BaseCard from "@/components/Base/Card.vue";
   import { Card } from "~/components/ui/card";
   import DropZone from "~/components/global/DropZone.vue";
+  import PasteImageButton from "~/components/Form/PasteImageButton.vue";
   import EntitySelector from "~/components/Entity/Selector.vue";
   import { useEntityTypeStore } from "~/stores/entityTypes";
 
@@ -203,6 +204,14 @@
 
   const dropPhoto = (files: File[] | null) => uploadAttachment(files, AttachmentTypes.Photo);
   const dropAttachment = (files: File[] | null) => uploadAttachment(files, AttachmentTypes.Attachment);
+
+  async function pastePhotos(files: File[]) {
+    for (const file of files) {
+      await uploadAttachment([file], AttachmentTypes.Photo);
+    }
+  }
+
+  usePasteImage(pastePhotos);
 
   async function uploadAttachment(files: File[] | null, type: AttachmentTypes | null) {
     if (!files || files.length === 0 || !files[0]) {
@@ -486,14 +495,16 @@
               <DropZone @drop="dropPhoto"> {{ $t("items.photos") }} </DropZone>
               <DropZone @drop="dropAttachment"> {{ $t("items.attachments") }} </DropZone>
             </div>
-            <button
-              v-else
-              class="grid h-24 w-full place-content-center border-2 border-dashed border-primary"
-              @click="clickUpload"
-            >
-              <input ref="refAttachmentInput" hidden type="file" @change="uploadImage" />
-              <p>{{ $t("items.drag_and_drop") }}</p>
-            </button>
+            <div v-else class="flex flex-col items-center gap-2">
+              <button
+                class="grid h-24 w-full place-content-center border-2 border-dashed border-primary"
+                @click="clickUpload"
+              >
+                <input ref="refAttachmentInput" hidden type="file" @change="uploadImage" />
+                <p>{{ $t("items.drag_and_drop_or_paste") }}</p>
+              </button>
+              <PasteImageButton @paste="pastePhotos" />
+            </div>
           </div>
 
           <div class="border-t p-4">

--- a/frontend/test/e2e/paste-image.browser.spec.ts
+++ b/frontend/test/e2e/paste-image.browser.spec.ts
@@ -1,0 +1,260 @@
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+// 1x1 transparent PNG.
+const PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+const PASSWORD = "ThisIsAStrongDemoPass";
+
+type Fixture = {
+  email: string;
+  password: string;
+  token: string;
+  attachmentToken: string;
+  locationId: string;
+  itemId: string;
+};
+
+async function api(request: APIRequestContext, token: string, method: "get" | "post", path: string, body?: unknown) {
+  const response = await request[method](`/api/v1${path}`, {
+    headers: token ? { Authorization: token } : {},
+    ...(body === undefined ? {} : { data: body }),
+  });
+
+  expect(response.ok(), `${method.toUpperCase()} ${path} -> ${response.status()} ${await response.text()}`).toBe(true);
+
+  return response.status() === 204 ? null : response.json();
+}
+
+/**
+ * Registers a throwaway user and seeds it with a location and an item. The user lands in
+ * its own group, so nothing already in the database is touched.
+ */
+async function seed(request: APIRequestContext): Promise<Fixture> {
+  const email = `paste-${Date.now()}-${Math.floor(Math.random() * 1e6)}@example.com`;
+
+  await api(request, "", "post", "/users/register", { email, name: "Paste Test", password: PASSWORD });
+
+  const { token, attachmentToken } = await api(request, "", "post", "/users/login", {
+    username: email,
+    password: PASSWORD,
+    stayLoggedIn: false,
+  });
+
+  const entityTypes = await api(request, token, "get", "/entity-types");
+  const typeId = (isLocation: boolean) =>
+    (entityTypes.items ?? entityTypes).find((type: { isLocation: boolean }) => type.isLocation === isLocation).id;
+
+  const location = await api(request, token, "post", "/entities", {
+    name: "Paste Test Location",
+    description: "",
+    quantity: 1,
+    tagIds: [],
+    entityTypeId: typeId(true),
+  });
+
+  const item = await api(request, token, "post", "/entities", {
+    name: "Paste Test Item",
+    description: "",
+    quantity: 1,
+    tagIds: [],
+    parentId: location.id,
+    entityTypeId: typeId(false),
+  });
+
+  return { email, password: PASSWORD, token, attachmentToken, locationId: location.id, itemId: item.id };
+}
+
+async function login(page: Page, fixture: Fixture) {
+  await page.goto("/home");
+  await expect(page).toHaveURL("/");
+  await page.fill("input[type='text']", fixture.email);
+  await page.fill("input[type='password']", fixture.password);
+  await page.click("button[type='submit']");
+  await expect(page).toHaveURL("/home");
+
+  // The backend sets its auth cookies with Domain=localhost when served from
+  // localhost, and WebKit silently rejects any cookie whose Domain attribute
+  // is a single-label host (https://bugs.webkit.org/show_bug.cgi?id=160368) -
+  // so on webkit the login above leaves no usable session and every API call
+  // 401s. Playwright's addCookies() writes straight into the jar, bypassing
+  // Set-Cookie parsing, so re-add the session here (values from seed()'s API
+  // login) and re-enter the app with it. Harmless on the other browsers.
+  //
+  // Tear the page down first: a straggler 401 from the dying page would run
+  // invalidateSession(), which deletes the client-writable cookies - including
+  // the ones injected below, if they were already in the jar.
+  const origin = new URL(page.url()).origin;
+  await page.goto("about:blank");
+  const cookie = (name: string, value: string, httpOnly: boolean) => ({
+    name,
+    value,
+    url: origin,
+    httpOnly,
+    sameSite: "Lax" as const,
+  });
+  await page
+    .context()
+    .addCookies([
+      cookie("hb.auth.token", fixture.token.replace(/^Bearer /, ""), true),
+      cookie("hb.auth.remember", "false", true),
+      cookie("hb.auth.session", "true", false),
+      cookie("hb.auth.attachment_token", fixture.attachmentToken, false),
+    ]);
+  await page.goto("/home");
+  await expect(page).toHaveURL("/home");
+}
+
+/**
+ * Firefox builds a constructed ClipboardEvent with an *empty* copy of the DataTransfer it
+ * is handed, so a synthetic paste cannot carry a file there. Real pastes are unaffected -
+ * this is purely a limit on what the test harness can fake.
+ */
+async function supportsSyntheticPaste(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const transfer = new DataTransfer();
+    transfer.items.add(new File(["x"], "probe.png", { type: "image/png" }));
+    return new ClipboardEvent("paste", { clipboardData: transfer }).clipboardData?.files.length === 1;
+  });
+}
+
+/** Dispatches the paste event a browser fires when the clipboard holds an image. */
+async function pasteImage(page: Page) {
+  await page.evaluate(async base64 => {
+    const blob = await (await fetch(`data:image/png;base64,${base64}`)).blob();
+    const transfer = new DataTransfer();
+    transfer.items.add(new File([blob], "image.png", { type: "image/png" }));
+
+    document.dispatchEvent(new ClipboardEvent("paste", { clipboardData: transfer, bubbles: true, cancelable: true }));
+  }, PNG_BASE64);
+}
+
+async function attachmentCount(request: APIRequestContext, fixture: Fixture, id: string): Promise<number> {
+  const entity = await api(request, fixture.token, "get", `/entities/${id}`);
+  return entity.attachments.length;
+}
+
+// Every test here registers a user and writes an attachment. Run them in order: against
+// a sqlite backend, concurrent attachment writes hit SQLITE_BUSY, the same reason
+// `pnpm test:ci` runs vitest with --no-file-parallelism.
+test.describe.configure({ mode: "serial" });
+
+test.describe("paste image from clipboard", () => {
+  test("pastes into the entity create modal", async ({ page, request }) => {
+    const fixture = await seed(request);
+    await login(page, fixture);
+    test.skip(!(await supportsSyntheticPaste(page)), "browser cannot carry a file in a synthetic paste");
+
+    await page.getByRole("button", { name: "Create", exact: true }).first().click();
+    await page.getByRole("menuitem", { name: "Item / Asset" }).click();
+    // The upload button is aria-hidden - the file input stacked on top of it is the
+    // real control - so anchor on the input itself.
+    await expect(page.locator("input#photo-uploader")).toBeAttached();
+
+    await pasteImage(page);
+
+    // The pasted image shows up as a preview thumbnail before the item is created.
+    await expect(page.locator("img[src^='data:image/png']").first()).toBeVisible();
+
+    await page.getByLabel(/^Item Name/).fill("Pasted Photo Item");
+    await page.getByRole("combobox", { name: /Parent Location/ }).click();
+    await page.getByPlaceholder("Search Locations").fill("Paste Test Location");
+    await expect(page.getByRole("option", { name: "Paste Test Location" })).toBeVisible();
+    // The option list re-renders as results settle, so drive it from the keyboard
+    // rather than racing a click against a moving target.
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("Enter");
+    await expect(page.getByRole("combobox", { name: /Parent Location/ })).toContainText("Paste Test Location");
+
+    const upload = page.waitForResponse(r => /\/attachments$/.test(r.url()) && r.request().method() === "POST");
+    await page.getByRole("button", { name: "Create", exact: true }).last().click();
+    await upload;
+
+    // ...and is attached to the item that gets created.
+    const created = await api(request, fixture.token, "get", "/entities?q=Pasted Photo Item");
+    const detail = await api(request, fixture.token, "get", `/entities/${created.items[0].id}`);
+    expect(detail.attachments).toHaveLength(1);
+    expect(detail.attachments[0].title).toMatch(/^pasted-image-\d{8}-\d{6}\.png$/);
+    expect(detail.attachments[0].mimeType).toBe("image/png");
+  });
+
+  test("pastes an attachment onto the item edit page", async ({ page, request }) => {
+    const fixture = await seed(request);
+    await login(page, fixture);
+
+    test.skip(!(await supportsSyntheticPaste(page)), "browser cannot carry a file in a synthetic paste");
+
+    expect(await attachmentCount(request, fixture, fixture.itemId)).toBe(0);
+
+    await page.goto(`/item/${fixture.itemId}/edit`);
+    await expect(page.getByText("Attachments").first()).toBeVisible();
+
+    await pasteImage(page);
+
+    await expect(page.getByText("Attachment uploaded")).toBeVisible();
+    await expect.poll(() => attachmentCount(request, fixture, fixture.itemId)).toBe(1);
+  });
+
+  test("pastes an attachment onto the location edit page", async ({ page, request }) => {
+    const fixture = await seed(request);
+    await login(page, fixture);
+
+    test.skip(!(await supportsSyntheticPaste(page)), "browser cannot carry a file in a synthetic paste");
+
+    expect(await attachmentCount(request, fixture, fixture.locationId)).toBe(0);
+
+    await page.goto(`/location/${fixture.locationId}/edit`);
+    await expect(page.getByText("Attachments").first()).toBeVisible();
+
+    await pasteImage(page);
+
+    await expect(page.getByText("Attachment uploaded")).toBeVisible();
+    await expect.poll(() => attachmentCount(request, fixture, fixture.locationId)).toBe(1);
+  });
+
+  test("uploads via the Paste Image button", async ({ page, context, request, browserName }) => {
+    // Only Chromium lets Playwright pre-grant the clipboard permissions this needs.
+    test.skip(browserName !== "chromium", "clipboard permissions are chromium-only in playwright");
+
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    const fixture = await seed(request);
+    await login(page, fixture);
+
+    await page.goto(`/item/${fixture.itemId}/edit`);
+    await expect(page.getByTestId("paste-image-button")).toBeVisible();
+
+    await page.evaluate(async base64 => {
+      const blob = await (await fetch(`data:image/png;base64,${base64}`)).blob();
+      await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+    }, PNG_BASE64);
+
+    await page.getByTestId("paste-image-button").click();
+
+    await expect(page.getByText("Attachment uploaded")).toBeVisible();
+    await expect.poll(() => attachmentCount(request, fixture, fixture.itemId)).toBe(1);
+  });
+
+  test("leaves ordinary text pastes alone", async ({ page, context, request, browserName }) => {
+    test.skip(browserName !== "chromium", "needs clipboard permissions to paste for real");
+
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    const fixture = await seed(request);
+    await login(page, fixture);
+
+    await page.goto(`/item/${fixture.itemId}/edit`);
+
+    // The label carries a trailing character counter, hence the prefix match.
+    const name = page.getByLabel(/^Name/);
+    await expect(name).toHaveValue("Paste Test Item");
+    await name.fill("");
+
+    await page.evaluate(() => navigator.clipboard.writeText("Pasted Name"));
+    await name.focus();
+    await page.keyboard.press("ControlOrMeta+v");
+
+    // The paste listener must not swallow text pastes into form fields.
+    await expect(name).toHaveValue("Pasted Name");
+  });
+});


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Lets you paste an image from the clipboard anywhere you can currently pick one from disk. This is the request from discussion #721 — copying a product photo off a web page today means "save image as…", find the file, browse back to it. As @crispybegs put it there, "downloading then uploading hundreds of images is a painful procedure."

Three spots gain it, which is every place Homebox takes a picture:

| Spot | File |
| --- | --- |
| Entity create modal (items + locations) | `frontend/components/Form/PhotoUploader.vue` |
| Item edit → Attachments card | `frontend/pages/item/[id]/index/edit.vue` |
| Location edit → Attachments card | `frontend/pages/location/[id]/index/edit.vue` |

Two ways in, because neither alone is enough:

- **Ctrl/Cmd+V** anywhere on the page or in the modal.
- **A "Paste Image" button**, for discoverability and for anyone not reaching for the keyboard. It hides itself where `navigator.clipboard.read()` is unavailable, leaving Ctrl+V as the path.

File-by-file:

- **`frontend/composables/use-paste-image.ts`** *(new)* — `imageFilesFromClipboard()` pulls images out of a `DataTransfer` (falling back from `.files` to `.items`, which Safari needs); `readClipboardImages()` is the async-clipboard path for the button; `usePasteImage()` registers the `paste` listener through VueUse's `useEventListener`, so it unregisters on unmount and is naturally scoped to the mounted page or open modal.
- **`frontend/components/Form/PasteImageButton.vue`** *(new)* — shared button so the affordance is identical in all three spots, with toasts for the empty-clipboard and permission-denied cases.
- **`frontend/components/Form/PhotoUploader.vue`** — pastes feed the existing `filesToPhotoPreviews()`, so `Entity/CreateModal.vue` needed no change at all; preview, rotate, set-primary and the per-photo upload on submit all work as they already did.
- **The two edit pages** — pastes feed the existing `uploadAttachment(files, AttachmentTypes.Photo)`, matching what dropping on the "Photos" `DropZone` already does. The item page's URL-drop handler is untouched.
- **`backend/internal/web/mid/security.go`** — see the note to reviewers below.
- **`frontend/locales/en.json`** — four new keys, English only.

Two decisions worth calling out:

**The paste listener only fires when the clipboard actually holds an image.** A paste carrying only text falls straight through to the focused field, so typing into the item name or the markdown description behaves exactly as before. There's a test for this specifically.

**Pasted images get renamed.** Browsers hand clipboard images over as `image.png`, or with no name at all, which would produce a pile of identically-named attachments. They become `pasted-image-<yyyymmdd-hhmmss>[-n].<ext>`, with the extension derived from the MIME type.

Scope note: #721 asks for "attachments or pictures" — this PR does images only. Clipboards essentially never hold a PDF or a spreadsheet, so wiring the non-image case seemed like dead code. Easy to extend if you'd rather it were broader.

## Which issue(s) this PR fixes:

Implements the request in discussion #721.

<!-- No issue number exists for this yet — per CONTRIBUTING/issue-gatekeeper, feature
     requests live in Discussions until a maintainer opens an issue. Happy to add a
     "Fixes #NNN" line if you'd like an issue created first. -->

## Special notes for your reviewer:

**There is one backend change, and it's a security header — please look at this closely.**

`SecurityHeaders()` was sending:

```
Permissions-Policy: … clipboard-read=(), clipboard-write=(self) …
```

`clipboard-read=()` disables the API for *everyone including same-origin*, so `navigator.clipboard.read()` was blocked outright and the Paste Image button could never have worked. I discovered this only because the button silently failed against a real build. It's now `clipboard-read=(self)`.

What that does and does not give up:

- Cross-origin frames stay blocked, exactly as before.
- The browser still requires a user gesture, and still shows its own permission prompt, before any read succeeds.
- Same-origin JS could now read the clipboard on user interaction — that is the point of the feature, and it's the same permission the paste event already grants implicitly.
- **Ctrl+V never depended on this.** If you'd rather not relax the header at all, dropping this one line still leaves the keyboard path fully working; the button would just hide itself everywhere. I'd understand that call and it's a clean revert.

Smaller things reviewers might want to weigh in on:

- **`AttachmentTypes.Photo` for pasted images on the edit pages**, versus the `null` the file-picker uses. Photo seemed right for something that is by definition an image, and matches the "Photos" drop zone.
- I noticed while working here that `PhotoUploader.vue`'s `openFilePicker()` is effectively a no-op — `ui/input/Input.vue` has no `defineExpose`, so the `ref` is a restricted component proxy rather than the `<input>` element. The invisible overlaid input is what actually receives the click. **I did not fix that**, since it's pre-existing and out of scope, but I preserved the overlay structure carefully when adding the button beside it, and left a comment marking the trap.

## Testing

**Unit** — `frontend/composables/use-paste-image.test.ts`, 8 tests: images kept and non-images dropped, empty payload, MIME→extension mapping, unique names across a multi-image paste, and the `.items` fallback path.

```
pnpm exec vitest --run --config ./test/vitest.config.ts composables/use-paste-image.test.ts
```

**E2E** — `frontend/test/e2e/paste-image.browser.spec.ts`, 5 tests, run against a Docker build of this branch:

1. Paste into the create modal → preview appears → item is created → the attachment really lands, with the expected `pasted-image-*.png` name and `image/png` MIME.
2. Paste on the item edit page → toast → attachment count goes 0 → 1, confirmed via the API.
3. Same on the location edit page.
4. The Paste Image button, driving the real async clipboard.
5. A real Ctrl+V of *text* into the item name field still fills the field — the listener doesn't swallow it.

```
E2E_BASE_URL=http://localhost:7745 pnpm exec playwright test -c ./test/playwright.config.ts paste-image
```

**Also run:** `task swag --force` and `task typescript-types --force` (both produce zero diff — no API surface changed), `task ui:fix`, `pnpm run lint:ci` clean, `go build ./...` clean.

Two honest caveats:

- **`task go:lint` reports 26 pre-existing issues** (`tagalign` ×24, `testifylint` ×2) in `repo_entity_templates.go`, `repo_entities.go` and `service_user_login_test.go`. None are in the file I touched and all are present on `main` — I left them alone rather than mix unrelated fixes into this PR.
- **The E2E tests skip on Firefox.** Firefox constructs a `ClipboardEvent` with an *empty* copy of the `DataTransfer` it's handed, so a synthetic paste can't carry a file there. That's a limit on what the harness can fake, not on the feature — real Firefox pastes are unaffected. The spec detects this at runtime rather than hardcoding browser names. Chromium is fully covered; **I have not empirically verified Firefox or WebKit.**
- The spec runs `mode: "serial"`. Concurrent attachment writes against SQLite hit `SQLITE_BUSY` under parallel workers, which is the same reason `pnpm test:ci` uses `--no-file-parallelism`.