### PR TITLE
fix(ci): attest the published manifest list digest instead of a copied source manifest

### DIFF
--- a/.github/workflows/docker-publish-hardened.yaml
+++ b/.github/workflows/docker-publish-hardened.yaml
@@ -217,14 +217,22 @@ jobs:
         run: |
           set -euo pipefail
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.GHCR_REPO }}@sha256:%s ' *) 2>&1 | tee /tmp/push-ghcr.out
-          digest=$(grep -oE 'sha256:[a-f0-9]{64}' /tmp/push-ghcr.out | head -n1 || true)
-          if [ -z "$digest" ]; then
-            echo "No digest found in imagetools output:"
-            cat /tmp/push-ghcr.out
+            $(printf '${{ env.GHCR_REPO }}@sha256:%s ' *)
+          tag=$(jq -r --arg repo "${{ env.GHCR_REPO }}" \
+            '[.tags[] | select(ascii_downcase | startswith(($repo | ascii_downcase) + ":"))][0] // ""' \
+            <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          if [ -z "$tag" ]; then
+            echo "No ${{ env.GHCR_REPO }} tag found in DOCKER_METADATA_OUTPUT_JSON:"
+            echo "$DOCKER_METADATA_OUTPUT_JSON"
             exit 1
           fi
-          echo "digest=$digest" >> $GITHUB_OUTPUT
+          digest=$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')
+          if [ -z "$digest" ]; then
+            echo "Could not resolve a manifest digest for $tag"
+            exit 1
+          fi
+          echo "Attesting $tag@$digest"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Attest GHCR images
         uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8
@@ -241,14 +249,22 @@ jobs:
         run: |
           set -euo pipefail
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.DOCKERHUB_REPO }}@sha256:%s ' *) 2>&1 | tee /tmp/push-dockerhub.out
-          digest=$(grep -oE 'sha256:[a-f0-9]{64}' /tmp/push-dockerhub.out | head -n1 || true)
-          if [ -z "$digest" ]; then
-            echo "No digest found in imagetools output:"
-            cat /tmp/push-dockerhub.out
+            $(printf '${{ env.DOCKERHUB_REPO }}@sha256:%s ' *)
+          tag=$(jq -r --arg repo "${{ env.DOCKERHUB_REPO }}" \
+            '[.tags[] | select(ascii_downcase | startswith(($repo | ascii_downcase) + ":"))][0] // ""' \
+            <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          if [ -z "$tag" ]; then
+            echo "No ${{ env.DOCKERHUB_REPO }} tag found in DOCKER_METADATA_OUTPUT_JSON:"
+            echo "$DOCKER_METADATA_OUTPUT_JSON"
             exit 1
           fi
-          echo "digest=$digest" >> $GITHUB_OUTPUT
+          digest=$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')
+          if [ -z "$digest" ]; then
+            echo "Could not resolve a manifest digest for $tag"
+            exit 1
+          fi
+          echo "Attesting $tag@$digest"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Attest Dockerhub images
         uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8

--- a/.github/workflows/docker-publish-rootless.yaml
+++ b/.github/workflows/docker-publish-rootless.yaml
@@ -219,14 +219,22 @@ jobs:
         run: |
           set -euo pipefail
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.GHCR_REPO }}@sha256:%s ' *) 2>&1 | tee /tmp/push-ghcr.out
-          digest=$(grep -oE 'sha256:[a-f0-9]{64}' /tmp/push-ghcr.out | head -n1 || true)
-          if [ -z "$digest" ]; then
-            echo "No digest found in imagetools output:"
-            cat /tmp/push-ghcr.out
+            $(printf '${{ env.GHCR_REPO }}@sha256:%s ' *)
+          tag=$(jq -r --arg repo "${{ env.GHCR_REPO }}" \
+            '[.tags[] | select(ascii_downcase | startswith(($repo | ascii_downcase) + ":"))][0] // ""' \
+            <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          if [ -z "$tag" ]; then
+            echo "No ${{ env.GHCR_REPO }} tag found in DOCKER_METADATA_OUTPUT_JSON:"
+            echo "$DOCKER_METADATA_OUTPUT_JSON"
             exit 1
           fi
-          echo "digest=$digest" >> $GITHUB_OUTPUT
+          digest=$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')
+          if [ -z "$digest" ]; then
+            echo "Could not resolve a manifest digest for $tag"
+            exit 1
+          fi
+          echo "Attesting $tag@$digest"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Attest GHCR images
         uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8
@@ -243,14 +251,22 @@ jobs:
         run: |
           set -euo pipefail
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.DOCKERHUB_REPO }}@sha256:%s ' *) 2>&1 | tee /tmp/push-dockerhub.out
-          digest=$(grep -oE 'sha256:[a-f0-9]{64}' /tmp/push-dockerhub.out | head -n1 || true)
-          if [ -z "$digest" ]; then
-            echo "No digest found in imagetools output:"
-            cat /tmp/push-dockerhub.out
+            $(printf '${{ env.DOCKERHUB_REPO }}@sha256:%s ' *)
+          tag=$(jq -r --arg repo "${{ env.DOCKERHUB_REPO }}" \
+            '[.tags[] | select(ascii_downcase | startswith(($repo | ascii_downcase) + ":"))][0] // ""' \
+            <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          if [ -z "$tag" ]; then
+            echo "No ${{ env.DOCKERHUB_REPO }} tag found in DOCKER_METADATA_OUTPUT_JSON:"
+            echo "$DOCKER_METADATA_OUTPUT_JSON"
             exit 1
           fi
-          echo "digest=$digest" >> $GITHUB_OUTPUT
+          digest=$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')
+          if [ -z "$digest" ]; then
+            echo "Could not resolve a manifest digest for $tag"
+            exit 1
+          fi
+          echo "Attesting $tag@$digest"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Attest Dockerhub images
         uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -216,14 +216,22 @@ jobs:
         run: |
           set -euo pipefail
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.GHCR_REPO }}@sha256:%s ' *) 2>&1 | tee /tmp/push-ghcr.out
-          digest=$(grep -oE 'sha256:[a-f0-9]{64}' /tmp/push-ghcr.out | head -n1 || true)
-          if [ -z "$digest" ]; then
-            echo "No digest found in imagetools output:"
-            cat /tmp/push-ghcr.out
+            $(printf '${{ env.GHCR_REPO }}@sha256:%s ' *)
+          tag=$(jq -r --arg repo "${{ env.GHCR_REPO }}" \
+            '[.tags[] | select(ascii_downcase | startswith(($repo | ascii_downcase) + ":"))][0] // ""' \
+            <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          if [ -z "$tag" ]; then
+            echo "No ${{ env.GHCR_REPO }} tag found in DOCKER_METADATA_OUTPUT_JSON:"
+            echo "$DOCKER_METADATA_OUTPUT_JSON"
             exit 1
           fi
-          echo "digest=$digest" >> $GITHUB_OUTPUT
+          digest=$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')
+          if [ -z "$digest" ]; then
+            echo "Could not resolve a manifest digest for $tag"
+            exit 1
+          fi
+          echo "Attesting $tag@$digest"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Attest GHCR images
         uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8
@@ -240,14 +248,22 @@ jobs:
         run: |
           set -euo pipefail
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.DOCKERHUB_REPO }}@sha256:%s ' *) 2>&1 | tee /tmp/push-dockerhub.out
-          digest=$(grep -oE 'sha256:[a-f0-9]{64}' /tmp/push-dockerhub.out | head -n1 || true)
-          if [ -z "$digest" ]; then
-            echo "No digest found in imagetools output:"
-            cat /tmp/push-dockerhub.out
+            $(printf '${{ env.DOCKERHUB_REPO }}@sha256:%s ' *)
+          tag=$(jq -r --arg repo "${{ env.DOCKERHUB_REPO }}" \
+            '[.tags[] | select(ascii_downcase | startswith(($repo | ascii_downcase) + ":"))][0] // ""' \
+            <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          if [ -z "$tag" ]; then
+            echo "No ${{ env.DOCKERHUB_REPO }} tag found in DOCKER_METADATA_OUTPUT_JSON:"
+            echo "$DOCKER_METADATA_OUTPUT_JSON"
             exit 1
           fi
-          echo "digest=$digest" >> $GITHUB_OUTPUT
+          digest=$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')
+          if [ -z "$digest" ]; then
+            echo "Could not resolve a manifest digest for $tag"
+            exit 1
+          fi
+          echo "Attesting $tag@$digest"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Attest Dockerhub images
         uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8


### PR DESCRIPTION
Ran into this when trying to cherry-pick a nightly image from a few months ago. Claude noticed attestation was not resolving correctly. The result was a crash course in image attestation and docker workflows. 

## What type of PR is this?

- bug

## What this PR does / why we need it:

### Problem

The `merge` job recovers its attestation subject by grepping `docker buildx imagetools
create` progress output with `head -n1`:

```bash
docker buildx imagetools create ... 2>&1 | tee /tmp/push-ghcr.out
digest=$(grep -oE 'sha256:[a-f0-9]{64}' /tmp/push-ghcr.out | head -n1 || true)
```

That output starts with a `copying <digest>` line for each source manifest; the index that
was actually created only appears later, on the `pushing <digest> to <tag>` line. So
`head -n1` reliably captures a **source manifest** — in practice an `attestation-manifest`
sidecar — rather than the published index. Both `Attest GHCR images` and
`Attest Dockerhub images` then bind provenance to an object nobody pulls.

Nightly run 31549410145 (2026-08-12) attested `sha256:8cb42178…` (the arm64
attestation-manifest) while pushing `sha256:57ee260f…` to `:nightly` and `:main`.

The bug is still live and still reproduces on today's `:nightly`, which resolves to
`sha256:16b76b57…`:

```console
$ gh attestation verify oci://ghcr.io/sysadminsmedia/homebox:nightly --repo sysadminsmedia/homebox
Error: HTTP 404: Not Found (https://api.github.com/repos/sysadminsmedia/homebox/attestations/
sha256:16b76b5757700e953bf353f8f7ef637ca87b2b206dce70ce516be3998882f494?…)
```

Walking that index and asking the attestations API about each object shows where the
provenance actually landed:

| object | role | attestations |
|---|---|---|
| `sha256:16b76b57…` | **index — what `:nightly` resolves to** | **0 (HTTP 404)** |
| `sha256:4cca7e89…` | linux/arm64 | 0 |
| `sha256:505e5055…` | attestation-manifest (arm64) | 0 |
| `sha256:6d703e5d…` | linux/amd64 | 0 |
| `sha256:b7e82330…` | attestation-manifest (amd64) | **2** |

Note that the sidecar which collects the records is not stable between runs — the cited run
landed on the *arm64* sidecar, today's nightly on the *amd64* one — because `head -n1` just
takes whichever source manifest buildx happened to copy first.

This affects every published tag (`nightly`, `main`, `latest`, `0.26.x`) across all three
publish workflows. Nothing is insecure: the images are fine and are signed. But the
published provenance is unusable, which defeats its purpose.

The `build` jobs are **not** affected — they use the structured
`steps.build.outputs.digest`, and their attestations are correct
(`sha256:d4f3f5a9…` → 1 attestation).

### Fix

Stop parsing progress output. Push as before, then ask the registry what the tag resolves
to:

```bash
digest=$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')
```

`.Manifest.Digest` is the top-level descriptor — by definition the digest the tag points
at, which is exactly what the attestation should cover. Exactly one value, no parsing.
(`--format` has been available since buildx v0.8.0; `imagetools` runs client-side, so the
custom BuildKit driver image is not involved.)

The tag itself is selected from `DOCKER_METADATA_OUTPUT_JSON` by repository prefix rather
than with a bare `.tags[0]`: on `schedule` and tag builds `metadata-action` emits Docker Hub
tags *before* GHCR tags into the same array, so `.tags[0]` would hand the GHCR step a
Docker Hub reference. The two prefixes do not overlap (`DOCKERHUB_REPO` is bare,
`GHCR_REPO` is `ghcr.io/…`-prefixed). The comparison is case-insensitive because
`metadata-action` unconditionally lowercases image names while `GHCR_REPO` interpolates
`github.repository` verbatim — those differ for any fork whose owner has uppercase
characters.

Applied to both push steps in all three publish workflows (six sites):

- `.github/workflows/docker-publish.yaml`
- `.github/workflows/docker-publish-rootless.yaml`
- `.github/workflows/docker-publish-hardened.yaml`

The `tee`/`2>&1` redirection, the `/tmp/push-*.out` files, and the now-dead
`cat`-the-log error branches are removed. The `attest-build-provenance` steps, their pinned
action SHAs, and every `permissions:` block are untouched.

## Testing

- `actionlint` + `shellcheck` over all three workflows: no new findings; six pre-existing
  SC2086 warnings (`>> $GITHUB_OUTPUT` unquoted) are removed. Remaining findings
  (`ignore:` key, `artifact-metadata` permission scope) are pre-existing and unrelated.
- The jq tag selector was exercised against synthetic `DOCKER_METADATA_OUTPUT_JSON`
  payloads for: branch build (GHCR only), `schedule` (both registries), semver tag build
  (full fan-out, both registries), `-rootless`/`-hardened` suffix flavours, mixed-case fork
  owner, and an empty tag list. All pick the intended tag, and the two registry filters
  match exactly one tag each with no overlap.
- The premise was re-verified live against the GHCR registry API and the GitHub
  attestations API (table above), which is the same tag→digest resolution that
  `imagetools inspect --format '{{.Manifest.Digest}}'` performs.
