### PR TITLE
fix: translate "Location" text on generated labels

### DIFF
--- a/backend/app/api/handlers/v1/v1_ctrl_labelmaker.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_labelmaker.go
@@ -15,6 +15,17 @@ import (
 	"github.com/sysadminsmedia/homebox/backend/pkgs/labelmaker"
 )
 
+// labelText returns the caller-supplied translation for a fixed string printed
+// on a label, falling back to English when the client doesn't provide one. The
+// backend has no translation catalog of its own, so the frontend passes the
+// user's selected language along with the label request.
+func labelText(r *http.Request, param string, fallback string) string {
+	if v := strings.TrimSpace(r.URL.Query().Get(param)); v != "" {
+		return v
+	}
+	return fallback
+}
+
 func generateOrPrint(ctrl *V1Controller, w http.ResponseWriter, r *http.Request, title string, description string, url string) error {
 	params := labelmaker.NewGenerateParams(int(ctrl.config.LabelMaker.Width), int(ctrl.config.LabelMaker.Height), int(ctrl.config.LabelMaker.Margin), int(ctrl.config.LabelMaker.Padding), ctrl.config.LabelMaker.FontSize, title, description, url, ctrl.config.LabelMaker.DynamicLength, ctrl.config.LabelMaker.AdditionalInformation)
 
@@ -38,9 +49,10 @@ func generateOrPrint(ctrl *V1Controller, w http.ResponseWriter, r *http.Request,
 //	@Summary	Get Location label
 //	@Tags		Locations
 //	@Produce	json
-//	@Param		id		path		string	true	"Location ID"
-//	@Param		print	query		bool	false	"Print this label, defaults to false"
-//	@Success	200		{string}	string	"image/png"
+//	@Param		id					path		string	true	"Location ID"
+//	@Param		print				query		bool	false	"Print this label, defaults to false"
+//	@Param		locationDescription	query		string	false	"Translated description text, defaults to 'Homebox Location'"
+//	@Success	200					{string}	string	"image/png"
 //	@Router		/v1/labelmaker/location/{id} [GET]
 //	@Security	Bearer
 func (ctrl *V1Controller) HandleGetLocationLabel() errchain.HandlerFunc {
@@ -57,7 +69,8 @@ func (ctrl *V1Controller) HandleGetLocationLabel() errchain.HandlerFunc {
 		}
 
 		hbURL := GetHBURL(r, &ctrl.config.Options, ctrl.url)
-		return generateOrPrint(ctrl, w, r, location.Name, "Homebox Location", fmt.Sprintf("%s/location/%s", hbURL, location.ID))
+		description := labelText(r, "locationDescription", "Homebox Location")
+		return generateOrPrint(ctrl, w, r, location.Name, description, fmt.Sprintf("%s/location/%s", hbURL, location.ID))
 	}
 }
 
@@ -66,9 +79,10 @@ func (ctrl *V1Controller) HandleGetLocationLabel() errchain.HandlerFunc {
 //	@Summary	Get Item label
 //	@Tags		Items
 //	@Produce	json
-//	@Param		id		path		string	true	"Item ID"
-//	@Param		print	query		bool	false	"Print this label, defaults to false"
-//	@Success	200		{string}	string	"image/png"
+//	@Param		id				path		string	true	"Item ID"
+//	@Param		print			query		bool	false	"Print this label, defaults to false"
+//	@Param		locationLabel	query		string	false	"Translated word for 'Location', used as the location line prefix"
+//	@Success	200				{string}	string	"image/png"
 //	@Router		/v1/labelmaker/item/{id} [GET]
 //	@Security	Bearer
 func (ctrl *V1Controller) HandleGetItemLabel() errchain.HandlerFunc {
@@ -87,7 +101,7 @@ func (ctrl *V1Controller) HandleGetItemLabel() errchain.HandlerFunc {
 		description := ""
 
 		if item.Parent != nil {
-			description += fmt.Sprintf("\nLocation: %s", item.Parent.Name)
+			description += fmt.Sprintf("\n%s: %s", labelText(r, "locationLabel", "Location"), item.Parent.Name)
 		}
 
 		hbURL := GetHBURL(r, &ctrl.config.Options, ctrl.url)
@@ -100,9 +114,10 @@ func (ctrl *V1Controller) HandleGetItemLabel() errchain.HandlerFunc {
 //	@Summary	Get Asset label
 //	@Tags		Items
 //	@Produce	json
-//	@Param		id		path		string	true	"Asset ID"
-//	@Param		print	query		bool	false	"Print this label, defaults to false"
-//	@Success	200		{string}	string	"image/png"
+//	@Param		id				path		string	true	"Asset ID"
+//	@Param		print			query		bool	false	"Print this label, defaults to false"
+//	@Param		locationLabel	query		string	false	"Translated word for 'Location', used as the location line prefix"
+//	@Success	200				{string}	string	"image/png"
 //	@Router		/v1/labelmaker/asset/{id} [GET]
 //	@Security	Bearer
 func (ctrl *V1Controller) HandleGetAssetLabel() errchain.HandlerFunc {
@@ -127,7 +142,7 @@ func (ctrl *V1Controller) HandleGetAssetLabel() errchain.HandlerFunc {
 		description := item.Items[0].Name
 
 		if item.Items[0].Parent != nil {
-			description += fmt.Sprintf("\nLocation: %s", item.Items[0].Parent.Name)
+			description += fmt.Sprintf("\n%s: %s", labelText(r, "locationLabel", "Location"), item.Items[0].Parent.Name)
 		}
 
 		hbURL := GetHBURL(r, &ctrl.config.Options, ctrl.url)

--- a/backend/app/api/handlers/v1/v1_ctrl_labelmaker_test.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_labelmaker_test.go
@@ -1,0 +1,74 @@
+package v1
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Repeated across the table below; extracted to satisfy goconst.
+const (
+	fixtureLocationParam    = "locationLabel"
+	fixtureLocationFallback = "Location"
+)
+
+func TestLabelText(t *testing.T) {
+	cases := []struct {
+		name     string
+		query    string
+		param    string
+		fallback string
+		expect   string
+	}{
+		{
+			name:     "missing parameter falls back to English",
+			query:    "/labelmaker/entity/1",
+			param:    fixtureLocationParam,
+			fallback: fixtureLocationFallback,
+			expect:   fixtureLocationFallback,
+		},
+		{
+			name:     "translation is used when supplied",
+			query:    "/labelmaker/entity/1?locationLabel=Emplacement",
+			param:    fixtureLocationParam,
+			fallback: fixtureLocationFallback,
+			expect:   "Emplacement",
+		},
+		{
+			name:     "empty value falls back to English",
+			query:    "/labelmaker/entity/1?locationLabel=",
+			param:    fixtureLocationParam,
+			fallback: fixtureLocationFallback,
+			expect:   fixtureLocationFallback,
+		},
+		{
+			name:     "whitespace-only value falls back to English",
+			query:    "/labelmaker/entity/1?locationLabel=%20%20",
+			param:    fixtureLocationParam,
+			fallback: fixtureLocationFallback,
+			expect:   fixtureLocationFallback,
+		},
+		{
+			name:     "surrounding whitespace is trimmed",
+			query:    "/labelmaker/entity/1?locationLabel=%20Ubicaci%C3%B3n%20",
+			param:    fixtureLocationParam,
+			fallback: fixtureLocationFallback,
+			expect:   "Ubicación",
+		},
+		{
+			name:     "a different parameter is unaffected",
+			query:    "/labelmaker/location/1?locationDescription=Emplacement%20Homebox",
+			param:    "locationDescription",
+			fallback: "Homebox Location",
+			expect:   "Emplacement Homebox",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", tt.query, nil)
+			assert.Equal(t, tt.expect, labelText(r, tt.param, tt.fallback))
+		})
+	}
+}

--- a/backend/app/api/static/docs/docs.go
+++ b/backend/app/api/static/docs/docs.go
@@ -1791,6 +1791,12 @@ const docTemplate = `{
                         "description": "Print this label, defaults to false",
                         "name": "print",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Translated word for 'Location', used as the location line prefix",
+                        "name": "locationLabel",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1830,6 +1836,12 @@ const docTemplate = `{
                         "description": "Print this label, defaults to false",
                         "name": "print",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Translated word for 'Location', used as the location line prefix",
+                        "name": "locationLabel",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1868,6 +1880,12 @@ const docTemplate = `{
                         "type": "boolean",
                         "description": "Print this label, defaults to false",
                         "name": "print",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Translated description text, defaults to 'Homebox Location'",
+                        "name": "locationDescription",
                         "in": "query"
                     }
                 ],

--- a/backend/app/api/static/docs/openapi-3.json
+++ b/backend/app/api/static/docs/openapi-3.json
@@ -1928,6 +1928,14 @@
                         "schema": {
                             "type": "boolean"
                         }
+                    },
+                    {
+                        "description": "Translated word for 'Location', used as the location line prefix",
+                        "name": "locationLabel",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "responses": {
@@ -1972,6 +1980,14 @@
                         "schema": {
                             "type": "boolean"
                         }
+                    },
+                    {
+                        "description": "Translated word for 'Location', used as the location line prefix",
+                        "name": "locationLabel",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "responses": {
@@ -2015,6 +2031,14 @@
                         "in": "query",
                         "schema": {
                             "type": "boolean"
+                        }
+                    },
+                    {
+                        "description": "Translated description text, defaults to 'Homebox Location'",
+                        "name": "locationDescription",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
                         }
                     }
                 ],

--- a/backend/app/api/static/docs/openapi-3.yaml
+++ b/backend/app/api/static/docs/openapi-3.yaml
@@ -1150,6 +1150,11 @@ paths:
           in: query
           schema:
             type: boolean
+        - description: Translated word for 'Location', used as the location line prefix
+          name: locationLabel
+          in: query
+          schema:
+            type: string
       responses:
         "200":
           description: image/png
@@ -1176,6 +1181,11 @@ paths:
           in: query
           schema:
             type: boolean
+        - description: Translated word for 'Location', used as the location line prefix
+          name: locationLabel
+          in: query
+          schema:
+            type: string
       responses:
         "200":
           description: image/png
@@ -1202,6 +1212,11 @@ paths:
           in: query
           schema:
             type: boolean
+        - description: Translated description text, defaults to 'Homebox Location'
+          name: locationDescription
+          in: query
+          schema:
+            type: string
       responses:
         "200":
           description: image/png

--- a/backend/app/api/static/docs/swagger.json
+++ b/backend/app/api/static/docs/swagger.json
@@ -1788,6 +1788,12 @@
                         "description": "Print this label, defaults to false",
                         "name": "print",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Translated word for 'Location', used as the location line prefix",
+                        "name": "locationLabel",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1827,6 +1833,12 @@
                         "description": "Print this label, defaults to false",
                         "name": "print",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Translated word for 'Location', used as the location line prefix",
+                        "name": "locationLabel",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1865,6 +1877,12 @@
                         "type": "boolean",
                         "description": "Print this label, defaults to false",
                         "name": "print",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Translated description text, defaults to 'Homebox Location'",
+                        "name": "locationDescription",
                         "in": "query"
                     }
                 ],

--- a/backend/app/api/static/docs/swagger.yaml
+++ b/backend/app/api/static/docs/swagger.yaml
@@ -3459,6 +3459,10 @@ paths:
         in: query
         name: print
         type: boolean
+      - description: Translated word for 'Location', used as the location line prefix
+        in: query
+        name: locationLabel
+        type: string
       produces:
       - application/json
       responses:
@@ -3483,6 +3487,10 @@ paths:
         in: query
         name: print
         type: boolean
+      - description: Translated word for 'Location', used as the location line prefix
+        in: query
+        name: locationLabel
+        type: string
       produces:
       - application/json
       responses:
@@ -3507,6 +3515,10 @@ paths:
         in: query
         name: print
         type: boolean
+      - description: Translated description text, defaults to 'Homebox Location'
+        in: query
+        name: locationDescription
+        type: string
       produces:
       - application/json
       responses:

--- a/docs/public/api/openapi-3.0.json
+++ b/docs/public/api/openapi-3.0.json
@@ -1928,6 +1928,14 @@
                         "schema": {
                             "type": "boolean"
                         }
+                    },
+                    {
+                        "description": "Translated word for 'Location', used as the location line prefix",
+                        "name": "locationLabel",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "responses": {
@@ -1972,6 +1980,14 @@
                         "schema": {
                             "type": "boolean"
                         }
+                    },
+                    {
+                        "description": "Translated word for 'Location', used as the location line prefix",
+                        "name": "locationLabel",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "responses": {
@@ -2015,6 +2031,14 @@
                         "in": "query",
                         "schema": {
                             "type": "boolean"
+                        }
+                    },
+                    {
+                        "description": "Translated description text, defaults to 'Homebox Location'",
+                        "name": "locationDescription",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
                         }
                     }
                 ],

--- a/docs/public/api/openapi-3.0.yaml
+++ b/docs/public/api/openapi-3.0.yaml
@@ -1150,6 +1150,11 @@ paths:
           in: query
           schema:
             type: boolean
+        - description: Translated word for 'Location', used as the location line prefix
+          name: locationLabel
+          in: query
+          schema:
+            type: string
       responses:
         "200":
           description: image/png
@@ -1176,6 +1181,11 @@ paths:
           in: query
           schema:
             type: boolean
+        - description: Translated word for 'Location', used as the location line prefix
+          name: locationLabel
+          in: query
+          schema:
+            type: string
       responses:
         "200":
           description: image/png
@@ -1202,6 +1212,11 @@ paths:
           in: query
           schema:
             type: boolean
+        - description: Translated description text, defaults to 'Homebox Location'
+          name: locationDescription
+          in: query
+          schema:
+            type: string
       responses:
         "200":
           description: image/png

--- a/docs/public/api/swagger-2.0.json
+++ b/docs/public/api/swagger-2.0.json
@@ -1788,6 +1788,12 @@
                         "description": "Print this label, defaults to false",
                         "name": "print",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Translated word for 'Location', used as the location line prefix",
+                        "name": "locationLabel",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1827,6 +1833,12 @@
                         "description": "Print this label, defaults to false",
                         "name": "print",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Translated word for 'Location', used as the location line prefix",
+                        "name": "locationLabel",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1865,6 +1877,12 @@
                         "type": "boolean",
                         "description": "Print this label, defaults to false",
                         "name": "print",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Translated description text, defaults to 'Homebox Location'",
+                        "name": "locationDescription",
                         "in": "query"
                     }
                 ],

--- a/docs/public/api/swagger-2.0.yaml
+++ b/docs/public/api/swagger-2.0.yaml
@@ -3459,6 +3459,10 @@ paths:
         in: query
         name: print
         type: boolean
+      - description: Translated word for 'Location', used as the location line prefix
+        in: query
+        name: locationLabel
+        type: string
       produces:
       - application/json
       responses:
@@ -3483,6 +3487,10 @@ paths:
         in: query
         name: print
         type: boolean
+      - description: Translated word for 'Location', used as the location line prefix
+        in: query
+        name: locationLabel
+        type: string
       produces:
       - application/json
       responses:
@@ -3507,6 +3515,10 @@ paths:
         in: query
         name: print
         type: boolean
+      - description: Translated description text, defaults to 'Homebox Location'
+        in: query
+        name: locationDescription
+        type: string
       produces:
       - application/json
       responses:

--- a/frontend/components/global/LabelMaker.vue
+++ b/frontend/components/global/LabelMaker.vue
@@ -85,11 +85,16 @@
       params.tenant = selectedId.value;
     }
 
+    // The backend has no translations of its own, so the text it prints on the
+    // label is passed along in the user's current language.
     if (props.type === "item" || props.type === "entity") {
+      params.locationLabel = t("items.location");
       return route(`/labelmaker/entity/${props.id}`, params);
     } else if (props.type === "location") {
+      params.locationDescription = t("components.global.label_maker.location_description");
       return route(`/labelmaker/location/${props.id}`, params);
     } else if (props.type === "asset") {
+      params.locationLabel = t("items.location");
       return route(`/labelmaker/asset/${props.id}`, params);
     } else {
       throw new Error(`Unexpected labelmaker type ${props.type}`);

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -159,6 +159,7 @@
                 "browser_print": "Print from Browser",
                 "confirm_description": "Are you sure you want to print this label?",
                 "download": "Download Label",
+                "location_description": "Homebox Location",
                 "print": "Print label",
                 "server_print": "Print on Server",
                 "titles": "Labels",


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

Printable labels always showed the English word "Location:" regardless of the
selected language. The label image is rendered server-side, and the strings on
it were hardcoded English literals, so no amount of frontend i18n could reach
them.

The backend has no translation catalog of its own, so the frontend now passes
the text in the user's current language as query parameters, with the previous
English strings as fallbacks.

- **`backend/app/api/handlers/v1/v1_ctrl_labelmaker.go`** — added a small
  `labelText(r, param, fallback)` helper that reads a translated string from the
  query, trimmed, falling back to English when absent or blank. Applied it to
  the three hardcoded literals: `"Location: %s"` on the item and asset labels,
  and `"Homebox Location"` on the location label. Added the `@Param`
  annotations.
- **`frontend/components/global/LabelMaker.vue`** — `getLabelUrl()` now appends
  `locationLabel` (item/asset) or `locationDescription` (location).
- **`frontend/locales/en.json`** — one new key,
  `components.global.label_maker.location_description`. Only `en.json` is
  touched; the other locales come from Weblate.
- **`backend/app/api/handlers/v1/v1_ctrl_labelmaker_test.go`** — new table test
  for `labelText`.
- Swagger/OpenAPI definitions regenerated via `task swag` (additive only).

Two decisions worth calling out:

**Why query parameters rather than server-side i18n.** The alternative is
embedding the locale files into the Go binary and resolving a language per
request. That is a considerably larger change, and it needs a language source —
the Homebox language is a frontend preference, not the browser's
`Accept-Language`. Passing the string keeps the fix small and leaves the
existing English behaviour intact for direct API consumers.

This is one way to mitigate the issue, not a claim that it is the right
architecture — that call is yours. If you would rather have a proper
server-side translation layer, that is a much larger piece of work and not one
I am taking on; please close this in favour of that approach.

**Why `items.location` and not `global.location`.** `global.location` exists
only in `en.json` — it is untranslated in all 42 other locales (and unused
elsewhere in the frontend), so it would have fallen back to English everywhere
and left the bug unfixed. `items.location` is translated in 29 of 42 locales;
the remainder fall back to English, which is no worse than today.

## Which issue(s) this PR fixes:

Fixes #1576

## Special notes for your reviewer:

- **CJK still renders as boxes.** The bundled Go fonts have no CJK glyphs, so
  Chinese, Japanese and Korean show tofu. This is pre-existing and affects item
  names too, not something this PR introduces; operators can supply a font via
  the existing `LabelMaker` `RegularFontPath` / `BoldFontPath` settings. Flagging
  it so it is not mistaken for a regression.
- **The `Frontend Tests / Lint` job is already failing on main** (pre-existing
  `vue-tsc` errors). I verified the error count is identical with and without
  this branch, so the red typecheck is not from this change.
- The new `location_description` key will read English until Weblate picks it
  up, which is expected for a new string.
- The issue also asks for a way to customise or remove the label text entirely.
  That is a separate feature (a config option alongside the existing
  `AdditionalInformation`), deliberately not in scope here.
- The issue notes "Print from Browser" should probably be "Print From Browser".
  I have left it as-is: the string already matches the convention used
  throughout `en.json`, where labels are title-cased but prepositions stay
  lowercase — "Print on Server", "Restore from Backup", "No Items to Display",
  "Bill of Materials". Capitalising "From" would make it the odd one out, and
  changing the key would invalidate the existing translations for no gain.

## Testing

Ran the API in demo mode with the Nuxt dev server and drove it through the
browser as the demo user with the UI set to French. Confirmed the request
carries `locationLabel=Emplacement` and the returned PNG reads
`Emplacement: Kitchen`. Also verified directly against the API:

| Case | Result |
| --- | --- |
| No parameter (default) | `Location: Kitchen` — unchanged |
| `locationLabel=Emplacement` | `Emplacement: Kitchen` |
| `locationLabel=Ubicación` | renders correctly (accented Latin) |
| `locationLabel=Расположение` | renders correctly (Cyrillic) |
| `locationLabel=位置` | boxes — pre-existing font limit, see above |
| `locationDescription` on a location label | `Emplacement Homebox` |

Item, asset and location label paths were all exercised. Also run: `go build`,
`go vet`, `golangci-lint` (0 issues), `go test`, `gofmt`, and frontend
`lint:ci`.
