### PR TITLE
fix: use standard Cross-Origin header names in SecurityHeaders

### DIFF
--- a/backend/internal/web/mid/security.go
+++ b/backend/internal/web/mid/security.go
@@ -12,9 +12,9 @@ import (
 func SecurityHeaders() func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Origin-Embedder-Policy", "require-corp")
-			w.Header().Set("Content-Origin-Opener-Policy", "same-origin")
-			w.Header().Set("Content-Origin-Resource-Policy", "same-site")
+			w.Header().Set("Cross-Origin-Embedder-Policy", "require-corp")
+			w.Header().Set("Cross-Origin-Opener-Policy", "same-origin")
+			w.Header().Set("Cross-Origin-Resource-Policy", "same-site")
 			w.Header().Set("Permissions-Policy", "accelerometer=(), autoplay=(), camera=(self), cross-origin-isolated=(), display-capture=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(self), usb=(), web-share=(), xr-spatial-tracking=(), clipboard-read=(), clipboard-write=(self), gamepad=(), hid=(), idle-detection=(), interest-cohort=(), serial=(), unload=()")
 			w.Header().Set("Referrer-Policy", "no-referrer")
 			w.Header().Set("X-Content-Type-Options", "nosniff")

--- a/backend/internal/web/mid/security_test.go
+++ b/backend/internal/web/mid/security_test.go
@@ -1,0 +1,46 @@
+package mid
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The cross-origin isolation headers were spelled "Content-Origin-*" instead of
+// "Cross-Origin-*". Browsers ignore header names they do not recognise, so all
+// three policies were silently inert rather than merely misconfigured, and
+// nothing in the response looked wrong enough to notice. This is issue #1665.
+func TestSecurityHeadersUsesStandardCrossOriginNames(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	handler := SecurityHeaders()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	want := map[string]string{
+		"Cross-Origin-Embedder-Policy":      "require-corp",
+		"Cross-Origin-Opener-Policy":        "same-origin",
+		"Cross-Origin-Resource-Policy":      "same-site",
+		"Referrer-Policy":                   "no-referrer",
+		"X-Content-Type-Options":            "nosniff",
+		"X-Frame-Options":                   "DENY",
+		"X-Permitted-Cross-Domain-Policies": "none",
+	}
+	for name, value := range want {
+		assert.Equal(t, value, rec.Header().Get(name), "%s should be set", name)
+	}
+
+	// Guard against the misspelling coming back: a stray "Content-Origin-*"
+	// header is indistinguishable from a working one without checking the
+	// exact name, which is what let this go unnoticed in the first place.
+	for _, name := range []string{
+		"Content-Origin-Embedder-Policy",
+		"Content-Origin-Opener-Policy",
+		"Content-Origin-Resource-Policy",
+	} {
+		assert.Empty(t, rec.Header().Values(name), "%s is not a real header and should not be sent", name)
+	}
+}


### PR DESCRIPTION
## What

Renames three headers emitted by the `SecurityHeaders` middleware to their standard names:

| before | after |
| --- | --- |
| `Content-Origin-Embedder-Policy` | `Cross-Origin-Embedder-Policy` |
| `Content-Origin-Opener-Policy` | `Cross-Origin-Opener-Policy` |
| `Content-Origin-Resource-Policy` | `Cross-Origin-Resource-Policy` |

Fixes #1665.

## Why

`Content-Origin-*` is not a real header name. Browsers ignore header names they don't recognise, so COEP, COOP and CORP were inert rather than merely misconfigured — the middleware looked like it was setting them, but no policy was ever applied.

## A note on the "risk breaking things" concern in the issue

The reporter was right that this is the interesting part: renaming activates three headers that have never actually been live. I checked each against the current tree.

- **COOP `same-origin`** — only matters for cross-origin popups that use `window.opener`. The single external auth flow is OIDC, and it is a full-page redirect (`window.location.href = "/api/v1/users/login/oidc"` in `frontend/pages/index.vue`), not a popup.
- **CORP `same-site`** — governs who may embed Homebox's own resources. `X-Frame-Options: DENY` is already in place and stricter.
- **COEP `require-corp`** — the one that can actually break a page, since it blocks cross-origin subresources that don't opt in via CORP/CORS. I couldn't find any: `nuxt.config.ts` pulls no CDN fonts or external scripts, item/label/QR images are served from the API on the same origin, and barcode product photos are `data:` URIs.

So none of the three should change observable behaviour for a stock deployment. That said, you know the deployment surface better than I do — happy to drop `require-corp` (it only buys cross-origin isolation, which Homebox doesn't use) or split it into its own PR if you'd rather land the rename alone.

## Testing

- Added `backend/internal/web/mid/security_test.go`, asserting the emitted names and values and that the three misspelled names are absent.
- Verified the test is a real regression guard: with the rename reverted it fails on all six assertions, and passes with it applied.
- `go vet ./internal/web/mid/...` clean; `go test ./internal/web/mid/...` passes.