### PR TITLE
feat: opt-in found item contact page (resolves #13)

### DIFF
--- a/backend/app/api/app.go
+++ b/backend/app/api/app.go
@@ -21,6 +21,8 @@ type app struct {
 	bus                 *eventbus.EventBus
 	authLimiter         *authRateLimiter
 	notifierTestLimiter *simpleRateLimiter
+	foundLimiter        *simpleRateLimiter
+	foundSendLimiter    *simpleRateLimiter
 	otel                *otel.Provider
 }
 
@@ -39,6 +41,14 @@ func new(conf *config.Config) *app {
 
 	s.authLimiter = newAuthRateLimiter(s.conf.Auth.RateLimit)
 	s.notifierTestLimiter = newSimpleRateLimiter(10, time.Minute, s.conf.Options.TrustProxy) // 10 requests per minute
+	// Public found-item endpoints. foundLimiter is a per-IP request cap on
+	// both routes (30/min/IP) that throttles asset-ID enumeration; unlike
+	// mwAuthRateLimit it is not a failed-auth backoff and does not reset on a
+	// successful response. foundSendLimiter is a per-item email cap
+	// (3 per 10 min) that bounds owner-directed mailbombing even from
+	// distributed source IPs.
+	s.foundLimiter = newSimpleRateLimiter(30, time.Minute, s.conf.Options.TrustProxy)
+	s.foundSendLimiter = newSimpleRateLimiter(3, 10*time.Minute, s.conf.Options.TrustProxy)
 
 	return s
 }

--- a/backend/app/api/handlers/v1/controller.go
+++ b/backend/app/api/handlers/v1/controller.go
@@ -94,6 +94,22 @@ func WithURL(url string) func(*V1Controller) {
 	}
 }
 
+// sendLimiter is the minimal contract the found-contact handler needs from the
+// per-item send cap. The concrete limiter lives in package main, which this
+// package cannot import, so it is injected behind this interface.
+type sendLimiter interface {
+	Allow(key string) bool
+}
+
+// WithFoundSendLimiter injects the per-item found-contact email cap. The
+// handler gates on it before dispatching the SMTP send so a single item cannot
+// be mailbombed even from distributed source IPs.
+func WithFoundSendLimiter(limiter sendLimiter) func(*V1Controller) {
+	return func(ctrl *V1Controller) {
+		ctrl.foundSendLimiter = limiter
+	}
+}
+
 type V1Controller struct {
 	repo              *repo.AllRepos
 	svc               *services.AllServices
@@ -107,6 +123,7 @@ type V1Controller struct {
 	cookieSecure      bool
 	isDemo            bool
 	allowRegistration bool
+	foundSendLimiter  sendLimiter
 }
 
 type (

--- a/backend/app/api/handlers/v1/v1_ctrl_found.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_found.go
@@ -1,0 +1,253 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/mail"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/hay-kot/httpkit/errchain"
+	"github.com/hay-kot/httpkit/server"
+	"github.com/rs/zerolog/log"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/repo"
+	"github.com/sysadminsmedia/homebox/backend/internal/sys/validate"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type (
+	FoundItemResponse struct {
+		ItemID  string `json:"itemId"`
+		Message string `json:"message,omitempty"`
+		Mode    string `json:"mode"  enums:"form,mailto"`
+		Email   string `json:"email,omitempty"`
+	}
+
+	// FoundContactRequest's validate tags feed the OpenAPI spec via swaggo;
+	// enforcement is manual in HandleFoundContact, and max=2000 must stay in
+	// sync with foundContactMaxMessageLen.
+	FoundContactRequest struct {
+		Message string `json:"message"           validate:"required,max=2000"`
+		ReplyTo string `json:"replyTo,omitempty" validate:"omitempty,email"`
+	}
+)
+
+// foundContactMaxMessageLen bounds the finder's message. The inbound body is
+// already capped by the body-size middleware; this keeps the relayed email a
+// sane size.
+const foundContactMaxMessageLen = 2000
+
+// foundModeForm is returned when the SMTP mailer is configured and the
+// frontend should render an in-page contact form; foundModeMailto is the
+// fallback where the owner's address is exposed for a mailto: link.
+const (
+	foundModeForm   = "form"
+	foundModeMailto = "mailto"
+)
+
+// errFoundNotFound is the single error produced for every failed resolution:
+// unknown kind, malformed ID, missing item, archived item, opted-out group,
+// or ambiguous asset ID. Keeping them indistinguishable prevents an
+// unauthenticated caller from probing which of those states applies.
+var errFoundNotFound = errors.New("found item not found")
+
+// foundKindAttr bounds the route's {kind} value for span attributes so
+// arbitrary client input never becomes an attribute value.
+func foundKindAttr(kind string) string {
+	switch kind {
+	case "item", "asset":
+		return kind
+	default:
+		return "other"
+	}
+}
+
+// foundLookup resolves the {kind}/{id} route params to a FoundContact.
+// Parse failures and unknown kinds return the same error shape as a failed
+// repository lookup so all not-found paths are identical to the client.
+func (ctrl *V1Controller) foundLookup(r *http.Request) (repo.FoundContact, error) {
+	kind := chi.URLParam(r, "kind")
+	id := chi.URLParam(r, "id")
+
+	switch kind {
+	case "item":
+		itemID, err := uuid.Parse(id)
+		if err != nil {
+			return repo.FoundContact{}, errFoundNotFound
+		}
+		return ctrl.repo.Groups.FoundContactByItemID(r.Context(), itemID)
+	case "asset":
+		assetID, ok := repo.ParseAssetID(id)
+		// Every entity defaults to asset_id 0, so "000-000" (and anything
+		// non-positive) must never resolve; reject before touching the DB.
+		if !ok || assetID <= 0 {
+			return repo.FoundContact{}, errFoundNotFound
+		}
+		return ctrl.repo.Groups.FoundContactByAssetID(r.Context(), assetID)
+	default:
+		return repo.FoundContact{}, errFoundNotFound
+	}
+}
+
+// sendFoundContact performs the SMTP send in the background, mirroring
+// UserService.processResetRequest: fresh root span, errors logged rather than
+// returned so the always-204 response never reflects the outcome. Unlike
+// forgot-password, the goroutine lives here in the handler rather than in the
+// service, deliberately: FoundService.SendContact stays synchronous and
+// directly testable.
+func (ctrl *V1Controller) sendFoundContact(contact repo.FoundContact, message, replyTo string) {
+	_, span := startEntityCtrlSpan(context.Background(), "controller.V1.sendFoundContact",
+		attribute.String("item.id", contact.ItemID.String()),
+	)
+	defer span.End()
+
+	if err := ctrl.svc.Found.SendContact(contact, message, replyTo); err != nil {
+		recordCtrlSpanError(span, err)
+		span.SetAttributes(attribute.String("found.outcome", "send_failed"))
+		log.Err(err).Msg("found-item contact message failed to send")
+		return
+	}
+	span.SetAttributes(attribute.String("found.outcome", "sent"))
+}
+
+// HandleFoundGet godoc
+//
+//	@Summary		Get Found Item Contact Page
+//	@Description	Public, unauthenticated lookup for the found-item contact page. Resolves an
+//	@Description	item by UUID (kind "item") or by asset ID (kind "asset") when the owning
+//	@Description	group has opted in. Returns 404 for anything that does not resolve, with no
+//	@Description	distinction between missing, archived, opted-out, or ambiguous.
+//	@Tags			Found
+//	@Produce		json
+//	@Param			kind	path		string	true	"ID kind"	Enums(item, asset)
+//	@Param			id		path		string	true	"Item UUID or asset ID"
+//	@Success		200		{object}	FoundItemResponse
+//	@Failure		404		{string}	string	"item not found or found-item contact not enabled"
+//	@Router			/v1/found/{kind}/{id} [GET]
+func (ctrl *V1Controller) HandleFoundGet() errchain.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		spanCtx, span := startEntityCtrlSpan(r.Context(), "controller.V1.HandleFoundGet",
+			attribute.String("found.kind", foundKindAttr(chi.URLParam(r, "kind"))),
+		)
+		defer span.End()
+
+		contact, err := ctrl.foundLookup(r.WithContext(spanCtx))
+		if err != nil {
+			// SECURITY: never return the underlying error; a raw ent error
+			// would leak schema details and let callers distinguish the
+			// not-found cases. The static sentinel keeps every 404 identical.
+			// (validate.NewRequestError(nil, ...) is not used because
+			// RequestError.Error() dereferences Err unconditionally and the
+			// error middleware calls it.)
+			span.SetAttributes(attribute.String("found.outcome", "not_found"))
+			return validate.NewRequestError(errFoundNotFound, http.StatusNotFound)
+		}
+
+		resp := FoundItemResponse{
+			ItemID:  contact.ItemID.String(),
+			Message: contact.Message,
+		}
+		if ctrl.svc.Found.MailerReady() {
+			resp.Mode = foundModeForm
+		} else {
+			// SECURITY: the owner's email is exposed only in mailto mode,
+			// where it is the sole way for the finder to make contact. When
+			// the mailer is configured the address stays server-side.
+			resp.Mode = foundModeMailto
+			resp.Email = contact.OwnerEmail
+		}
+
+		span.SetAttributes(
+			attribute.String("found.outcome", "ok"),
+			attribute.String("found.mode", resp.Mode),
+		)
+		return server.JSON(w, http.StatusOK, resp)
+	}
+}
+
+// HandleFoundContact godoc
+//
+//	@Summary		Send Found Item Contact Message
+//	@Description	Relays a finder's message to the item owner by email. After basic input
+//	@Description	validation this always returns 204, whether or not the item resolved or
+//	@Description	the email was sent, so the endpoint cannot be used to probe for items.
+//	@Tags			Found
+//	@Accept			application/json
+//	@Produce		json
+//	@Param			kind	path	string				true	"ID kind"	Enums(item, asset)
+//	@Param			id		path	string				true	"Item UUID or asset ID"
+//	@Param			payload	body	FoundContactRequest	true	"Message"
+//	@Success		204
+//	@Failure		400	{string}	string	"invalid request body, empty or oversized message, or invalid reply-to address"
+//	@Router			/v1/found/{kind}/{id}/contact [POST]
+func (ctrl *V1Controller) HandleFoundContact() errchain.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		spanCtx, span := startEntityCtrlSpan(r.Context(), "controller.V1.HandleFoundContact",
+			attribute.String("found.kind", foundKindAttr(chi.URLParam(r, "kind"))),
+		)
+		defer span.End()
+
+		var body FoundContactRequest
+		if err := server.Decode(r, &body); err != nil {
+			span.SetAttributes(attribute.String("found.outcome", "decode_failed"))
+			return validate.NewRequestError(err, http.StatusBadRequest)
+		}
+
+		body.Message = strings.TrimSpace(body.Message)
+		if body.Message == "" {
+			span.SetAttributes(attribute.String("found.outcome", "missing_message"))
+			return validate.NewRequestError(errors.New("message is required"), http.StatusBadRequest)
+		}
+		if len(body.Message) > foundContactMaxMessageLen {
+			span.SetAttributes(attribute.String("found.outcome", "message_too_long"))
+			return validate.NewRequestError(
+				fmt.Errorf("message is too long (max %d)", foundContactMaxMessageLen),
+				http.StatusBadRequest,
+			)
+		}
+
+		body.ReplyTo = strings.TrimSpace(body.ReplyTo)
+		if body.ReplyTo != "" {
+			if _, err := mail.ParseAddress(body.ReplyTo); err != nil {
+				span.SetAttributes(attribute.String("found.outcome", "invalid_reply_to"))
+				return validate.NewRequestError(errors.New("replyTo must be a valid email address"), http.StatusBadRequest)
+			}
+		}
+
+		// SECURITY: From here on the response is ALWAYS 204, mirroring
+		// HandleForgotPassword. Whether the ID resolved, whether the group
+		// opted in, and whether the mailer is configured or the send
+		// succeeded are all server state an unauthenticated caller must not
+		// be able to probe. Failures are logged for operators instead. The
+		// mailer-readiness check below MUST NOT change the response either;
+		// on a mailto-mode instance a direct POST is simply dropped. The
+		// SMTP send runs in a background goroutine (same as the
+		// forgot-password flow), so response timing is uniform for hit and
+		// miss: both paths do one lookup and return immediately, and an
+		// attacker cannot time-distinguish resolved items from unresolved
+		// ones.
+		if !ctrl.svc.Found.MailerReady() {
+			span.SetAttributes(attribute.String("found.outcome", "mailer_not_configured"))
+			log.Warn().Msg("found-item contact posted but SMTP mailer is not configured; no email will be sent")
+			return server.JSON(w, http.StatusNoContent, nil)
+		}
+
+		contact, err := ctrl.foundLookup(r.WithContext(spanCtx))
+		if err != nil {
+			span.SetAttributes(attribute.String("found.outcome", "not_found"))
+			return server.JSON(w, http.StatusNoContent, nil)
+		}
+
+		// Detached from the request context so a client disconnect doesn't
+		// abort the send; SendContact takes no context, and the goroutine
+		// starts its own root span. Errors are logged, never propagated —
+		// the response is already committed to 204.
+		go ctrl.sendFoundContact(contact, body.Message, body.ReplyTo)
+
+		span.SetAttributes(attribute.String("found.outcome", "queued"))
+		return server.JSON(w, http.StatusNoContent, nil)
+	}
+}

--- a/backend/app/api/handlers/v1/v1_ctrl_found.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_found.go
@@ -241,6 +241,18 @@ func (ctrl *V1Controller) HandleFoundContact() errchain.HandlerFunc {
 			return server.JSON(w, http.StatusNoContent, nil)
 		}
 
+		// Per-item send cap, keyed on the resolved item ID so the bound holds
+		// regardless of source IP (the per-IP foundLimiter middleware cannot
+		// stop distributed mailbombing of one owner). Gated only after a
+		// successful lookup to preserve the uniform 204/404 behavior, and the
+		// response stays 204 when denied so the cap is never observable to the
+		// caller (anti-probing).
+		if ctrl.foundSendLimiter != nil && !ctrl.foundSendLimiter.Allow(contact.ItemID.String()) {
+			span.SetAttributes(attribute.String("found.outcome", "send_rate_limited"))
+			log.Warn().Str("item.id", contact.ItemID.String()).Msg("found-item contact send rate limit exceeded; dropping message")
+			return server.JSON(w, http.StatusNoContent, nil)
+		}
+
 		// Detached from the request context so a client disconnect doesn't
 		// abort the send; SendContact takes no context, and the goroutine
 		// starts its own root span. Errors are logged, never propagated —

--- a/backend/app/api/handlers/v1/v1_ctrl_found.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_found.go
@@ -22,7 +22,7 @@ type (
 	FoundItemResponse struct {
 		ItemID  string `json:"itemId"`
 		Message string `json:"message,omitempty"`
-		Mode    string `json:"mode"  enums:"form,mailto"`
+		Mode    string `json:"mode"              enums:"form,mailto"`
 		Email   string `json:"email,omitempty"`
 	}
 
@@ -48,6 +48,13 @@ const (
 	foundModeMailto = "mailto"
 )
 
+// foundKindItem and foundKindAsset are the two accepted values of the {kind}
+// route segment.
+const (
+	foundKindItem  = "item"
+	foundKindAsset = "asset"
+)
+
 // errFoundNotFound is the single error produced for every failed resolution:
 // unknown kind, malformed ID, missing item, archived item, opted-out group,
 // or ambiguous asset ID. Keeping them indistinguishable prevents an
@@ -58,7 +65,7 @@ var errFoundNotFound = errors.New("found item not found")
 // arbitrary client input never becomes an attribute value.
 func foundKindAttr(kind string) string {
 	switch kind {
-	case "item", "asset":
+	case foundKindItem, foundKindAsset:
 		return kind
 	default:
 		return "other"
@@ -73,13 +80,13 @@ func (ctrl *V1Controller) foundLookup(r *http.Request) (repo.FoundContact, error
 	id := chi.URLParam(r, "id")
 
 	switch kind {
-	case "item":
+	case foundKindItem:
 		itemID, err := uuid.Parse(id)
 		if err != nil {
 			return repo.FoundContact{}, errFoundNotFound
 		}
 		return ctrl.repo.Groups.FoundContactByItemID(r.Context(), itemID)
-	case "asset":
+	case foundKindAsset:
 		assetID, ok := repo.ParseAssetID(id)
 		// Every entity defaults to asset_id 0, so "000-000" (and anything
 		// non-positive) must never resolve; reject before touching the DB.

--- a/backend/app/api/handlers/v1/v1_ctrl_found_test.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_found_test.go
@@ -1,0 +1,137 @@
+package v1
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/sysadminsmedia/homebox/backend/internal/core/services"
+	"github.com/sysadminsmedia/homebox/backend/internal/sys/validate"
+)
+
+// foundTestRequest builds a request whose chi route context carries the
+// {kind} and {id} params, matching how the router invokes the handlers.
+func foundTestRequest(method, kind, id string, body string) *http.Request {
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, "/api/v1/found/"+kind+"/"+id, nil)
+	} else {
+		r = httptest.NewRequest(method, "/api/v1/found/"+kind+"/"+id+"/contact", strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+	}
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("kind", kind)
+	rctx.URLParams.Add("id", id)
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+// The cases below only exercise paths that fail before any repository or
+// service access, so a zero-value controller is sufficient. Cases that reach
+// the database are covered by the repository and service layer tests.
+
+func TestFoundLookupRejectsBadRefsBeforeQuery(t *testing.T) {
+	ctrl := &V1Controller{}
+
+	cases := []struct {
+		name string
+		kind string
+		id   string
+	}{
+		{name: "unknown kind", kind: "barcode", id: "000-001"},
+		{name: "empty kind", kind: "", id: "000-001"},
+		{name: "malformed item uuid", kind: "item", id: "not-a-uuid"},
+		{name: "empty item id", kind: "item", id: ""},
+		{name: "asset id zero", kind: "asset", id: "000-000"},
+		{name: "asset id bare zero", kind: "asset", id: "0"},
+		// Note: ParseAssetID strips dashes, so "-5" parses as asset 5 and
+		// is a legitimate (queryable) reference; negatives cannot occur.
+		{name: "asset id non-numeric", kind: "asset", id: "abc"},
+		{name: "empty asset id", kind: "asset", id: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := foundTestRequest(http.MethodGet, tc.kind, tc.id, "")
+			_, err := ctrl.foundLookup(r)
+			assert.ErrorIs(t, err, errFoundNotFound)
+		})
+	}
+}
+
+func TestHandleFoundGetNotFoundIsOpaque(t *testing.T) {
+	ctrl := &V1Controller{}
+	handler := ctrl.HandleFoundGet()
+
+	w := httptest.NewRecorder()
+	err := handler(w, foundTestRequest(http.MethodGet, "item", "not-a-uuid", ""))
+
+	var reqErr *validate.RequestError
+	require.ErrorAs(t, err, &reqErr)
+	assert.Equal(t, http.StatusNotFound, reqErr.Status)
+	assert.Equal(t, errFoundNotFound.Error(), reqErr.Error())
+}
+
+func TestHandleFoundContactValidation(t *testing.T) {
+	ctrl := &V1Controller{}
+	handler := ctrl.HandleFoundContact()
+
+	badBodies := []struct {
+		name string
+		body string
+	}{
+		{name: "invalid json", body: `{`},
+		{name: "missing message", body: `{}`},
+		{name: "empty message", body: `{"message": ""}`},
+		{name: "whitespace-only message", body: `{"message": "  \n\t "}`},
+		{name: "message too long", body: `{"message": "` + strings.Repeat("a", foundContactMaxMessageLen+1) + `"}`},
+		{name: "invalid replyTo", body: `{"message": "hi", "replyTo": "not-an-email"}`},
+	}
+
+	for _, tc := range badBodies {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			err := handler(w, foundTestRequest(http.MethodPost, "item", "not-a-uuid", tc.body))
+
+			var reqErr *validate.RequestError
+			require.ErrorAs(t, err, &reqErr)
+			assert.Equal(t, http.StatusBadRequest, reqErr.Status)
+		})
+	}
+}
+
+func TestHandleFoundContactBoundaryAndAlways204(t *testing.T) {
+	// A zero-value FoundService reports MailerReady false, so valid input
+	// hits the mailer-not-configured branch of the always-204 zone.
+	ctrl := &V1Controller{svc: &services.AllServices{Found: &services.FoundService{}}}
+	handler := ctrl.HandleFoundContact()
+
+	okBodies := []struct {
+		name string
+		body string
+	}{
+		// Message exactly at the limit passes validation.
+		{name: "message at max length", body: `{"message": "` + strings.Repeat("a", foundContactMaxMessageLen) + `"}`},
+		// Empty replyTo is optional.
+		{name: "empty replyTo", body: `{"message": "hi", "replyTo": ""}`},
+		{name: "valid replyTo", body: `{"message": "hi", "replyTo": "finder@example.com"}`},
+	}
+
+	// These exercise the always-204 anti-probing zone: valid input on an
+	// unready-mailer instance must return 204 with no error,
+	// indistinguishable from a successful send.
+	for _, tc := range okBodies {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			err := handler(w, foundTestRequest(http.MethodPost, "item", "not-a-uuid", tc.body))
+
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusNoContent, w.Code)
+		})
+	}
+}

--- a/backend/app/api/handlers/v1/v1_ctrl_found_test.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_found_test.go
@@ -45,14 +45,14 @@ func TestFoundLookupRejectsBadRefsBeforeQuery(t *testing.T) {
 	}{
 		{name: "unknown kind", kind: "barcode", id: "000-001"},
 		{name: "empty kind", kind: "", id: "000-001"},
-		{name: "malformed item uuid", kind: "item", id: "not-a-uuid"},
-		{name: "empty item id", kind: "item", id: ""},
-		{name: "asset id zero", kind: "asset", id: "000-000"},
-		{name: "asset id bare zero", kind: "asset", id: "0"},
+		{name: "malformed item uuid", kind: foundKindItem, id: "not-a-uuid"},
+		{name: "empty item id", kind: foundKindItem, id: ""},
+		{name: "asset id zero", kind: foundKindAsset, id: "000-000"},
+		{name: "asset id bare zero", kind: foundKindAsset, id: "0"},
 		// Note: ParseAssetID strips dashes, so "-5" parses as asset 5 and
 		// is a legitimate (queryable) reference; negatives cannot occur.
-		{name: "asset id non-numeric", kind: "asset", id: "abc"},
-		{name: "empty asset id", kind: "asset", id: ""},
+		{name: "asset id non-numeric", kind: foundKindAsset, id: "abc"},
+		{name: "empty asset id", kind: foundKindAsset, id: ""},
 	}
 
 	for _, tc := range cases {
@@ -69,7 +69,7 @@ func TestHandleFoundGetNotFoundIsOpaque(t *testing.T) {
 	handler := ctrl.HandleFoundGet()
 
 	w := httptest.NewRecorder()
-	err := handler(w, foundTestRequest(http.MethodGet, "item", "not-a-uuid", ""))
+	err := handler(w, foundTestRequest(http.MethodGet, foundKindItem, "not-a-uuid", ""))
 
 	var reqErr *validate.RequestError
 	require.ErrorAs(t, err, &reqErr)
@@ -96,7 +96,7 @@ func TestHandleFoundContactValidation(t *testing.T) {
 	for _, tc := range badBodies {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			err := handler(w, foundTestRequest(http.MethodPost, "item", "not-a-uuid", tc.body))
+			err := handler(w, foundTestRequest(http.MethodPost, foundKindItem, "not-a-uuid", tc.body))
 
 			var reqErr *validate.RequestError
 			require.ErrorAs(t, err, &reqErr)
@@ -128,7 +128,7 @@ func TestHandleFoundContactBoundaryAndAlways204(t *testing.T) {
 	for _, tc := range okBodies {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			err := handler(w, foundTestRequest(http.MethodPost, "item", "not-a-uuid", tc.body))
+			err := handler(w, foundTestRequest(http.MethodPost, foundKindItem, "not-a-uuid", tc.body))
 
 			require.NoError(t, err)
 			assert.Equal(t, http.StatusNoContent, w.Code)

--- a/backend/app/api/handlers/v1/v1_ctrl_group.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_group.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -38,6 +39,10 @@ type (
 	}
 )
 
+// groupFoundContactMessageMaxLen mirrors the ent schema's MaxLen(500) on
+// Group.found_contact_message.
+const groupFoundContactMessageMaxLen = 500
+
 // HandleGroupGet godoc
 //
 //	@Summary	Get Group
@@ -72,6 +77,17 @@ func (ctrl *V1Controller) HandleGroupUpdate() errchain.HandlerFunc {
 		if !ok {
 			return repo.Group{}, validate.NewFieldErrors(
 				validate.NewFieldError("currency", "currency '"+body.Currency+"' is not supported"),
+			)
+		}
+
+		// Enforce the ent schema's MaxLen(500) here so an oversized message
+		// surfaces as a 422 field error (mid.Errors maps FieldErrors to
+		// unprocessable entity, matching the currency check above) instead
+		// of a 500 from the ent validator. ent's MaxLen counts bytes
+		// (len(v)), so this check does too.
+		if body.FoundContactMessage != nil && len(*body.FoundContactMessage) > groupFoundContactMessageMaxLen {
+			return repo.Group{}, validate.NewFieldErrors(
+				validate.NewFieldError("foundContactMessage", fmt.Sprintf("message is too long (max %d)", groupFoundContactMessageMaxLen)),
 			)
 		}
 

--- a/backend/app/api/handlers/v1/v1_ctrl_group.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_group.go
@@ -91,6 +91,20 @@ func (ctrl *V1Controller) HandleGroupUpdate() errchain.HandlerFunc {
 			)
 		}
 
+		// Changing the found-contact settings can publish the group owner's
+		// email (mailto mode), so only the owner may touch them. Enforced only
+		// when a found-contact field is actually being set so members can still
+		// update name/currency.
+		if body.FoundContactEnabled != nil || body.FoundContactMessage != nil {
+			isOwner, err := ctrl.repo.Groups.IsOwnerOf(auth, auth.UID, auth.GID)
+			if err != nil {
+				return repo.Group{}, err
+			}
+			if !isOwner {
+				return repo.Group{}, validate.NewRequestError(errors.New("only the group owner can change found-contact settings"), http.StatusForbidden)
+			}
+		}
+
 		return ctrl.svc.Group.UpdateGroup(auth, body)
 	}
 

--- a/backend/app/api/middleware.go
+++ b/backend/app/api/middleware.go
@@ -690,6 +690,13 @@ func (rl *simpleRateLimiter) allow(clientIP string) bool {
 	return false
 }
 
+// Allow is an exported wrapper around allow so callers outside this package
+// (e.g. the v1 controller's per-item found-contact send cap) can gate on an
+// arbitrary key without reaching into the unexported method.
+func (rl *simpleRateLimiter) Allow(key string) bool {
+	return rl.allow(key)
+}
+
 // getClientIP extracts the client IP from the request.
 // It only uses proxy headers (X-Real-IP, X-Forwarded-For) if trustProxy is enabled.
 func (rl *simpleRateLimiter) getClientIP(r *http.Request, trustProxy bool) string {

--- a/backend/app/api/middleware_ratelimit_test.go
+++ b/backend/app/api/middleware_ratelimit_test.go
@@ -92,6 +92,32 @@ func TestSimpleRateLimiter(t *testing.T) {
 	}
 }
 
+// TestSimpleRateLimiterAllowPerKey exercises the exported Allow wrapper the
+// found-contact handler relies on for its per-item send cap: the cap is
+// enforced per key, and exhausting one key's bucket does not affect another's.
+func TestSimpleRateLimiterAllowPerKey(t *testing.T) {
+	// 3 sends per window, matching the found send-limiter's cap. trustProxy is
+	// irrelevant here: Allow takes an arbitrary key (the item ID), not an IP.
+	limiter := newSimpleRateLimiter(3, 10*time.Second, false)
+	t.Cleanup(func() { limiter.Stop() })
+
+	// Cap enforced per key: first 3 allowed, 4th denied.
+	for i := 0; i < 3; i++ {
+		if !limiter.Allow("item-A") {
+			t.Errorf("send %d for item-A should have been allowed", i+1)
+		}
+	}
+	if limiter.Allow("item-A") {
+		t.Error("4th send for item-A should have been blocked")
+	}
+
+	// Per-key isolation: item-A exhausting its bucket must not affect item-B.
+	// This is the property that makes the per-item mailbomb bound correct.
+	if !limiter.Allow("item-B") {
+		t.Error("item-B should be allowed even after item-A is exhausted")
+	}
+}
+
 func TestSimpleRateLimiterRefill(t *testing.T) {
 	type testCase struct {
 		name       string

--- a/backend/app/api/routes.go
+++ b/backend/app/api/routes.go
@@ -93,6 +93,10 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 		r.Post("/users/forgot-password", chain.ToHandlerFunc(v1Ctrl.HandleForgotPassword(), a.mwAuthRateLimit))
 		r.Post("/users/reset-password", chain.ToHandlerFunc(v1Ctrl.HandleResetPassword(), a.mwAuthRateLimit))
 
+		// Public found-item contact page (unauthenticated, rate limited)
+		r.Get("/found/{kind}/{id}", chain.ToHandlerFunc(v1Ctrl.HandleFoundGet(), a.mwAuthRateLimit))
+		r.Post("/found/{kind}/{id}/contact", chain.ToHandlerFunc(v1Ctrl.HandleFoundContact(), a.mwAuthRateLimit))
+
 		if a.conf.OIDC.Enabled {
 			r.Get("/users/login/oidc", chain.ToHandlerFunc(v1Ctrl.HandleOIDCLogin(), a.mwAuthRateLimit))
 			r.Get("/users/login/oidc/callback", chain.ToHandlerFunc(v1Ctrl.HandleOIDCCallback(), a.mwAuthRateLimit))

--- a/backend/app/api/routes.go
+++ b/backend/app/api/routes.go
@@ -73,6 +73,7 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 		v1.WithRegistration(a.conf.Options.AllowRegistration),
 		v1.WithDemoStatus(a.conf.Demo), // Disable Password Change in Demo Mode
 		v1.WithURL(fmt.Sprintf("%s:%s", a.conf.Web.Host, a.conf.Web.Port)),
+		v1.WithFoundSendLimiter(a.foundSendLimiter),
 	)
 
 	r.Route(prefix+"/v1", func(r chi.Router) {
@@ -94,8 +95,8 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 		r.Post("/users/reset-password", chain.ToHandlerFunc(v1Ctrl.HandleResetPassword(), a.mwAuthRateLimit))
 
 		// Public found-item contact page (unauthenticated, rate limited)
-		r.Get("/found/{kind}/{id}", chain.ToHandlerFunc(v1Ctrl.HandleFoundGet(), a.mwAuthRateLimit))
-		r.Post("/found/{kind}/{id}/contact", chain.ToHandlerFunc(v1Ctrl.HandleFoundContact(), a.mwAuthRateLimit))
+		r.Get("/found/{kind}/{id}", chain.ToHandlerFunc(v1Ctrl.HandleFoundGet(), a.foundLimiter.middleware))
+		r.Post("/found/{kind}/{id}/contact", chain.ToHandlerFunc(v1Ctrl.HandleFoundContact(), a.foundLimiter.middleware))
 
 		if a.conf.OIDC.Enabled {
 			r.Get("/users/login/oidc", chain.ToHandlerFunc(v1Ctrl.HandleOIDCLogin(), a.mwAuthRateLimit))

--- a/backend/app/api/static/docs/docs.go
+++ b/backend/app/api/static/docs/docs.go
@@ -1155,6 +1155,107 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/found/{kind}/{id}": {
+            "get": {
+                "description": "Public, unauthenticated lookup for the found-item contact page. Resolves an\nitem by UUID (kind \"item\") or by asset ID (kind \"asset\") when the owning\ngroup has opted in. Returns 404 for anything that does not resolve, with no\ndistinction between missing, archived, opted-out, or ambiguous.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Found"
+                ],
+                "summary": "Get Found Item Contact Page",
+                "parameters": [
+                    {
+                        "enum": [
+                            "item",
+                            "asset"
+                        ],
+                        "type": "string",
+                        "description": "ID kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Item UUID or asset ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1.FoundItemResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "item not found or found-item contact not enabled",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/found/{kind}/{id}/contact": {
+            "post": {
+                "description": "Relays a finder's message to the item owner by email. After basic input\nvalidation this always returns 204, whether or not the item resolved or\nthe email was sent, so the endpoint cannot be used to probe for items.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Found"
+                ],
+                "summary": "Send Found Item Contact Message",
+                "parameters": [
+                    {
+                        "enum": [
+                            "item",
+                            "asset"
+                        ],
+                        "type": "string",
+                        "description": "ID kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Item UUID or asset ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Message",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v1.FoundContactRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "invalid request body, empty or oversized message, or invalid reply-to address",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/group/exports": {
             "get": {
                 "security": [
@@ -3997,6 +4098,14 @@ const docTemplate = `{
                         }
                     ]
                 },
+                "found_contact_enabled": {
+                    "description": "FoundContactEnabled holds the value of the \"found_contact_enabled\" field.",
+                    "type": "boolean"
+                },
+                "found_contact_message": {
+                    "description": "FoundContactMessage holds the value of the \"found_contact_message\" field.",
+                    "type": "string"
+                },
                 "id": {
                     "description": "ID of the ent.",
                     "type": "string"
@@ -5659,6 +5768,12 @@ const docTemplate = `{
                 "currency": {
                     "type": "string"
                 },
+                "foundContactEnabled": {
+                    "type": "boolean"
+                },
+                "foundContactMessage": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -5714,6 +5829,12 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "currency": {
+                    "type": "string"
+                },
+                "foundContactEnabled": {
+                    "type": "boolean"
+                },
+                "foundContactMessage": {
                     "type": "string"
                 },
                 "name": {
@@ -6461,6 +6582,42 @@ const docTemplate = `{
                 "email": {
                     "type": "string",
                     "example": "user@example.com"
+                }
+            }
+        },
+        "v1.FoundContactRequest": {
+            "type": "object",
+            "required": [
+                "message"
+            ],
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "replyTo": {
+                    "type": "string"
+                }
+            }
+        },
+        "v1.FoundItemResponse": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "itemId": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": [
+                        "form",
+                        "mailto"
+                    ]
                 }
             }
         },

--- a/backend/app/api/static/docs/openapi-3.json
+++ b/backend/app/api/static/docs/openapi-3.json
@@ -1258,6 +1258,120 @@
                 }
             }
         },
+        "/v1/found/{kind}/{id}": {
+            "get": {
+                "description": "Public, unauthenticated lookup for the found-item contact page. Resolves an\nitem by UUID (kind \"item\") or by asset ID (kind \"asset\") when the owning\ngroup has opted in. Returns 404 for anything that does not resolve, with no\ndistinction between missing, archived, opted-out, or ambiguous.",
+                "tags": [
+                    "Found"
+                ],
+                "summary": "Get Found Item Contact Page",
+                "parameters": [
+                    {
+                        "description": "ID kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "item",
+                                "asset"
+                            ]
+                        }
+                    },
+                    {
+                        "description": "Item UUID or asset ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/v1.FoundItemResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "item not found or found-item contact not enabled",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/found/{kind}/{id}/contact": {
+            "post": {
+                "description": "Relays a finder's message to the item owner by email. After basic input\nvalidation this always returns 204, whether or not the item resolved or\nthe email was sent, so the endpoint cannot be used to probe for items.",
+                "tags": [
+                    "Found"
+                ],
+                "summary": "Send Found Item Contact Message",
+                "parameters": [
+                    {
+                        "description": "ID kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "item",
+                                "asset"
+                            ]
+                        }
+                    },
+                    {
+                        "description": "Item UUID or asset ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/v1.FoundContactRequest"
+                            }
+                        }
+                    },
+                    "description": "Message",
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "invalid request body, empty or oversized message, or invalid reply-to address",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v1/group/exports": {
             "get": {
                 "security": [
@@ -4236,6 +4350,14 @@
                             }
                         ]
                     },
+                    "found_contact_enabled": {
+                        "description": "FoundContactEnabled holds the value of the \"found_contact_enabled\" field.",
+                        "type": "boolean"
+                    },
+                    "found_contact_message": {
+                        "description": "FoundContactMessage holds the value of the \"found_contact_message\" field.",
+                        "type": "string"
+                    },
                     "id": {
                         "description": "ID of the ent.",
                         "type": "string"
@@ -5898,6 +6020,12 @@
                     "currency": {
                         "type": "string"
                     },
+                    "foundContactEnabled": {
+                        "type": "boolean"
+                    },
+                    "foundContactMessage": {
+                        "type": "string"
+                    },
                     "id": {
                         "type": "string"
                     },
@@ -5953,6 +6081,12 @@
                 "type": "object",
                 "properties": {
                     "currency": {
+                        "type": "string"
+                    },
+                    "foundContactEnabled": {
+                        "type": "boolean"
+                    },
+                    "foundContactMessage": {
                         "type": "string"
                     },
                     "name": {
@@ -6700,6 +6834,42 @@
                     "email": {
                         "type": "string",
                         "example": "user@example.com"
+                    }
+                }
+            },
+            "v1.FoundContactRequest": {
+                "type": "object",
+                "required": [
+                    "message"
+                ],
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "maxLength": 2000
+                    },
+                    "replyTo": {
+                        "type": "string"
+                    }
+                }
+            },
+            "v1.FoundItemResponse": {
+                "type": "object",
+                "properties": {
+                    "email": {
+                        "type": "string"
+                    },
+                    "itemId": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "mode": {
+                        "type": "string",
+                        "enum": [
+                            "form",
+                            "mailto"
+                        ]
                     }
                 }
             },

--- a/backend/app/api/static/docs/openapi-3.yaml
+++ b/backend/app/api/static/docs/openapi-3.yaml
@@ -753,6 +753,91 @@ paths:
       responses:
         "204":
           description: No Content
+  "/v1/found/{kind}/{id}":
+    get:
+      description: >-
+        Public, unauthenticated lookup for the found-item contact page. Resolves
+        an
+
+        item by UUID (kind "item") or by asset ID (kind "asset") when the owning
+
+        group has opted in. Returns 404 for anything that does not resolve, with no
+
+        distinction between missing, archived, opted-out, or ambiguous.
+      tags:
+        - Found
+      summary: Get Found Item Contact Page
+      parameters:
+        - description: ID kind
+          name: kind
+          in: path
+          required: true
+          schema:
+            type: string
+            enum:
+              - item
+              - asset
+        - description: Item UUID or asset ID
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1.FoundItemResponse"
+        "404":
+          description: item not found or found-item contact not enabled
+          content:
+            application/json:
+              schema:
+                type: string
+  "/v1/found/{kind}/{id}/contact":
+    post:
+      description: |-
+        Relays a finder's message to the item owner by email. After basic input
+        validation this always returns 204, whether or not the item resolved or
+        the email was sent, so the endpoint cannot be used to probe for items.
+      tags:
+        - Found
+      summary: Send Found Item Contact Message
+      parameters:
+        - description: ID kind
+          name: kind
+          in: path
+          required: true
+          schema:
+            type: string
+            enum:
+              - item
+              - asset
+        - description: Item UUID or asset ID
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/v1.FoundContactRequest"
+        description: Message
+        required: true
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: invalid request body, empty or oversized message, or invalid
+            reply-to address
+          content:
+            application/json:
+              schema:
+                type: string
   /v1/group/exports:
     get:
       security:
@@ -2610,6 +2695,14 @@ components:
             The values are being populated by the GroupQuery when eager-loading is set.
           allOf:
             - $ref: "#/components/schemas/ent.GroupEdges"
+        found_contact_enabled:
+          description: FoundContactEnabled holds the value of the "found_contact_enabled"
+            field.
+          type: boolean
+        found_contact_message:
+          description: FoundContactMessage holds the value of the "found_contact_message"
+            field.
+          type: string
         id:
           description: ID of the ent.
           type: string
@@ -3778,6 +3871,10 @@ components:
           type: string
         currency:
           type: string
+        foundContactEnabled:
+          type: boolean
+        foundContactMessage:
+          type: string
         id:
           type: string
         name:
@@ -3814,6 +3911,10 @@ components:
       type: object
       properties:
         currency:
+          type: string
+        foundContactEnabled:
+          type: boolean
+        foundContactMessage:
           type: string
         name:
           type: string
@@ -4318,6 +4419,30 @@ components:
         email:
           type: string
           example: user@example.com
+    v1.FoundContactRequest:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          maxLength: 2000
+        replyTo:
+          type: string
+    v1.FoundItemResponse:
+      type: object
+      properties:
+        email:
+          type: string
+        itemId:
+          type: string
+        message:
+          type: string
+        mode:
+          type: string
+          enum:
+            - form
+            - mailto
     v1.GroupAcceptInvitationResponse:
       type: object
       properties:

--- a/backend/app/api/static/docs/swagger.json
+++ b/backend/app/api/static/docs/swagger.json
@@ -1152,6 +1152,107 @@
                 }
             }
         },
+        "/v1/found/{kind}/{id}": {
+            "get": {
+                "description": "Public, unauthenticated lookup for the found-item contact page. Resolves an\nitem by UUID (kind \"item\") or by asset ID (kind \"asset\") when the owning\ngroup has opted in. Returns 404 for anything that does not resolve, with no\ndistinction between missing, archived, opted-out, or ambiguous.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Found"
+                ],
+                "summary": "Get Found Item Contact Page",
+                "parameters": [
+                    {
+                        "enum": [
+                            "item",
+                            "asset"
+                        ],
+                        "type": "string",
+                        "description": "ID kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Item UUID or asset ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1.FoundItemResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "item not found or found-item contact not enabled",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/found/{kind}/{id}/contact": {
+            "post": {
+                "description": "Relays a finder's message to the item owner by email. After basic input\nvalidation this always returns 204, whether or not the item resolved or\nthe email was sent, so the endpoint cannot be used to probe for items.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Found"
+                ],
+                "summary": "Send Found Item Contact Message",
+                "parameters": [
+                    {
+                        "enum": [
+                            "item",
+                            "asset"
+                        ],
+                        "type": "string",
+                        "description": "ID kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Item UUID or asset ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Message",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v1.FoundContactRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "invalid request body, empty or oversized message, or invalid reply-to address",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/group/exports": {
             "get": {
                 "security": [
@@ -3994,6 +4095,14 @@
                         }
                     ]
                 },
+                "found_contact_enabled": {
+                    "description": "FoundContactEnabled holds the value of the \"found_contact_enabled\" field.",
+                    "type": "boolean"
+                },
+                "found_contact_message": {
+                    "description": "FoundContactMessage holds the value of the \"found_contact_message\" field.",
+                    "type": "string"
+                },
                 "id": {
                     "description": "ID of the ent.",
                     "type": "string"
@@ -5656,6 +5765,12 @@
                 "currency": {
                     "type": "string"
                 },
+                "foundContactEnabled": {
+                    "type": "boolean"
+                },
+                "foundContactMessage": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -5711,6 +5826,12 @@
             "type": "object",
             "properties": {
                 "currency": {
+                    "type": "string"
+                },
+                "foundContactEnabled": {
+                    "type": "boolean"
+                },
+                "foundContactMessage": {
                     "type": "string"
                 },
                 "name": {
@@ -6458,6 +6579,42 @@
                 "email": {
                     "type": "string",
                     "example": "user@example.com"
+                }
+            }
+        },
+        "v1.FoundContactRequest": {
+            "type": "object",
+            "required": [
+                "message"
+            ],
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "replyTo": {
+                    "type": "string"
+                }
+            }
+        },
+        "v1.FoundItemResponse": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "itemId": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": [
+                        "form",
+                        "mailto"
+                    ]
                 }
             }
         },

--- a/backend/app/api/static/docs/swagger.yaml
+++ b/backend/app/api/static/docs/swagger.yaml
@@ -552,6 +552,14 @@ definitions:
         description: |-
           Edges holds the relations/edges for other nodes in the graph.
           The values are being populated by the GroupQuery when eager-loading is set.
+      found_contact_enabled:
+        description: FoundContactEnabled holds the value of the "found_contact_enabled"
+          field.
+        type: boolean
+      found_contact_message:
+        description: FoundContactMessage holds the value of the "found_contact_message"
+          field.
+        type: string
       id:
         description: ID of the ent.
         type: string
@@ -1712,6 +1720,10 @@ definitions:
         type: string
       currency:
         type: string
+      foundContactEnabled:
+        type: boolean
+      foundContactMessage:
+        type: string
       id:
         type: string
       name:
@@ -1748,6 +1760,10 @@ definitions:
   repo.GroupUpdate:
     properties:
       currency:
+        type: string
+      foundContactEnabled:
+        type: boolean
+      foundContactMessage:
         type: string
       name:
         type: string
@@ -2250,6 +2266,30 @@ definitions:
         type: string
     required:
     - email
+    type: object
+  v1.FoundContactRequest:
+    properties:
+      message:
+        maxLength: 2000
+        type: string
+      replyTo:
+        type: string
+    required:
+    - message
+    type: object
+  v1.FoundItemResponse:
+    properties:
+      email:
+        type: string
+      itemId:
+        type: string
+      message:
+        type: string
+      mode:
+        enum:
+        - form
+        - mailto
+        type: string
     type: object
   v1.GroupAcceptInvitationResponse:
     properties:
@@ -3077,6 +3117,82 @@ paths:
       summary: Update Entity Type
       tags:
       - Entity Types
+  /v1/found/{kind}/{id}:
+    get:
+      description: |-
+        Public, unauthenticated lookup for the found-item contact page. Resolves an
+        item by UUID (kind "item") or by asset ID (kind "asset") when the owning
+        group has opted in. Returns 404 for anything that does not resolve, with no
+        distinction between missing, archived, opted-out, or ambiguous.
+      parameters:
+      - description: ID kind
+        enum:
+        - item
+        - asset
+        in: path
+        name: kind
+        required: true
+        type: string
+      - description: Item UUID or asset ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v1.FoundItemResponse'
+        "404":
+          description: item not found or found-item contact not enabled
+          schema:
+            type: string
+      summary: Get Found Item Contact Page
+      tags:
+      - Found
+  /v1/found/{kind}/{id}/contact:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Relays a finder's message to the item owner by email. After basic input
+        validation this always returns 204, whether or not the item resolved or
+        the email was sent, so the endpoint cannot be used to probe for items.
+      parameters:
+      - description: ID kind
+        enum:
+        - item
+        - asset
+        in: path
+        name: kind
+        required: true
+        type: string
+      - description: Item UUID or asset ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Message
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/v1.FoundContactRequest'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: invalid request body, empty or oversized message, or invalid
+            reply-to address
+          schema:
+            type: string
+      summary: Send Found Item Contact Message
+      tags:
+      - Found
   /v1/group/exports:
     get:
       description: Returns export job rows for the caller's group, newest first.

--- a/backend/internal/core/services/all.go
+++ b/backend/internal/core/services/all.go
@@ -17,6 +17,7 @@ type AllServices struct {
 	BackgroundService *BackgroundService
 	Exports           *ExportService
 	Currencies        *currencies.CurrencyRegistry
+	Found             *FoundService
 }
 
 type OptionsFunc func(*options)
@@ -65,9 +66,9 @@ func WithExportPlumbing(bus *eventbus.EventBus, db *ent.Client, storage config.S
 	}
 }
 
-// WithMailer hands the SMTP mailer to services that send mail (currently only
-// password reset). A nil or unconfigured mailer disables those code paths
-// rather than panicking.
+// WithMailer hands the SMTP mailer to services that send mail (currently
+// password reset and the found-item contact relay). A nil or unconfigured
+// mailer disables those code paths rather than panicking.
 func WithMailer(m *mailer.Mailer) func(*options) {
 	return func(o *options) {
 		o.mailer = m
@@ -127,5 +128,6 @@ func New(repos *repo.AllRepos, opts ...OptionsFunc) *AllServices {
 			dialect:    options.dialect,
 		},
 		Currencies: currencies.NewCurrencyService(options.currencies),
+		Found:      &FoundService{mailer: options.mailer},
 	}
 }

--- a/backend/internal/core/services/service_found.go
+++ b/backend/internal/core/services/service_found.go
@@ -1,0 +1,68 @@
+package services
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sysadminsmedia/homebox/backend/internal/data/repo"
+	"github.com/sysadminsmedia/homebox/backend/pkgs/mailer"
+)
+
+// FoundService relays messages from anonymous finders of lost items to the
+// item's group owner. It never exposes the owner's address to the caller.
+// It does not look up FoundContact itself; the caller (the found-item HTTP
+// handler) resolves the contact via repo.AllRepos.Groups.FoundContactBy* and
+// passes the result in.
+type FoundService struct {
+	mailer *mailer.Mailer
+}
+
+// MailerReady reports whether the SMTP mailer is configured and usable.
+func (svc *FoundService) MailerReady() bool {
+	return svc.mailer != nil && svc.mailer.Ready()
+}
+
+// SendContact relays a finder's message to the item owner's email address.
+func (svc *FoundService) SendContact(contact repo.FoundContact, message, replyTo string) error {
+	if !svc.MailerReady() {
+		return errors.New("mailer is not configured")
+	}
+
+	subject, body := buildFoundContactEmail(contact.ItemName, message, replyTo)
+
+	msg := mailer.NewMessageBuilder().
+		SetTo(contact.OwnerName, contact.OwnerEmail).
+		SetFrom("Homebox", svc.mailer.From).
+		SetSubject(subject).
+		SetBody(body).
+		Build()
+
+	return svc.mailer.Send(msg)
+}
+
+// buildFoundContactEmail builds the subject and body for a found-item contact
+// email. mailer.Mailer.Send always sends with Content-Type: text/html (see
+// pkgs/mailer/mailer.go), so even though this content is conceptually plain
+// text, every interpolated value (finder message, reply address, and item
+// name) must be HTML-escaped before interpolation - otherwise an anonymous
+// finder, or a group member who names an item with HTML in it, could inject
+// markup (or script, depending on the recipient's mail client) into an email
+// sent to the item owner. Wrapped in <pre> so newlines in the finder's
+// message still render as line breaks. The subject line is not escaped this
+// way; it goes through mime.QEncoding in the mailer, which already protects
+// email headers.
+func buildFoundContactEmail(itemName, message, replyTo string) (subject, body string) {
+	subject = fmt.Sprintf("Someone found your item: %s", itemName)
+
+	body = fmt.Sprintf(
+		`<pre style="white-space: pre-wrap; font-family: inherit;">Someone scanned the label on your item "%s" and sent you a message through Homebox:
+
+%s
+</pre>`,
+		htmlEscape(itemName), htmlEscape(message),
+	)
+	if replyTo != "" {
+		body += fmt.Sprintf(`<p>Reply to: %s</p>`, htmlEscape(replyTo))
+	}
+	return subject, body
+}

--- a/backend/internal/core/services/service_found_test.go
+++ b/backend/internal/core/services/service_found_test.go
@@ -1,0 +1,36 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildFoundContactEmail(t *testing.T) {
+	subject, body := buildFoundContactEmail("Camera Bag", "I found this at the park", "finder@example.com")
+
+	assert.Contains(t, subject, "Camera Bag", "subject should contain item name")
+	assert.Contains(t, body, "I found this at the park", "body should contain finder message")
+	assert.Contains(t, body, "finder@example.com", "body should contain reply address")
+}
+
+func TestBuildFoundContactEmail_NoReplyTo(t *testing.T) {
+	_, body := buildFoundContactEmail("Camera Bag", "hello", "")
+	assert.NotContains(t, body, "Reply to:", "body should omit reply line when empty")
+}
+
+func TestBuildFoundContactEmail_EscapesItemName(t *testing.T) {
+	_, body := buildFoundContactEmail(`<b>x</b>`, "hello", "")
+	assert.NotContains(t, body, "<b>x</b>", "raw item name markup should not appear in body")
+	assert.Contains(t, body, "&lt;b&gt;x&lt;/b&gt;", "item name should be HTML-escaped in body")
+}
+
+func TestBuildFoundContactEmail_EscapesFinderControlledFields(t *testing.T) {
+	_, body := buildFoundContactEmail("x", "<script>alert(1)</script>", "<b>a</b>@x")
+
+	assert.NotContains(t, body, "<script>alert(1)</script>", "raw message markup should not appear in body")
+	assert.Contains(t, body, "&lt;script&gt;alert(1)&lt;/script&gt;", "message should be HTML-escaped in body")
+
+	assert.NotContains(t, body, "<b>a</b>@x", "raw reply-to markup should not appear in body")
+	assert.Contains(t, body, "&lt;b&gt;a&lt;/b&gt;@x", "reply-to should be HTML-escaped in body")
+}

--- a/backend/internal/data/ent/group.go
+++ b/backend/internal/data/ent/group.go
@@ -26,6 +26,10 @@ type Group struct {
 	Name string `json:"name,omitempty"`
 	// Currency holds the value of the "currency" field.
 	Currency string `json:"currency,omitempty"`
+	// FoundContactEnabled holds the value of the "found_contact_enabled" field.
+	FoundContactEnabled bool `json:"found_contact_enabled,omitempty"`
+	// FoundContactMessage holds the value of the "found_contact_message" field.
+	FoundContactMessage string `json:"found_contact_message,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the GroupQuery when eager-loading is set.
 	Edges        GroupEdges `json:"edges"`
@@ -143,7 +147,9 @@ func (*Group) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case group.FieldName, group.FieldCurrency:
+		case group.FieldFoundContactEnabled:
+			values[i] = new(sql.NullBool)
+		case group.FieldName, group.FieldCurrency, group.FieldFoundContactMessage:
 			values[i] = new(sql.NullString)
 		case group.FieldCreatedAt, group.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
@@ -193,6 +199,18 @@ func (_m *Group) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field currency", values[i])
 			} else if value.Valid {
 				_m.Currency = value.String
+			}
+		case group.FieldFoundContactEnabled:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field found_contact_enabled", values[i])
+			} else if value.Valid {
+				_m.FoundContactEnabled = value.Bool
+			}
+		case group.FieldFoundContactMessage:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field found_contact_message", values[i])
+			} else if value.Valid {
+				_m.FoundContactMessage = value.String
 			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
@@ -286,6 +304,12 @@ func (_m *Group) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("currency=")
 	builder.WriteString(_m.Currency)
+	builder.WriteString(", ")
+	builder.WriteString("found_contact_enabled=")
+	builder.WriteString(fmt.Sprintf("%v", _m.FoundContactEnabled))
+	builder.WriteString(", ")
+	builder.WriteString("found_contact_message=")
+	builder.WriteString(_m.FoundContactMessage)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/backend/internal/data/ent/group/group.go
+++ b/backend/internal/data/ent/group/group.go
@@ -23,6 +23,10 @@ const (
 	FieldName = "name"
 	// FieldCurrency holds the string denoting the currency field in the database.
 	FieldCurrency = "currency"
+	// FieldFoundContactEnabled holds the string denoting the found_contact_enabled field in the database.
+	FieldFoundContactEnabled = "found_contact_enabled"
+	// FieldFoundContactMessage holds the string denoting the found_contact_message field in the database.
+	FieldFoundContactMessage = "found_contact_message"
 	// EdgeUsers holds the string denoting the users edge name in mutations.
 	EdgeUsers = "users"
 	// EdgeEntityTypes holds the string denoting the entity_types edge name in mutations.
@@ -113,6 +117,8 @@ var Columns = []string{
 	FieldUpdatedAt,
 	FieldName,
 	FieldCurrency,
+	FieldFoundContactEnabled,
+	FieldFoundContactMessage,
 }
 
 var (
@@ -142,6 +148,12 @@ var (
 	NameValidator func(string) error
 	// DefaultCurrency holds the default value on creation for the "currency" field.
 	DefaultCurrency string
+	// DefaultFoundContactEnabled holds the default value on creation for the "found_contact_enabled" field.
+	DefaultFoundContactEnabled bool
+	// DefaultFoundContactMessage holds the default value on creation for the "found_contact_message" field.
+	DefaultFoundContactMessage string
+	// FoundContactMessageValidator is a validator for the "found_contact_message" field. It is called by the builders before save.
+	FoundContactMessageValidator func(string) error
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() uuid.UUID
 )
@@ -172,6 +184,16 @@ func ByName(opts ...sql.OrderTermOption) OrderOption {
 // ByCurrency orders the results by the currency field.
 func ByCurrency(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCurrency, opts...).ToFunc()
+}
+
+// ByFoundContactEnabled orders the results by the found_contact_enabled field.
+func ByFoundContactEnabled(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldFoundContactEnabled, opts...).ToFunc()
+}
+
+// ByFoundContactMessage orders the results by the found_contact_message field.
+func ByFoundContactMessage(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldFoundContactMessage, opts...).ToFunc()
 }
 
 // ByUsersCount orders the results by users count.

--- a/backend/internal/data/ent/group/where.go
+++ b/backend/internal/data/ent/group/where.go
@@ -76,6 +76,16 @@ func Currency(v string) predicate.Group {
 	return predicate.Group(sql.FieldEQ(FieldCurrency, v))
 }
 
+// FoundContactEnabled applies equality check predicate on the "found_contact_enabled" field. It's identical to FoundContactEnabledEQ.
+func FoundContactEnabled(v bool) predicate.Group {
+	return predicate.Group(sql.FieldEQ(FieldFoundContactEnabled, v))
+}
+
+// FoundContactMessage applies equality check predicate on the "found_contact_message" field. It's identical to FoundContactMessageEQ.
+func FoundContactMessage(v string) predicate.Group {
+	return predicate.Group(sql.FieldEQ(FieldFoundContactMessage, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Group {
 	return predicate.Group(sql.FieldEQ(FieldCreatedAt, v))
@@ -284,6 +294,81 @@ func CurrencyEqualFold(v string) predicate.Group {
 // CurrencyContainsFold applies the ContainsFold predicate on the "currency" field.
 func CurrencyContainsFold(v string) predicate.Group {
 	return predicate.Group(sql.FieldContainsFold(FieldCurrency, v))
+}
+
+// FoundContactEnabledEQ applies the EQ predicate on the "found_contact_enabled" field.
+func FoundContactEnabledEQ(v bool) predicate.Group {
+	return predicate.Group(sql.FieldEQ(FieldFoundContactEnabled, v))
+}
+
+// FoundContactEnabledNEQ applies the NEQ predicate on the "found_contact_enabled" field.
+func FoundContactEnabledNEQ(v bool) predicate.Group {
+	return predicate.Group(sql.FieldNEQ(FieldFoundContactEnabled, v))
+}
+
+// FoundContactMessageEQ applies the EQ predicate on the "found_contact_message" field.
+func FoundContactMessageEQ(v string) predicate.Group {
+	return predicate.Group(sql.FieldEQ(FieldFoundContactMessage, v))
+}
+
+// FoundContactMessageNEQ applies the NEQ predicate on the "found_contact_message" field.
+func FoundContactMessageNEQ(v string) predicate.Group {
+	return predicate.Group(sql.FieldNEQ(FieldFoundContactMessage, v))
+}
+
+// FoundContactMessageIn applies the In predicate on the "found_contact_message" field.
+func FoundContactMessageIn(vs ...string) predicate.Group {
+	return predicate.Group(sql.FieldIn(FieldFoundContactMessage, vs...))
+}
+
+// FoundContactMessageNotIn applies the NotIn predicate on the "found_contact_message" field.
+func FoundContactMessageNotIn(vs ...string) predicate.Group {
+	return predicate.Group(sql.FieldNotIn(FieldFoundContactMessage, vs...))
+}
+
+// FoundContactMessageGT applies the GT predicate on the "found_contact_message" field.
+func FoundContactMessageGT(v string) predicate.Group {
+	return predicate.Group(sql.FieldGT(FieldFoundContactMessage, v))
+}
+
+// FoundContactMessageGTE applies the GTE predicate on the "found_contact_message" field.
+func FoundContactMessageGTE(v string) predicate.Group {
+	return predicate.Group(sql.FieldGTE(FieldFoundContactMessage, v))
+}
+
+// FoundContactMessageLT applies the LT predicate on the "found_contact_message" field.
+func FoundContactMessageLT(v string) predicate.Group {
+	return predicate.Group(sql.FieldLT(FieldFoundContactMessage, v))
+}
+
+// FoundContactMessageLTE applies the LTE predicate on the "found_contact_message" field.
+func FoundContactMessageLTE(v string) predicate.Group {
+	return predicate.Group(sql.FieldLTE(FieldFoundContactMessage, v))
+}
+
+// FoundContactMessageContains applies the Contains predicate on the "found_contact_message" field.
+func FoundContactMessageContains(v string) predicate.Group {
+	return predicate.Group(sql.FieldContains(FieldFoundContactMessage, v))
+}
+
+// FoundContactMessageHasPrefix applies the HasPrefix predicate on the "found_contact_message" field.
+func FoundContactMessageHasPrefix(v string) predicate.Group {
+	return predicate.Group(sql.FieldHasPrefix(FieldFoundContactMessage, v))
+}
+
+// FoundContactMessageHasSuffix applies the HasSuffix predicate on the "found_contact_message" field.
+func FoundContactMessageHasSuffix(v string) predicate.Group {
+	return predicate.Group(sql.FieldHasSuffix(FieldFoundContactMessage, v))
+}
+
+// FoundContactMessageEqualFold applies the EqualFold predicate on the "found_contact_message" field.
+func FoundContactMessageEqualFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldEqualFold(FieldFoundContactMessage, v))
+}
+
+// FoundContactMessageContainsFold applies the ContainsFold predicate on the "found_contact_message" field.
+func FoundContactMessageContainsFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldContainsFold(FieldFoundContactMessage, v))
 }
 
 // HasUsers applies the HasEdge predicate on the "users" edge.

--- a/backend/internal/data/ent/group_create.go
+++ b/backend/internal/data/ent/group_create.go
@@ -77,6 +77,34 @@ func (_c *GroupCreate) SetNillableCurrency(v *string) *GroupCreate {
 	return _c
 }
 
+// SetFoundContactEnabled sets the "found_contact_enabled" field.
+func (_c *GroupCreate) SetFoundContactEnabled(v bool) *GroupCreate {
+	_c.mutation.SetFoundContactEnabled(v)
+	return _c
+}
+
+// SetNillableFoundContactEnabled sets the "found_contact_enabled" field if the given value is not nil.
+func (_c *GroupCreate) SetNillableFoundContactEnabled(v *bool) *GroupCreate {
+	if v != nil {
+		_c.SetFoundContactEnabled(*v)
+	}
+	return _c
+}
+
+// SetFoundContactMessage sets the "found_contact_message" field.
+func (_c *GroupCreate) SetFoundContactMessage(v string) *GroupCreate {
+	_c.mutation.SetFoundContactMessage(v)
+	return _c
+}
+
+// SetNillableFoundContactMessage sets the "found_contact_message" field if the given value is not nil.
+func (_c *GroupCreate) SetNillableFoundContactMessage(v *string) *GroupCreate {
+	if v != nil {
+		_c.SetFoundContactMessage(*v)
+	}
+	return _c
+}
+
 // SetID sets the "id" field.
 func (_c *GroupCreate) SetID(v uuid.UUID) *GroupCreate {
 	_c.mutation.SetID(v)
@@ -258,6 +286,14 @@ func (_c *GroupCreate) defaults() {
 		v := group.DefaultCurrency
 		_c.mutation.SetCurrency(v)
 	}
+	if _, ok := _c.mutation.FoundContactEnabled(); !ok {
+		v := group.DefaultFoundContactEnabled
+		_c.mutation.SetFoundContactEnabled(v)
+	}
+	if _, ok := _c.mutation.FoundContactMessage(); !ok {
+		v := group.DefaultFoundContactMessage
+		_c.mutation.SetFoundContactMessage(v)
+	}
 	if _, ok := _c.mutation.ID(); !ok {
 		v := group.DefaultID()
 		_c.mutation.SetID(v)
@@ -282,6 +318,17 @@ func (_c *GroupCreate) check() error {
 	}
 	if _, ok := _c.mutation.Currency(); !ok {
 		return &ValidationError{Name: "currency", err: errors.New(`ent: missing required field "Group.currency"`)}
+	}
+	if _, ok := _c.mutation.FoundContactEnabled(); !ok {
+		return &ValidationError{Name: "found_contact_enabled", err: errors.New(`ent: missing required field "Group.found_contact_enabled"`)}
+	}
+	if _, ok := _c.mutation.FoundContactMessage(); !ok {
+		return &ValidationError{Name: "found_contact_message", err: errors.New(`ent: missing required field "Group.found_contact_message"`)}
+	}
+	if v, ok := _c.mutation.FoundContactMessage(); ok {
+		if err := group.FoundContactMessageValidator(v); err != nil {
+			return &ValidationError{Name: "found_contact_message", err: fmt.Errorf(`ent: validator failed for field "Group.found_contact_message": %w`, err)}
+		}
 	}
 	return nil
 }
@@ -333,6 +380,14 @@ func (_c *GroupCreate) createSpec() (*Group, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.Currency(); ok {
 		_spec.SetField(group.FieldCurrency, field.TypeString, value)
 		_node.Currency = value
+	}
+	if value, ok := _c.mutation.FoundContactEnabled(); ok {
+		_spec.SetField(group.FieldFoundContactEnabled, field.TypeBool, value)
+		_node.FoundContactEnabled = value
+	}
+	if value, ok := _c.mutation.FoundContactMessage(); ok {
+		_spec.SetField(group.FieldFoundContactMessage, field.TypeString, value)
+		_node.FoundContactMessage = value
 	}
 	if nodes := _c.mutation.UsersIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/backend/internal/data/ent/group_update.go
+++ b/backend/internal/data/ent/group_update.go
@@ -71,6 +71,34 @@ func (_u *GroupUpdate) SetNillableCurrency(v *string) *GroupUpdate {
 	return _u
 }
 
+// SetFoundContactEnabled sets the "found_contact_enabled" field.
+func (_u *GroupUpdate) SetFoundContactEnabled(v bool) *GroupUpdate {
+	_u.mutation.SetFoundContactEnabled(v)
+	return _u
+}
+
+// SetNillableFoundContactEnabled sets the "found_contact_enabled" field if the given value is not nil.
+func (_u *GroupUpdate) SetNillableFoundContactEnabled(v *bool) *GroupUpdate {
+	if v != nil {
+		_u.SetFoundContactEnabled(*v)
+	}
+	return _u
+}
+
+// SetFoundContactMessage sets the "found_contact_message" field.
+func (_u *GroupUpdate) SetFoundContactMessage(v string) *GroupUpdate {
+	_u.mutation.SetFoundContactMessage(v)
+	return _u
+}
+
+// SetNillableFoundContactMessage sets the "found_contact_message" field if the given value is not nil.
+func (_u *GroupUpdate) SetNillableFoundContactMessage(v *string) *GroupUpdate {
+	if v != nil {
+		_u.SetFoundContactMessage(*v)
+	}
+	return _u
+}
+
 // AddUserIDs adds the "users" edge to the User entity by IDs.
 func (_u *GroupUpdate) AddUserIDs(ids ...uuid.UUID) *GroupUpdate {
 	_u.mutation.AddUserIDs(ids...)
@@ -407,6 +435,11 @@ func (_u *GroupUpdate) check() error {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`ent: validator failed for field "Group.name": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.FoundContactMessage(); ok {
+		if err := group.FoundContactMessageValidator(v); err != nil {
+			return &ValidationError{Name: "found_contact_message", err: fmt.Errorf(`ent: validator failed for field "Group.found_contact_message": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -430,6 +463,12 @@ func (_u *GroupUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.Currency(); ok {
 		_spec.SetField(group.FieldCurrency, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.FoundContactEnabled(); ok {
+		_spec.SetField(group.FieldFoundContactEnabled, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.FoundContactMessage(); ok {
+		_spec.SetField(group.FieldFoundContactMessage, field.TypeString, value)
 	}
 	if _u.mutation.UsersCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -857,6 +896,34 @@ func (_u *GroupUpdateOne) SetNillableCurrency(v *string) *GroupUpdateOne {
 	return _u
 }
 
+// SetFoundContactEnabled sets the "found_contact_enabled" field.
+func (_u *GroupUpdateOne) SetFoundContactEnabled(v bool) *GroupUpdateOne {
+	_u.mutation.SetFoundContactEnabled(v)
+	return _u
+}
+
+// SetNillableFoundContactEnabled sets the "found_contact_enabled" field if the given value is not nil.
+func (_u *GroupUpdateOne) SetNillableFoundContactEnabled(v *bool) *GroupUpdateOne {
+	if v != nil {
+		_u.SetFoundContactEnabled(*v)
+	}
+	return _u
+}
+
+// SetFoundContactMessage sets the "found_contact_message" field.
+func (_u *GroupUpdateOne) SetFoundContactMessage(v string) *GroupUpdateOne {
+	_u.mutation.SetFoundContactMessage(v)
+	return _u
+}
+
+// SetNillableFoundContactMessage sets the "found_contact_message" field if the given value is not nil.
+func (_u *GroupUpdateOne) SetNillableFoundContactMessage(v *string) *GroupUpdateOne {
+	if v != nil {
+		_u.SetFoundContactMessage(*v)
+	}
+	return _u
+}
+
 // AddUserIDs adds the "users" edge to the User entity by IDs.
 func (_u *GroupUpdateOne) AddUserIDs(ids ...uuid.UUID) *GroupUpdateOne {
 	_u.mutation.AddUserIDs(ids...)
@@ -1206,6 +1273,11 @@ func (_u *GroupUpdateOne) check() error {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`ent: validator failed for field "Group.name": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.FoundContactMessage(); ok {
+		if err := group.FoundContactMessageValidator(v); err != nil {
+			return &ValidationError{Name: "found_contact_message", err: fmt.Errorf(`ent: validator failed for field "Group.found_contact_message": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -1246,6 +1318,12 @@ func (_u *GroupUpdateOne) sqlSave(ctx context.Context) (_node *Group, err error)
 	}
 	if value, ok := _u.mutation.Currency(); ok {
 		_spec.SetField(group.FieldCurrency, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.FoundContactEnabled(); ok {
+		_spec.SetField(group.FieldFoundContactEnabled, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.FoundContactMessage(); ok {
+		_spec.SetField(group.FieldFoundContactMessage, field.TypeString, value)
 	}
 	if _u.mutation.UsersCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/backend/internal/data/ent/migrate/schema.go
+++ b/backend/internal/data/ent/migrate/schema.go
@@ -374,6 +374,8 @@ var (
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "name", Type: field.TypeString, Size: 255},
 		{Name: "currency", Type: field.TypeString, Default: "usd"},
+		{Name: "found_contact_enabled", Type: field.TypeBool, Default: false},
+		{Name: "found_contact_message", Type: field.TypeString, Size: 500, Default: ""},
 	}
 	// GroupsTable holds the schema information for the "groups" table.
 	GroupsTable = &schema.Table{

--- a/backend/internal/data/ent/mutation.go
+++ b/backend/internal/data/ent/mutation.go
@@ -9504,6 +9504,8 @@ type GroupMutation struct {
 	updated_at               *time.Time
 	name                     *string
 	currency                 *string
+	found_contact_enabled    *bool
+	found_contact_message    *string
 	clearedFields            map[string]struct{}
 	users                    map[uuid.UUID]struct{}
 	removedusers             map[uuid.UUID]struct{}
@@ -9780,6 +9782,78 @@ func (m *GroupMutation) OldCurrency(ctx context.Context) (v string, err error) {
 // ResetCurrency resets all changes to the "currency" field.
 func (m *GroupMutation) ResetCurrency() {
 	m.currency = nil
+}
+
+// SetFoundContactEnabled sets the "found_contact_enabled" field.
+func (m *GroupMutation) SetFoundContactEnabled(b bool) {
+	m.found_contact_enabled = &b
+}
+
+// FoundContactEnabled returns the value of the "found_contact_enabled" field in the mutation.
+func (m *GroupMutation) FoundContactEnabled() (r bool, exists bool) {
+	v := m.found_contact_enabled
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldFoundContactEnabled returns the old "found_contact_enabled" field's value of the Group entity.
+// If the Group object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *GroupMutation) OldFoundContactEnabled(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldFoundContactEnabled is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldFoundContactEnabled requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldFoundContactEnabled: %w", err)
+	}
+	return oldValue.FoundContactEnabled, nil
+}
+
+// ResetFoundContactEnabled resets all changes to the "found_contact_enabled" field.
+func (m *GroupMutation) ResetFoundContactEnabled() {
+	m.found_contact_enabled = nil
+}
+
+// SetFoundContactMessage sets the "found_contact_message" field.
+func (m *GroupMutation) SetFoundContactMessage(s string) {
+	m.found_contact_message = &s
+}
+
+// FoundContactMessage returns the value of the "found_contact_message" field in the mutation.
+func (m *GroupMutation) FoundContactMessage() (r string, exists bool) {
+	v := m.found_contact_message
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldFoundContactMessage returns the old "found_contact_message" field's value of the Group entity.
+// If the Group object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *GroupMutation) OldFoundContactMessage(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldFoundContactMessage is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldFoundContactMessage requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldFoundContactMessage: %w", err)
+	}
+	return oldValue.FoundContactMessage, nil
+}
+
+// ResetFoundContactMessage resets all changes to the "found_contact_message" field.
+func (m *GroupMutation) ResetFoundContactMessage() {
+	m.found_contact_message = nil
 }
 
 // AddUserIDs adds the "users" edge to the User entity by ids.
@@ -10248,7 +10322,7 @@ func (m *GroupMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *GroupMutation) Fields() []string {
-	fields := make([]string, 0, 4)
+	fields := make([]string, 0, 6)
 	if m.created_at != nil {
 		fields = append(fields, group.FieldCreatedAt)
 	}
@@ -10260,6 +10334,12 @@ func (m *GroupMutation) Fields() []string {
 	}
 	if m.currency != nil {
 		fields = append(fields, group.FieldCurrency)
+	}
+	if m.found_contact_enabled != nil {
+		fields = append(fields, group.FieldFoundContactEnabled)
+	}
+	if m.found_contact_message != nil {
+		fields = append(fields, group.FieldFoundContactMessage)
 	}
 	return fields
 }
@@ -10277,6 +10357,10 @@ func (m *GroupMutation) Field(name string) (ent.Value, bool) {
 		return m.Name()
 	case group.FieldCurrency:
 		return m.Currency()
+	case group.FieldFoundContactEnabled:
+		return m.FoundContactEnabled()
+	case group.FieldFoundContactMessage:
+		return m.FoundContactMessage()
 	}
 	return nil, false
 }
@@ -10294,6 +10378,10 @@ func (m *GroupMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldName(ctx)
 	case group.FieldCurrency:
 		return m.OldCurrency(ctx)
+	case group.FieldFoundContactEnabled:
+		return m.OldFoundContactEnabled(ctx)
+	case group.FieldFoundContactMessage:
+		return m.OldFoundContactMessage(ctx)
 	}
 	return nil, fmt.Errorf("unknown Group field %s", name)
 }
@@ -10330,6 +10418,20 @@ func (m *GroupMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCurrency(v)
+		return nil
+	case group.FieldFoundContactEnabled:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetFoundContactEnabled(v)
+		return nil
+	case group.FieldFoundContactMessage:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetFoundContactMessage(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Group field %s", name)
@@ -10391,6 +10493,12 @@ func (m *GroupMutation) ResetField(name string) error {
 		return nil
 	case group.FieldCurrency:
 		m.ResetCurrency()
+		return nil
+	case group.FieldFoundContactEnabled:
+		m.ResetFoundContactEnabled()
+		return nil
+	case group.FieldFoundContactMessage:
+		m.ResetFoundContactMessage()
 		return nil
 	}
 	return fmt.Errorf("unknown Group field %s", name)

--- a/backend/internal/data/ent/runtime.go
+++ b/backend/internal/data/ent/runtime.go
@@ -494,6 +494,16 @@ func init() {
 	groupDescCurrency := groupFields[1].Descriptor()
 	// group.DefaultCurrency holds the default value on creation for the currency field.
 	group.DefaultCurrency = groupDescCurrency.Default.(string)
+	// groupDescFoundContactEnabled is the schema descriptor for found_contact_enabled field.
+	groupDescFoundContactEnabled := groupFields[2].Descriptor()
+	// group.DefaultFoundContactEnabled holds the default value on creation for the found_contact_enabled field.
+	group.DefaultFoundContactEnabled = groupDescFoundContactEnabled.Default.(bool)
+	// groupDescFoundContactMessage is the schema descriptor for found_contact_message field.
+	groupDescFoundContactMessage := groupFields[3].Descriptor()
+	// group.DefaultFoundContactMessage holds the default value on creation for the found_contact_message field.
+	group.DefaultFoundContactMessage = groupDescFoundContactMessage.Default.(string)
+	// group.FoundContactMessageValidator is a validator for the "found_contact_message" field. It is called by the builders before save.
+	group.FoundContactMessageValidator = groupDescFoundContactMessage.Validators[0].(func(string) error)
 	// groupDescID is the schema descriptor for id field.
 	groupDescID := groupMixinFields0[0].Descriptor()
 	// group.DefaultID holds the default value on creation for the id field.

--- a/backend/internal/data/ent/schema/group.go
+++ b/backend/internal/data/ent/schema/group.go
@@ -29,6 +29,11 @@ func (Group) Fields() []ent.Field {
 			NotEmpty(),
 		field.String("currency").
 			Default("usd"),
+		field.Bool("found_contact_enabled").
+			Default(false),
+		field.String("found_contact_message").
+			MaxLen(500).
+			Default(""),
 	}
 }
 

--- a/backend/internal/data/migrations/postgres/20260730120001_add_found_contact_fields.sql
+++ b/backend/internal/data/migrations/postgres/20260730120001_add_found_contact_fields.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+ALTER TABLE "groups"
+    ADD COLUMN "found_contact_enabled" boolean NOT NULL DEFAULT false;
+ALTER TABLE "groups"
+    ADD COLUMN "found_contact_message" character varying NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE "groups" DROP COLUMN "found_contact_message";
+ALTER TABLE "groups" DROP COLUMN "found_contact_enabled";

--- a/backend/internal/data/migrations/sqlite3/20260730120000_add_found_contact_fields.sql
+++ b/backend/internal/data/migrations/sqlite3/20260730120000_add_found_contact_fields.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE groups ADD COLUMN found_contact_enabled BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE groups ADD COLUMN found_contact_message TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE groups DROP COLUMN found_contact_message;
+ALTER TABLE groups DROP COLUMN found_contact_enabled;

--- a/backend/internal/data/repo/repo_group.go
+++ b/backend/internal/data/repo/repo_group.go
@@ -116,6 +116,14 @@ type (
 		Name  string    `json:"name"`
 		Total float64   `json:"total"`
 	}
+
+	FoundContact struct {
+		ItemID     uuid.UUID
+		ItemName   string
+		Message    string
+		OwnerName  string
+		OwnerEmail string
+	}
 )
 
 func (r *GroupRepository) GetAllGroups(ctx context.Context, userID uuid.UUID) ([]Group, error) {
@@ -476,6 +484,67 @@ func (r *GroupRepository) IsOwnerOf(ctx context.Context, userID, groupID uuid.UU
 			usergroup.RoleEQ(usergroup.RoleOwner),
 		).
 		Exist(ctx)
+}
+
+// FoundContactByItemID returns the public found-item contact details for an
+// item, but only when the owning group has opted in. Missing items, archived
+// items (sold/disposed), and disabled groups all return ent not-found errors
+// so callers cannot tell them apart.
+func (r *GroupRepository) FoundContactByItemID(ctx context.Context, itemID uuid.UUID) (FoundContact, error) {
+	e, err := r.db.Entity.Query().
+		Where(
+			entity.ID(itemID),
+			entity.Archived(false),
+			entity.HasGroupWith(group.FoundContactEnabled(true)),
+		).
+		WithGroup().
+		Only(ctx)
+	if err != nil {
+		return FoundContact{}, err
+	}
+	return r.foundContactFromEntity(ctx, e)
+}
+
+// FoundContactByAssetID resolves an asset ID across all opted-in groups.
+// Asset IDs are only unique within a group, so anything other than exactly
+// one match is treated as not found.
+func (r *GroupRepository) FoundContactByAssetID(ctx context.Context, assetID AssetID) (FoundContact, error) {
+	matches, err := r.db.Entity.Query().
+		Where(
+			entity.AssetID(int64(assetID)),
+			entity.Archived(false),
+			entity.HasGroupWith(group.FoundContactEnabled(true)),
+		).
+		WithGroup().
+		Limit(2).
+		All(ctx)
+	if err != nil {
+		return FoundContact{}, err
+	}
+	if len(matches) != 1 {
+		return FoundContact{}, &ent.NotFoundError{}
+	}
+	return r.foundContactFromEntity(ctx, matches[0])
+}
+
+func (r *GroupRepository) foundContactFromEntity(ctx context.Context, e *ent.Entity) (FoundContact, error) {
+	owner, err := r.db.User.Query().
+		Where(user.HasUserGroupsWith(
+			usergroup.GroupID(e.Edges.Group.ID),
+			usergroup.RoleEQ(usergroup.RoleOwner),
+		)).
+		Order(ent.Asc(user.FieldCreatedAt)).
+		First(ctx)
+	if err != nil {
+		return FoundContact{}, err
+	}
+	return FoundContact{
+		ItemID:     e.ID,
+		ItemName:   e.Name,
+		Message:    e.Edges.Group.FoundContactMessage,
+		OwnerName:  owner.Name,
+		OwnerEmail: owner.Email,
+	}, nil
 }
 
 func (r *GroupRepository) RemoveMember(ctx context.Context, groupID, userID uuid.UUID) error {

--- a/backend/internal/data/repo/repo_group.go
+++ b/backend/internal/data/repo/repo_group.go
@@ -31,11 +31,13 @@ type GroupRepository struct {
 func NewGroupRepository(db *ent.Client) *GroupRepository {
 	gmap := func(g *ent.Group) Group {
 		return Group{
-			ID:        g.ID,
-			Name:      g.Name,
-			CreatedAt: g.CreatedAt,
-			UpdatedAt: g.UpdatedAt,
-			Currency:  strings.ToUpper(g.Currency),
+			ID:                  g.ID,
+			Name:                g.Name,
+			CreatedAt:           g.CreatedAt,
+			UpdatedAt:           g.UpdatedAt,
+			Currency:            strings.ToUpper(g.Currency),
+			FoundContactEnabled: g.FoundContactEnabled,
+			FoundContactMessage: g.FoundContactMessage,
 		}
 	}
 
@@ -57,16 +59,20 @@ func NewGroupRepository(db *ent.Client) *GroupRepository {
 
 type (
 	Group struct {
-		ID        uuid.UUID `json:"id,omitempty"`
-		Name      string    `json:"name,omitempty"`
-		CreatedAt time.Time `json:"createdAt,omitempty"`
-		UpdatedAt time.Time `json:"updatedAt,omitempty"`
-		Currency  string    `json:"currency,omitempty"`
+		ID                  uuid.UUID `json:"id,omitempty"`
+		Name                string    `json:"name,omitempty"`
+		CreatedAt           time.Time `json:"createdAt,omitempty"`
+		UpdatedAt           time.Time `json:"updatedAt,omitempty"`
+		Currency            string    `json:"currency,omitempty"`
+		FoundContactEnabled bool      `json:"foundContactEnabled"`
+		FoundContactMessage string    `json:"foundContactMessage"`
 	}
 
 	GroupUpdate struct {
-		Name     string `json:"name"`
-		Currency string `json:"currency"`
+		Name                string  `json:"name"`
+		Currency            string  `json:"currency"`
+		FoundContactEnabled *bool   `json:"foundContactEnabled,omitempty"`
+		FoundContactMessage *string `json:"foundContactMessage,omitempty"`
 	}
 
 	GroupInvitationCreate struct {
@@ -312,11 +318,18 @@ func (r *GroupRepository) GroupCreate(ctx context.Context, name string, userID u
 }
 
 func (r *GroupRepository) GroupUpdate(ctx context.Context, id uuid.UUID, data GroupUpdate) (Group, error) {
-	entity, err := r.db.Group.UpdateOneID(id).
+	q := r.db.Group.UpdateOneID(id).
 		SetName(data.Name).
-		SetCurrency(strings.ToLower(data.Currency)).
-		Save(ctx)
+		SetCurrency(strings.ToLower(data.Currency))
 
+	if data.FoundContactEnabled != nil {
+		q = q.SetFoundContactEnabled(*data.FoundContactEnabled)
+	}
+	if data.FoundContactMessage != nil {
+		q = q.SetFoundContactMessage(*data.FoundContactMessage)
+	}
+
+	entity, err := q.Save(ctx)
 	return r.groupMapper.MapErr(entity, err)
 }
 

--- a/backend/internal/data/repo/repo_group_found_test.go
+++ b/backend/internal/data/repo/repo_group_found_test.go
@@ -218,9 +218,16 @@ func TestGroupRepository_FoundContact_ExcludesArchivedItems(t *testing.T) {
 	assetID := nextAssetID()
 	require.NoError(t, tClient.Entity.UpdateOneID(item.ID).SetAssetID(int64(assetID)).Exec(ctx))
 
+	// Confirm both lookups succeed before archiving, so the test is
+	// self-contained and doesn't rely on other tests to prove the happy path.
+	_, err := tRepos.Groups.FoundContactByItemID(ctx, item.ID)
+	require.NoError(t, err)
+	_, err = tRepos.Groups.FoundContactByAssetID(ctx, assetID)
+	require.NoError(t, err)
+
 	require.NoError(t, tClient.Entity.UpdateOneID(item.ID).SetArchived(true).Exec(ctx))
 
-	_, err := tRepos.Groups.FoundContactByItemID(ctx, item.ID)
+	_, err = tRepos.Groups.FoundContactByItemID(ctx, item.ID)
 	require.Error(t, err)
 	assert.True(t, ent.IsNotFound(err))
 

--- a/backend/internal/data/repo/repo_group_found_test.go
+++ b/backend/internal/data/repo/repo_group_found_test.go
@@ -1,0 +1,274 @@
+package repo
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/usergroup"
+)
+
+// assetIDSeq hands out strictly increasing asset IDs so tests never reuse a
+// value. FoundContact data (opted-in groups and their items) persists for
+// the lifetime of the test binary, so a hardcoded literal reused across
+// -count=N reruns of the same test would collide with data left behind by
+// the previous run.
+var assetIDSeq int64 = 900000
+
+func nextAssetID() AssetID {
+	return AssetID(atomic.AddInt64(&assetIDSeq, 1))
+}
+
+// foundContactGroup creates a fresh group with its own dedicated owner user.
+//
+// The shared tGroup/tUser fixtures cannot be reused here: bootstrap() creates
+// tGroup via GroupCreate(ctx, "test-group", uuid.Nil), which skips creating
+// any owner membership, and tUser is created via userFactory(), which does
+// not set UserCreate.IsOwner. So tUser is never an owner of tGroup, which
+// FoundContact's owner lookup requires.
+func foundContactGroup(t *testing.T) (Group, UserOut) {
+	t.Helper()
+	ctx := context.Background()
+
+	g, err := tRepos.Groups.GroupCreate(ctx, "found-contact-"+fk.Str(8), uuid.Nil)
+	require.NoError(t, err)
+
+	owner, err := tRepos.Users.Create(ctx, UserCreate{
+		Name:           fk.Str(10),
+		Email:          fk.Email(),
+		Password:       new(fk.Str(10)),
+		DefaultGroupID: g.ID,
+		IsOwner:        true,
+	})
+	require.NoError(t, err)
+
+	return g, owner
+}
+
+// enableFoundContact opts a group into found-item contact with the given
+// message. Name/Currency must be re-supplied because GroupUpdate overwrites
+// them unconditionally.
+func enableFoundContact(t *testing.T, g Group, message string) {
+	t.Helper()
+	ctx := context.Background()
+
+	enabled := true
+	_, err := tRepos.Groups.GroupUpdate(ctx, g.ID, GroupUpdate{
+		Name:                g.Name,
+		Currency:            g.Currency,
+		FoundContactEnabled: &enabled,
+		FoundContactMessage: &message,
+	})
+	require.NoError(t, err)
+}
+
+// createFoundContactItem creates a single item entity in the given group.
+func createFoundContactItem(t *testing.T, groupID uuid.UUID) EntityOut {
+	t.Helper()
+	ctx := context.Background()
+
+	itemET, err := tRepos.EntityTypes.GetDefault(ctx, groupID, false)
+	require.NoError(t, err)
+
+	item, err := tRepos.Entities.Create(ctx, groupID, EntityCreate{
+		Name:         fk.Str(10),
+		Description:  fk.Str(50),
+		EntityTypeID: itemET.ID,
+	})
+	require.NoError(t, err)
+
+	return item
+}
+
+// createOwnerAt creates an owner user for groupID with an explicit CreatedAt,
+// bypassing the repo layer (which always stamps CreatedAt with time.Now()).
+// Relying on two sequential repo calls landing in distinguishably-ordered
+// sqlite-stored instants would be flaky, so tests that need a deterministic
+// "earliest owner" set the timestamps explicitly instead.
+func createOwnerAt(t *testing.T, groupID uuid.UUID, createdAt time.Time) *ent.User {
+	t.Helper()
+	ctx := context.Background()
+
+	u, err := tClient.User.Create().
+		SetName(fk.Str(10)).
+		SetEmail(fk.Email()).
+		SetIsSuperuser(false).
+		SetDefaultGroupID(groupID).
+		SetCreatedAt(createdAt).
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = tClient.UserGroup.Create().
+		SetUserID(u.ID).
+		SetGroupID(groupID).
+		SetRole(usergroup.RoleOwner).
+		Save(ctx)
+	require.NoError(t, err)
+
+	return u
+}
+
+func TestGroupRepository_FoundContactByItemID_HappyPath(t *testing.T) {
+	ctx := context.Background()
+
+	g, owner := foundContactGroup(t)
+	enableFoundContact(t, g, "call me")
+
+	item := createFoundContactItem(t, g.ID)
+
+	fc, err := tRepos.Groups.FoundContactByItemID(ctx, item.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, item.ID, fc.ItemID)
+	assert.NotEmpty(t, fc.ItemName)
+	assert.Equal(t, "call me", fc.Message)
+	assert.Equal(t, owner.Name, fc.OwnerName)
+	assert.Equal(t, owner.Email, fc.OwnerEmail)
+}
+
+func TestGroupRepository_FoundContactByItemID_NotOptedIn(t *testing.T) {
+	ctx := context.Background()
+
+	g, _ := foundContactGroup(t)
+	// found-contact left at its default (disabled).
+
+	item := createFoundContactItem(t, g.ID)
+
+	_, err := tRepos.Groups.FoundContactByItemID(ctx, item.ID)
+	require.Error(t, err)
+	assert.True(t, ent.IsNotFound(err))
+}
+
+func TestGroupRepository_FoundContactByItemID_NonExistent(t *testing.T) {
+	ctx := context.Background()
+
+	g, _ := foundContactGroup(t)
+	enableFoundContact(t, g, "call me")
+
+	_, err := tRepos.Groups.FoundContactByItemID(ctx, uuid.New())
+	require.Error(t, err)
+	assert.True(t, ent.IsNotFound(err))
+}
+
+func TestGroupRepository_FoundContactByAssetID_HappyPath(t *testing.T) {
+	ctx := context.Background()
+
+	g, owner := foundContactGroup(t)
+	enableFoundContact(t, g, "call me too")
+
+	item := createFoundContactItem(t, g.ID)
+	assetID := nextAssetID()
+	require.NoError(t, tClient.Entity.UpdateOneID(item.ID).SetAssetID(int64(assetID)).Exec(ctx))
+
+	fc, err := tRepos.Groups.FoundContactByAssetID(ctx, assetID)
+	require.NoError(t, err)
+
+	assert.Equal(t, item.ID, fc.ItemID)
+	assert.NotEmpty(t, fc.ItemName)
+	assert.Equal(t, "call me too", fc.Message)
+	assert.Equal(t, owner.Name, fc.OwnerName)
+	assert.Equal(t, owner.Email, fc.OwnerEmail)
+}
+
+func TestGroupRepository_FoundContactByAssetID_NoMatch(t *testing.T) {
+	ctx := context.Background()
+
+	g, _ := foundContactGroup(t)
+	enableFoundContact(t, g, "call me")
+
+	_, err := tRepos.Groups.FoundContactByAssetID(ctx, nextAssetID())
+	require.Error(t, err)
+	assert.True(t, ent.IsNotFound(err))
+}
+
+func TestGroupRepository_FoundContactByAssetID_Ambiguous(t *testing.T) {
+	ctx := context.Background()
+	assetID := nextAssetID()
+
+	g1, _ := foundContactGroup(t)
+	enableFoundContact(t, g1, "call me")
+	item1 := createFoundContactItem(t, g1.ID)
+	require.NoError(t, tClient.Entity.UpdateOneID(item1.ID).SetAssetID(int64(assetID)).Exec(ctx))
+
+	g2, _ := foundContactGroup(t)
+	enableFoundContact(t, g2, "call me")
+	item2 := createFoundContactItem(t, g2.ID)
+	require.NoError(t, tClient.Entity.UpdateOneID(item2.ID).SetAssetID(int64(assetID)).Exec(ctx))
+
+	_, err := tRepos.Groups.FoundContactByAssetID(ctx, assetID)
+	require.Error(t, err)
+	assert.True(t, ent.IsNotFound(err))
+}
+
+// Archived (sold/disposed) items must read as not-found for both lookups,
+// even though their group is opted in — the item is no longer something
+// anyone should be able to return.
+func TestGroupRepository_FoundContact_ExcludesArchivedItems(t *testing.T) {
+	ctx := context.Background()
+
+	g, _ := foundContactGroup(t)
+	enableFoundContact(t, g, "call me")
+
+	item := createFoundContactItem(t, g.ID)
+	assetID := nextAssetID()
+	require.NoError(t, tClient.Entity.UpdateOneID(item.ID).SetAssetID(int64(assetID)).Exec(ctx))
+
+	require.NoError(t, tClient.Entity.UpdateOneID(item.ID).SetArchived(true).Exec(ctx))
+
+	_, err := tRepos.Groups.FoundContactByItemID(ctx, item.ID)
+	require.Error(t, err)
+	assert.True(t, ent.IsNotFound(err))
+
+	_, err = tRepos.Groups.FoundContactByAssetID(ctx, assetID)
+	require.Error(t, err)
+	assert.True(t, ent.IsNotFound(err))
+}
+
+// An opted-in group with no owner membership must not leak contact details;
+// the owner-resolution query in foundContactFromEntity has to fail closed.
+func TestGroupRepository_FoundContact_NoOwner(t *testing.T) {
+	ctx := context.Background()
+
+	g, err := tRepos.Groups.GroupCreate(ctx, "found-contact-no-owner-"+fk.Str(8), uuid.Nil)
+	require.NoError(t, err)
+	enableFoundContact(t, g, "call me")
+
+	item := createFoundContactItem(t, g.ID)
+	assetID := nextAssetID()
+	require.NoError(t, tClient.Entity.UpdateOneID(item.ID).SetAssetID(int64(assetID)).Exec(ctx))
+
+	_, err = tRepos.Groups.FoundContactByItemID(ctx, item.ID)
+	require.Error(t, err)
+	assert.True(t, ent.IsNotFound(err))
+
+	_, err = tRepos.Groups.FoundContactByAssetID(ctx, assetID)
+	require.Error(t, err)
+	assert.True(t, ent.IsNotFound(err))
+}
+
+// When a group somehow has two owner memberships, the earliest-created owner
+// wins deterministically rather than depending on query/storage order.
+func TestGroupRepository_FoundContact_MultipleOwners_EarliestWins(t *testing.T) {
+	ctx := context.Background()
+
+	g, err := tRepos.Groups.GroupCreate(ctx, "found-contact-multi-owner-"+fk.Str(8), uuid.Nil)
+	require.NoError(t, err)
+	enableFoundContact(t, g, "call me")
+
+	base := time.Now().Add(-time.Hour)
+	earliest := createOwnerAt(t, g.ID, base)
+	_ = createOwnerAt(t, g.ID, base.Add(time.Minute))
+
+	item := createFoundContactItem(t, g.ID)
+
+	fc, err := tRepos.Groups.FoundContactByItemID(ctx, item.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, earliest.Name, fc.OwnerName)
+	assert.Equal(t, earliest.Email, fc.OwnerEmail)
+}

--- a/backend/internal/data/repo/repo_group_test.go
+++ b/backend/internal/data/repo/repo_group_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -54,6 +55,28 @@ func Test_Group_Update(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "test2", g.Name)
 	assert.Equal(t, "EUR", g.Currency)
+
+	// Setting found-contact fields via non-nil pointers persists them.
+	g, err = tRepos.Groups.GroupUpdate(context.Background(), g.ID, GroupUpdate{
+		Name:                "test2",
+		Currency:            "eur",
+		FoundContactEnabled: lo.ToPtr(true),
+		FoundContactMessage: lo.ToPtr("email me at test@example.com"),
+	})
+	require.NoError(t, err)
+	assert.True(t, g.FoundContactEnabled)
+	assert.Equal(t, "email me at test@example.com", g.FoundContactMessage)
+
+	// Updating again with nil pointers (only name/currency) must not reset
+	// the found-contact fields.
+	g, err = tRepos.Groups.GroupUpdate(context.Background(), g.ID, GroupUpdate{
+		Name:     "test3",
+		Currency: "usd",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "test3", g.Name)
+	assert.True(t, g.FoundContactEnabled)
+	assert.Equal(t, "email me at test@example.com", g.FoundContactMessage)
 }
 
 // TODO: Fix this test at some point, the data itself in production/development is working fine, it only fails on the test

--- a/docs/public/api/openapi-3.0.json
+++ b/docs/public/api/openapi-3.0.json
@@ -1258,6 +1258,120 @@
                 }
             }
         },
+        "/v1/found/{kind}/{id}": {
+            "get": {
+                "description": "Public, unauthenticated lookup for the found-item contact page. Resolves an\nitem by UUID (kind \"item\") or by asset ID (kind \"asset\") when the owning\ngroup has opted in. Returns 404 for anything that does not resolve, with no\ndistinction between missing, archived, opted-out, or ambiguous.",
+                "tags": [
+                    "Found"
+                ],
+                "summary": "Get Found Item Contact Page",
+                "parameters": [
+                    {
+                        "description": "ID kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "item",
+                                "asset"
+                            ]
+                        }
+                    },
+                    {
+                        "description": "Item UUID or asset ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/v1.FoundItemResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "item not found or found-item contact not enabled",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/found/{kind}/{id}/contact": {
+            "post": {
+                "description": "Relays a finder's message to the item owner by email. After basic input\nvalidation this always returns 204, whether or not the item resolved or\nthe email was sent, so the endpoint cannot be used to probe for items.",
+                "tags": [
+                    "Found"
+                ],
+                "summary": "Send Found Item Contact Message",
+                "parameters": [
+                    {
+                        "description": "ID kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "item",
+                                "asset"
+                            ]
+                        }
+                    },
+                    {
+                        "description": "Item UUID or asset ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/v1.FoundContactRequest"
+                            }
+                        }
+                    },
+                    "description": "Message",
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "invalid request body, empty or oversized message, or invalid reply-to address",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v1/group/exports": {
             "get": {
                 "security": [
@@ -4236,6 +4350,14 @@
                             }
                         ]
                     },
+                    "found_contact_enabled": {
+                        "description": "FoundContactEnabled holds the value of the \"found_contact_enabled\" field.",
+                        "type": "boolean"
+                    },
+                    "found_contact_message": {
+                        "description": "FoundContactMessage holds the value of the \"found_contact_message\" field.",
+                        "type": "string"
+                    },
                     "id": {
                         "description": "ID of the ent.",
                         "type": "string"
@@ -5898,6 +6020,12 @@
                     "currency": {
                         "type": "string"
                     },
+                    "foundContactEnabled": {
+                        "type": "boolean"
+                    },
+                    "foundContactMessage": {
+                        "type": "string"
+                    },
                     "id": {
                         "type": "string"
                     },
@@ -5953,6 +6081,12 @@
                 "type": "object",
                 "properties": {
                     "currency": {
+                        "type": "string"
+                    },
+                    "foundContactEnabled": {
+                        "type": "boolean"
+                    },
+                    "foundContactMessage": {
                         "type": "string"
                     },
                     "name": {
@@ -6700,6 +6834,42 @@
                     "email": {
                         "type": "string",
                         "example": "user@example.com"
+                    }
+                }
+            },
+            "v1.FoundContactRequest": {
+                "type": "object",
+                "required": [
+                    "message"
+                ],
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "maxLength": 2000
+                    },
+                    "replyTo": {
+                        "type": "string"
+                    }
+                }
+            },
+            "v1.FoundItemResponse": {
+                "type": "object",
+                "properties": {
+                    "email": {
+                        "type": "string"
+                    },
+                    "itemId": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "mode": {
+                        "type": "string",
+                        "enum": [
+                            "form",
+                            "mailto"
+                        ]
                     }
                 }
             },

--- a/docs/public/api/openapi-3.0.yaml
+++ b/docs/public/api/openapi-3.0.yaml
@@ -753,6 +753,91 @@ paths:
       responses:
         "204":
           description: No Content
+  "/v1/found/{kind}/{id}":
+    get:
+      description: >-
+        Public, unauthenticated lookup for the found-item contact page. Resolves
+        an
+
+        item by UUID (kind "item") or by asset ID (kind "asset") when the owning
+
+        group has opted in. Returns 404 for anything that does not resolve, with no
+
+        distinction between missing, archived, opted-out, or ambiguous.
+      tags:
+        - Found
+      summary: Get Found Item Contact Page
+      parameters:
+        - description: ID kind
+          name: kind
+          in: path
+          required: true
+          schema:
+            type: string
+            enum:
+              - item
+              - asset
+        - description: Item UUID or asset ID
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1.FoundItemResponse"
+        "404":
+          description: item not found or found-item contact not enabled
+          content:
+            application/json:
+              schema:
+                type: string
+  "/v1/found/{kind}/{id}/contact":
+    post:
+      description: |-
+        Relays a finder's message to the item owner by email. After basic input
+        validation this always returns 204, whether or not the item resolved or
+        the email was sent, so the endpoint cannot be used to probe for items.
+      tags:
+        - Found
+      summary: Send Found Item Contact Message
+      parameters:
+        - description: ID kind
+          name: kind
+          in: path
+          required: true
+          schema:
+            type: string
+            enum:
+              - item
+              - asset
+        - description: Item UUID or asset ID
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/v1.FoundContactRequest"
+        description: Message
+        required: true
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: invalid request body, empty or oversized message, or invalid
+            reply-to address
+          content:
+            application/json:
+              schema:
+                type: string
   /v1/group/exports:
     get:
       security:
@@ -2610,6 +2695,14 @@ components:
             The values are being populated by the GroupQuery when eager-loading is set.
           allOf:
             - $ref: "#/components/schemas/ent.GroupEdges"
+        found_contact_enabled:
+          description: FoundContactEnabled holds the value of the "found_contact_enabled"
+            field.
+          type: boolean
+        found_contact_message:
+          description: FoundContactMessage holds the value of the "found_contact_message"
+            field.
+          type: string
         id:
           description: ID of the ent.
           type: string
@@ -3778,6 +3871,10 @@ components:
           type: string
         currency:
           type: string
+        foundContactEnabled:
+          type: boolean
+        foundContactMessage:
+          type: string
         id:
           type: string
         name:
@@ -3814,6 +3911,10 @@ components:
       type: object
       properties:
         currency:
+          type: string
+        foundContactEnabled:
+          type: boolean
+        foundContactMessage:
           type: string
         name:
           type: string
@@ -4318,6 +4419,30 @@ components:
         email:
           type: string
           example: user@example.com
+    v1.FoundContactRequest:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          maxLength: 2000
+        replyTo:
+          type: string
+    v1.FoundItemResponse:
+      type: object
+      properties:
+        email:
+          type: string
+        itemId:
+          type: string
+        message:
+          type: string
+        mode:
+          type: string
+          enum:
+            - form
+            - mailto
     v1.GroupAcceptInvitationResponse:
       type: object
       properties:

--- a/docs/public/api/swagger-2.0.json
+++ b/docs/public/api/swagger-2.0.json
@@ -1152,6 +1152,107 @@
                 }
             }
         },
+        "/v1/found/{kind}/{id}": {
+            "get": {
+                "description": "Public, unauthenticated lookup for the found-item contact page. Resolves an\nitem by UUID (kind \"item\") or by asset ID (kind \"asset\") when the owning\ngroup has opted in. Returns 404 for anything that does not resolve, with no\ndistinction between missing, archived, opted-out, or ambiguous.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Found"
+                ],
+                "summary": "Get Found Item Contact Page",
+                "parameters": [
+                    {
+                        "enum": [
+                            "item",
+                            "asset"
+                        ],
+                        "type": "string",
+                        "description": "ID kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Item UUID or asset ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1.FoundItemResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "item not found or found-item contact not enabled",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/found/{kind}/{id}/contact": {
+            "post": {
+                "description": "Relays a finder's message to the item owner by email. After basic input\nvalidation this always returns 204, whether or not the item resolved or\nthe email was sent, so the endpoint cannot be used to probe for items.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Found"
+                ],
+                "summary": "Send Found Item Contact Message",
+                "parameters": [
+                    {
+                        "enum": [
+                            "item",
+                            "asset"
+                        ],
+                        "type": "string",
+                        "description": "ID kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Item UUID or asset ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Message",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v1.FoundContactRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "invalid request body, empty or oversized message, or invalid reply-to address",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/group/exports": {
             "get": {
                 "security": [
@@ -3994,6 +4095,14 @@
                         }
                     ]
                 },
+                "found_contact_enabled": {
+                    "description": "FoundContactEnabled holds the value of the \"found_contact_enabled\" field.",
+                    "type": "boolean"
+                },
+                "found_contact_message": {
+                    "description": "FoundContactMessage holds the value of the \"found_contact_message\" field.",
+                    "type": "string"
+                },
                 "id": {
                     "description": "ID of the ent.",
                     "type": "string"
@@ -5656,6 +5765,12 @@
                 "currency": {
                     "type": "string"
                 },
+                "foundContactEnabled": {
+                    "type": "boolean"
+                },
+                "foundContactMessage": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -5711,6 +5826,12 @@
             "type": "object",
             "properties": {
                 "currency": {
+                    "type": "string"
+                },
+                "foundContactEnabled": {
+                    "type": "boolean"
+                },
+                "foundContactMessage": {
                     "type": "string"
                 },
                 "name": {
@@ -6458,6 +6579,42 @@
                 "email": {
                     "type": "string",
                     "example": "user@example.com"
+                }
+            }
+        },
+        "v1.FoundContactRequest": {
+            "type": "object",
+            "required": [
+                "message"
+            ],
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "replyTo": {
+                    "type": "string"
+                }
+            }
+        },
+        "v1.FoundItemResponse": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "itemId": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": [
+                        "form",
+                        "mailto"
+                    ]
                 }
             }
         },

--- a/docs/public/api/swagger-2.0.yaml
+++ b/docs/public/api/swagger-2.0.yaml
@@ -552,6 +552,14 @@ definitions:
         description: |-
           Edges holds the relations/edges for other nodes in the graph.
           The values are being populated by the GroupQuery when eager-loading is set.
+      found_contact_enabled:
+        description: FoundContactEnabled holds the value of the "found_contact_enabled"
+          field.
+        type: boolean
+      found_contact_message:
+        description: FoundContactMessage holds the value of the "found_contact_message"
+          field.
+        type: string
       id:
         description: ID of the ent.
         type: string
@@ -1712,6 +1720,10 @@ definitions:
         type: string
       currency:
         type: string
+      foundContactEnabled:
+        type: boolean
+      foundContactMessage:
+        type: string
       id:
         type: string
       name:
@@ -1748,6 +1760,10 @@ definitions:
   repo.GroupUpdate:
     properties:
       currency:
+        type: string
+      foundContactEnabled:
+        type: boolean
+      foundContactMessage:
         type: string
       name:
         type: string
@@ -2250,6 +2266,30 @@ definitions:
         type: string
     required:
     - email
+    type: object
+  v1.FoundContactRequest:
+    properties:
+      message:
+        maxLength: 2000
+        type: string
+      replyTo:
+        type: string
+    required:
+    - message
+    type: object
+  v1.FoundItemResponse:
+    properties:
+      email:
+        type: string
+      itemId:
+        type: string
+      message:
+        type: string
+      mode:
+        enum:
+        - form
+        - mailto
+        type: string
     type: object
   v1.GroupAcceptInvitationResponse:
     properties:
@@ -3077,6 +3117,82 @@ paths:
       summary: Update Entity Type
       tags:
       - Entity Types
+  /v1/found/{kind}/{id}:
+    get:
+      description: |-
+        Public, unauthenticated lookup for the found-item contact page. Resolves an
+        item by UUID (kind "item") or by asset ID (kind "asset") when the owning
+        group has opted in. Returns 404 for anything that does not resolve, with no
+        distinction between missing, archived, opted-out, or ambiguous.
+      parameters:
+      - description: ID kind
+        enum:
+        - item
+        - asset
+        in: path
+        name: kind
+        required: true
+        type: string
+      - description: Item UUID or asset ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v1.FoundItemResponse'
+        "404":
+          description: item not found or found-item contact not enabled
+          schema:
+            type: string
+      summary: Get Found Item Contact Page
+      tags:
+      - Found
+  /v1/found/{kind}/{id}/contact:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Relays a finder's message to the item owner by email. After basic input
+        validation this always returns 204, whether or not the item resolved or
+        the email was sent, so the endpoint cannot be used to probe for items.
+      parameters:
+      - description: ID kind
+        enum:
+        - item
+        - asset
+        in: path
+        name: kind
+        required: true
+        type: string
+      - description: Item UUID or asset ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Message
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/v1.FoundContactRequest'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: invalid request body, empty or oversized message, or invalid
+            reply-to address
+          schema:
+            type: string
+      summary: Send Found Item Contact Message
+      tags:
+      - Found
   /v1/group/exports:
     get:
       description: Returns export job rows for the caller's group, newest first.

--- a/frontend/lib/api/public.ts
+++ b/frontend/lib/api/public.ts
@@ -15,6 +15,18 @@ export type StatusResult = {
   message: string;
 };
 
+export type FoundItemKind = "item" | "asset";
+
+// The generator marks `message` and `email` as required on FoundItemResponse,
+// but the backend omits them when unset (message is optional, email is only
+// present in "mailto" mode). Redeclared here as optional to match reality.
+export type FoundItemResult = {
+  itemId: string;
+  message?: string;
+  mode: "form" | "mailto";
+  email?: string;
+};
+
 export class PublicApi extends BaseAPI {
   public status() {
     return this.http.get<APISummary>({ url: route("/status") });
@@ -46,6 +58,17 @@ export class PublicApi extends BaseAPI {
     return this.http.post<ResetPasswordRequest, void>({
       url: route("/users/reset-password"),
       body: { token, password },
+    });
+  }
+
+  public foundItem(kind: FoundItemKind, id: string) {
+    return this.http.get<FoundItemResult>({ url: route(`/found/${kind}/${id}`) });
+  }
+
+  public foundContact(kind: FoundItemKind, id: string, message: string, replyTo?: string) {
+    return this.http.post<{ message: string; replyTo?: string }, void>({
+      url: route(`/found/${kind}/${id}/contact`),
+      body: { message, replyTo: replyTo || undefined },
     });
   }
 }

--- a/frontend/lib/api/types/data-contracts.ts
+++ b/frontend/lib/api/types/data-contracts.ts
@@ -418,6 +418,10 @@ export interface EntGroup {
    * The values are being populated by the GroupQuery when eager-loading is set.
    */
   edges: EntGroupEdges;
+  /** FoundContactEnabled holds the value of the "found_contact_enabled" field. */
+  found_contact_enabled: boolean;
+  /** FoundContactMessage holds the value of the "found_contact_message" field. */
+  found_contact_message: string;
   /** ID of the ent. */
   id: string;
   /** Name holds the value of the "name" field. */
@@ -1067,6 +1071,8 @@ export interface ExportOut {
 export interface Group {
   createdAt: Date | string;
   currency: string;
+  foundContactEnabled: boolean;
+  foundContactMessage: string;
   id: string;
   name: string;
   updatedAt: Date | string;
@@ -1090,6 +1096,8 @@ export interface GroupStatistics {
 
 export interface GroupUpdate {
   currency: string;
+  foundContactEnabled: boolean;
+  foundContactMessage: string;
   name: string;
 }
 
@@ -1377,6 +1385,19 @@ export interface EntityTemplateCreateItemRequest {
 export interface ForgotPasswordRequest {
   /** @example "user@example.com" */
   email: string;
+}
+
+export interface FoundContactRequest {
+  /** @maxLength 2000 */
+  message: string;
+  replyTo: string;
+}
+
+export interface FoundItemResponse {
+  email: string;
+  itemId: string;
+  message: string;
+  mode: "form" | "mailto";
 }
 
 export interface GroupAcceptInvitationResponse {

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -451,6 +451,15 @@
         "mailto": "Email the owner",
         "not_available": "This item is not available, or its owner has not enabled public contact.",
         "owner_message": "Message from the owner",
+        "settings": {
+            "description": "When enabled, anyone who scans an item label without being signed in sees a public contact page for this collection instead of the login screen.",
+            "enable": "Enable found item contact page",
+            "message_label": "Message shown to finders (optional)",
+            "message_placeholder": "Thanks for finding my stuff! Please get in touch.",
+            "no_smtp_warning": "While enabled, finders contact you through a form and your email address stays hidden, as long as the server has an email server configured. If it does not, the collection owner's email address is shown publicly instead. Nothing is shown while this setting is off.",
+            "saved": "Found item settings saved.",
+            "title": "Found Item Contact Page"
+        },
         "sign_in": "Is this your item? Sign in",
         "title": "Did you find this item?"
     },

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -437,6 +437,23 @@
     "errors": {
         "api_failure": "Backend API call failed: "
     },
+    "found": {
+        "contact_form": {
+            "error": "The message could not be sent. Please try again later.",
+            "label": "Your message to the owner",
+            "placeholder": "Where can the owner pick it up, or how can they reach you?",
+            "reply_to": "Your email (optional, so the owner can reply)",
+            "send": "Send Message",
+            "sending": "Sending...",
+            "sent": "Message sent. Thank you for helping return this item!"
+        },
+        "description": "This item is registered with HomeBox. The owner would love to have it back.",
+        "mailto": "Email the owner",
+        "not_available": "This item is not available, or its owner has not enabled public contact.",
+        "owner_message": "Message from the owner",
+        "sign_in": "Is this your item? Sign in",
+        "title": "Did you find this item?"
+    },
     "global": {
         "add": "Add",
         "archived": "Archived",

--- a/frontend/middleware/auth.ts
+++ b/frontend/middleware/auth.ts
@@ -1,10 +1,10 @@
-export default defineNuxtRouteMiddleware(async () => {
+export default defineNuxtRouteMiddleware(async to => {
   const ctx = useAuthContext();
   const api = useUserApi();
   const redirectTo = useState("authRedirect");
 
   if (!ctx.isAuthorized()) {
-    const path = window.location.pathname;
+    const path = to.path;
 
     const asset = path.match(/^\/(?:a|assets)\/([^/]+)\/?$/);
     const item = path.match(/^\/item\/([^/]+)\/?$/);

--- a/frontend/middleware/auth.ts
+++ b/frontend/middleware/auth.ts
@@ -4,9 +4,22 @@ export default defineNuxtRouteMiddleware(async () => {
   const redirectTo = useState("authRedirect");
 
   if (!ctx.isAuthorized()) {
-    if (window.location.pathname !== "/") {
+    const path = window.location.pathname;
+
+    const asset = path.match(/^\/(?:a|assets)\/([^/]+)\/?$/);
+    const item = path.match(/^\/item\/([^/]+)\/?$/);
+    if (asset || item) {
+      console.debug("[middleware/auth] unauthenticated label scan, redirecting to found page");
+      redirectTo.value = path;
+      const kind = item ? "item" : "asset";
+      const match = item ?? asset;
+      const id = match?.[1];
+      return navigateTo(`/found/${kind}/${id}`);
+    }
+
+    if (path !== "/") {
       console.debug("[middleware/auth] isAuthorized returned false, redirecting to /");
-      redirectTo.value = window.location.pathname;
+      redirectTo.value = path;
       return navigateTo("/");
     }
   }

--- a/frontend/pages/collection/index/settings.vue
+++ b/frontend/pages/collection/index/settings.vue
@@ -4,10 +4,18 @@
   import { Button } from "@/components/ui/button";
   import { Label } from "@/components/ui/label";
   import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+  import { Switch } from "@/components/ui/switch";
   import MdiLoading from "~icons/mdi/loading";
   import FormTextField from "~/components/Form/TextField.vue";
-  import type { CurrenciesCurrency, Group } from "~~/lib/api/types/data-contracts";
+  import FormTextArea from "~/components/Form/TextArea.vue";
+  import type { CurrenciesCurrency, Group, GroupUpdate } from "~~/lib/api/types/data-contracts";
   import { fmtCurrencyAsync } from "~/composables/utils";
+  import { utf8Length } from "@/lib/utils";
+
+  // The generated GroupUpdate type marks every field (including
+  // foundContactEnabled/foundContactMessage) as required, but the backend applies pointer
+  // semantics: omitted fields are left unchanged. Redeclared here as partial to match reality.
+  type GroupUpdatePayload = Partial<GroupUpdate>;
 
   definePageMeta({
     middleware: ["auth"],
@@ -29,6 +37,10 @@
   const name = ref("");
   const currencyCode = ref("USD");
   const currencyExample = ref("$1,000.00");
+
+  const foundContactEnabled = ref(false);
+  const foundContactMessage = ref("");
+  const savingFoundContact = ref(false);
 
   const loadSettings = async () => {
     if (!selectedCollection.value) {
@@ -60,6 +72,8 @@
       group.value = res.data;
       name.value = res.data.name;
       currencyCode.value = res.data.currency;
+      foundContactEnabled.value = res.data.foundContactEnabled;
+      foundContactMessage.value = res.data.foundContactMessage ?? "";
     } catch (e) {
       const msg = (e as Error).message ?? String(e);
       error.value = msg;
@@ -97,13 +111,11 @@
     error.value = null;
 
     try {
-      const res = await api.group.update(
-        {
-          name: name.value,
-          currency: currencyCode.value,
-        },
-        selectedCollection.value.id
-      );
+      const payload: GroupUpdatePayload = {
+        name: name.value,
+        currency: currencyCode.value,
+      };
+      const res = await api.group.update(payload as GroupUpdate, selectedCollection.value.id);
 
       if (res.error || !res.data) {
         const msg = t("profile.toast.failed_update_group");
@@ -123,6 +135,41 @@
       toast.error(msg);
     } finally {
       saving.value = false;
+    }
+  };
+
+  const saveFoundContact = async () => {
+    if (!selectedCollection.value || !group.value) return;
+
+    savingFoundContact.value = true;
+    error.value = null;
+
+    try {
+      const payload: GroupUpdatePayload = {
+        name: group.value.name,
+        currency: group.value.currency,
+        foundContactEnabled: foundContactEnabled.value,
+        foundContactMessage: foundContactMessage.value,
+      };
+      const res = await api.group.update(payload as GroupUpdate, selectedCollection.value.id);
+
+      if (res.error || !res.data) {
+        const msg = t("profile.toast.failed_update_group");
+        error.value = msg;
+        toast.error(msg);
+        return;
+      }
+
+      group.value = res.data;
+      foundContactEnabled.value = res.data.foundContactEnabled;
+      foundContactMessage.value = res.data.foundContactMessage ?? "";
+      toast.success(t("found.settings.saved"));
+    } catch (e) {
+      const msg = (e as Error).message ?? String(e);
+      error.value = msg;
+      toast.error(msg);
+    } finally {
+      savingFoundContact.value = false;
     }
   };
 </script>
@@ -164,6 +211,41 @@
           <Button variant="secondary" size="sm" :disabled="saving" @click="save">
             <MdiLoading v-if="saving" class="mr-2 inline-block animate-spin" />
             <span>{{ $t("profile.update_group") }}</span>
+          </Button>
+        </div>
+      </div>
+
+      <div v-if="selectedCollection" class="mt-4 space-y-4 rounded-md border bg-card p-4">
+        <div>
+          <h2 class="text-lg font-medium">{{ $t("found.settings.title") }}</h2>
+          <p class="text-sm text-muted-foreground">{{ $t("found.settings.description") }}</p>
+        </div>
+
+        <div class="flex items-center gap-2">
+          <Switch id="found-contact-enabled" v-model="foundContactEnabled" />
+          <Label for="found-contact-enabled">{{ $t("found.settings.enable") }}</Label>
+        </div>
+
+        <FormTextArea
+          v-model="foundContactMessage"
+          :label="$t('found.settings.message_label')"
+          :placeholder="$t('found.settings.message_placeholder')"
+          :max-length="500"
+        />
+
+        <div class="rounded-md border border-accent-foreground bg-accent p-4 text-accent-foreground">
+          <p class="text-sm">{{ $t("found.settings.no_smtp_warning") }}</p>
+        </div>
+
+        <div class="mt-4">
+          <Button
+            variant="secondary"
+            size="sm"
+            :disabled="savingFoundContact || utf8Length(foundContactMessage) > 500"
+            @click="saveFoundContact"
+          >
+            <MdiLoading v-if="savingFoundContact" class="mr-2 inline-block animate-spin" />
+            <span>{{ $t("global.save") }}</span>
           </Button>
         </div>
       </div>

--- a/frontend/pages/found/[kind]/[id].vue
+++ b/frontend/pages/found/[kind]/[id].vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+  import { useI18n } from "vue-i18n";
+  import MdiLoading from "~icons/mdi/loading";
+  import MdiMapMarkerAlert from "~icons/mdi/map-marker-alert";
+  import MdiEmailOutline from "~icons/mdi/email-outline";
+  import MdiArrowLeft from "~icons/mdi/arrow-left";
+  import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+  import { Button } from "@/components/ui/button";
+  import AppLogo from "~/components/App/Logo.vue";
+  import FormTextArea from "~/components/Form/TextArea.vue";
+  import FormTextField from "~/components/Form/TextField.vue";
+  import type { FoundItemKind, FoundItemResult } from "~~/lib/api/public";
+  import { utf8Length } from "@/lib/utils";
+
+  const { t } = useI18n();
+
+  definePageMeta({
+    layout: "empty",
+  });
+
+  useHead({
+    title: "HomeBox | " + t("found.title"),
+  });
+
+  const route = useRoute();
+  const api = usePublicApi();
+
+  const kind = computed<FoundItemKind>(() => (route.params.kind === "item" ? "item" : "asset"));
+  const id = computed(() => String(route.params.id));
+
+  const { data: item, pending } = useAsyncData<FoundItemResult | null>(`found-${kind.value}-${id.value}`, async () => {
+    const { data, error } = await api.foundItem(kind.value, id.value);
+    if (error) {
+      return null;
+    }
+    return data;
+  });
+
+  const message = ref("");
+  const replyTo = ref("");
+  const sending = ref(false);
+  const sent = ref(false);
+  const sendError = ref(false);
+
+  async function submit() {
+    if (!message.value.trim()) {
+      return;
+    }
+
+    sending.value = true;
+    sendError.value = false;
+
+    const { error } = await api.foundContact(kind.value, id.value, message.value.trim(), replyTo.value.trim());
+
+    sending.value = false;
+
+    if (error) {
+      sendError.value = true;
+      return;
+    }
+
+    sent.value = true;
+  }
+</script>
+
+<template>
+  <div class="flex min-h-screen flex-col items-center justify-center p-6">
+    <div class="mb-6 flex items-center gap-2 whitespace-nowrap text-3xl font-bold tracking-tight">
+      HomeB
+      <AppLogo class="-mb-2 w-10" />
+      x
+    </div>
+
+    <div v-if="pending" class="flex flex-col items-center gap-2 text-sm text-muted-foreground">
+      <div class="flex items-center gap-2">
+        <MdiLoading class="size-5 animate-spin" />
+        {{ $t("global.loading") }}
+      </div>
+      <NuxtLink to="/" class="text-sm text-muted-foreground hover:underline">
+        <span class="inline-flex items-center gap-1">
+          <MdiArrowLeft class="size-4" />
+          {{ $t("found.sign_in") }}
+        </span>
+      </NuxtLink>
+    </div>
+
+    <Card v-else-if="!item" class="md:w-[460px]">
+      <CardHeader>
+        <CardTitle class="flex items-center gap-2">
+          <MdiMapMarkerAlert class="size-6" />
+          {{ $t("found.title") }}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p class="text-sm">{{ $t("found.not_available") }}</p>
+      </CardContent>
+      <CardFooter>
+        <NuxtLink to="/" class="text-sm text-muted-foreground hover:underline">
+          <span class="inline-flex items-center gap-1">
+            <MdiArrowLeft class="size-4" />
+            {{ $t("found.sign_in") }}
+          </span>
+        </NuxtLink>
+      </CardFooter>
+    </Card>
+
+    <Card v-else class="md:w-[460px]">
+      <CardHeader>
+        <CardTitle class="flex items-center gap-2">
+          <MdiMapMarkerAlert class="size-6" />
+          {{ $t("found.title") }}
+        </CardTitle>
+      </CardHeader>
+
+      <CardContent class="flex flex-col gap-4">
+        <p class="text-sm text-muted-foreground">{{ $t("found.description") }}</p>
+
+        <div v-if="item.message" class="rounded-md border border-border bg-muted/50 p-3">
+          <p class="mb-1 text-xs font-medium text-muted-foreground">{{ $t("found.owner_message") }}</p>
+          <p class="whitespace-pre-wrap text-sm">{{ item.message }}</p>
+        </div>
+
+        <template v-if="item.mode === 'mailto'">
+          <Button as-child class="w-full">
+            <a :href="`mailto:${item.email}`" class="inline-flex items-center justify-center gap-2">
+              <MdiEmailOutline class="size-4" />
+              {{ $t("found.mailto") }}
+            </a>
+          </Button>
+        </template>
+
+        <template v-else>
+          <template v-if="sent">
+            <p class="text-sm">{{ $t("found.contact_form.sent") }}</p>
+          </template>
+          <form v-else id="found-contact-form" class="flex flex-col gap-3" @submit.prevent="submit">
+            <FormTextArea
+              v-model="message"
+              :label="$t('found.contact_form.label')"
+              :placeholder="$t('found.contact_form.placeholder')"
+              :max-length="2000"
+            />
+            <FormTextField
+              id="found-reply-to"
+              v-model="replyTo"
+              :label="$t('found.contact_form.reply_to')"
+              type="email"
+              name="email"
+              autocomplete="email"
+            />
+            <p v-if="sendError" class="text-sm text-destructive">{{ $t("found.contact_form.error") }}</p>
+          </form>
+        </template>
+      </CardContent>
+
+      <CardFooter class="flex flex-col gap-2">
+        <Button
+          v-if="item.mode === 'form' && !sent"
+          form="found-contact-form"
+          type="submit"
+          class="w-full"
+          :disabled="sending || !message.trim() || utf8Length(message) > 2000"
+        >
+          {{ sending ? $t("found.contact_form.sending") : $t("found.contact_form.send") }}
+        </Button>
+        <NuxtLink to="/" class="text-sm text-muted-foreground hover:underline">
+          <span class="inline-flex items-center gap-1">
+            <MdiArrowLeft class="size-4" />
+            {{ $t("found.sign_in") }}
+          </span>
+        </NuxtLink>
+      </CardFooter>
+    </Card>
+  </div>
+</template>

--- a/frontend/pages/found/[kind]/[id].vue
+++ b/frontend/pages/found/[kind]/[id].vue
@@ -28,12 +28,18 @@
   const kind = computed<FoundItemKind>(() => (route.params.kind === "item" ? "item" : "asset"));
   const id = computed(() => String(route.params.id));
 
-  const { data: item, pending } = useAsyncData<FoundItemResult | null>(`found-${kind.value}-${id.value}`, async () => {
-    const { data, error } = await api.foundItem(kind.value, id.value);
-    if (error) {
-      return null;
+  const item = ref<FoundItemResult | null>(null);
+  const pending = ref(true);
+
+  onMounted(async () => {
+    try {
+      const { data, error } = await api.foundItem(kind.value, id.value);
+      item.value = error ? null : (data ?? null);
+    } catch {
+      item.value = null;
+    } finally {
+      pending.value = false;
     }
-    return data;
   });
 
   const message = ref("");


### PR DESCRIPTION
## Summary

Adds the "lost item" page requested in #13: when someone scans a QR
label while signed out, they now see a public "Did you find this
item?" contact page instead of the login screen.

The feature is opt-in per collection and off by default, and it
addresses the privacy concern raised on #1487 (unconditional exposure
of the owner's email on an unauthenticated endpoint):

- With SMTP configured, finders send a message through a contact form
  relayed server-side. The owner's email address is never sent to the
  client.
- Without SMTP, the page falls back to a mailto link, per the
  guidance in the issue thread. The settings UI warns the owner about
  this exposure before they enable the feature.

## Design notes

- Two new Group fields (`found_contact_enabled`, default false, and
  `found_contact_message`) with goose migrations for sqlite and
  postgres. Existing installs see zero behavior change.
- Public endpoints `GET /v1/found/{kind}/{id}` and
  `POST /v1/found/{kind}/{id}/contact`, both behind a per-IP request
  rate limiter (30/min), with an additional per-item send cap
  (3 per item / 10 min) so a single known item cannot be used to
  mailbomb its owner even from distributed IPs. Missing items,
  non-opted-in collections,
  archived items, and ambiguous asset IDs (asset IDs are only unique
  per collection) all return identical 404s, so a caller cannot probe
  an instance's inventory. After input validation the contact POST
  returns 204 whether or not the item resolved (forgot-password
  pattern), and the email send is backgrounded so the response does
  not wait on SMTP. Either endpoint may instead return 429 when the
  rate limiter trips; that response is IP-scoped and identical across
  items, so it does not leak item state.
- Asset ID 0 is rejected before querying (every entity defaults to
  asset_id 0).
- The finder's message and reply address are HTML-escaped before
  interpolation into the (HTML-only) mailer body.
- `GroupUpdate` gains pointer-optional fields so existing API callers
  that PUT only name/currency cannot silently reset the new settings.
- Changing the found-contact settings requires the group owner role
  (other collection settings remain member-editable). This prevents a
  non-owner member from publishing the owner's email via mailto mode.
- Translations are en.json only, per the Weblate workflow. Roughly
  1,000 of the added lines are regenerated API specs
  (swagger/OpenAPI/TS types); the hand-written diff is much smaller
  than the total suggests.

## Out of scope (future work per the issue thread)

Per-item "mark as lost" mode and reward fields, as floated by
@katosdev in the thread. Archiving an item already removes it from
the found page, which covers the per-item off switch. The per-item
lost mode layers cleanly on top of this change if wanted.

## Notes for reviewers

- Location entities share the entities table and carry asset IDs, so
  scanning a location label on an opted-in group resolves the found
  page ("Someone found your item: <location name>"). Left as-is since
  returning a mislaid storage bin is arguably valid, but flagging it
  in case you'd prefer to exclude `is_location` entities from the
  lookups.
- The finder's optional reply address is included in the email body
  rather than as a real `Reply-To` header. Adding a true `Reply-To`
  would mean extending the shared mailer `MessageBuilder` (used by
  password-reset mail too), which is beyond this feature's footprint,
  so I deliberately kept the change self-contained. Happy to add it as
  a follow-up if you'd like the header.

## Test plan

- Repo layer: 9 tests covering lookups by item UUID and asset ID,
  disabled/archived/ambiguous/no-owner cases (all fail closed), and
  owner-resolution determinism.
- Service layer: email builder tests including escaping of
  finder-controlled fields.
- Handler layer: table-driven tests covering parse rejection,
  validation boundaries, opaque-404 shape, and always-204 behavior.
- Rate limiter: per-item send-cap enforcement and per-item isolation.
- Group update: pointer-preservation round-trip test.
- Backend suite, `go vet`, and frontend lint pass (the only failing
  backend tests are pre-existing, environment-specific attachment/blob
  tests unrelated to this change).

Manually verified end to end against a copy of a real production
v0.26.2 database (goose migrations applied cleanly on startup):

- Scanning a label while signed out redirects to the found page;
  signing in from there returns to the item.
- mailto mode (no SMTP) shows the owner email; form mode (SMTP
  configured) shows the contact form and never exposes the email.
- A real message submitted through the form was delivered via SMTP
  (Gmail) with the finder's text and HTML-escaping intact.
- The send cap was confirmed live: repeated submissions for one item
  delivered 3 emails and then silently stopped, while the page
  continued to show the success state (no throttling signal to the
  sender). The cap's per-item isolation (each item having an
  independent budget) is covered by an automated unit test rather than
  the manual pass.
- The settings toggle/message round-trips and is owner-gated.

## Disclosure

This PR was developed with AI assistance (Claude), including repeated
AI review passes over the implementation. Every part of it was then
tested by a human on a real deployment to confirm it actually works
end to end, including live SMTP delivery. Happy to adjust anything in
review.
