### PR TITLE
Fixed bug in Quickstart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ docker run -d \
   --restart unless-stopped \
   --publish 3100:7745 \
   --env TZ=Europe/Bucharest \
+  --env HBOX_AUTH_API_KEY_PEPPER=$(openssl rand -base64 48) \
   --volume /path/to/data/folder/:/data \
   ghcr.io/sysadminsmedia/homebox:latest
 # ghcr.io/sysadminsmedia/homebox:latest-rootless

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ You can also try the demo instances of Homebox:
 [Configuration & Docker Compose](https://homebox.software/en/quick-start/)
 
 ```bash
+# Save pepper to local file
+openssl rand -base64 48 > hbox.pepper
+chmod 400 hbox.pepper
 # If using the rootless or hardened image, ensure data 
 # folder has correct permissions
 mkdir -p /path/to/data/folder
@@ -66,7 +69,7 @@ docker run -d \
   --restart unless-stopped \
   --publish 3100:7745 \
   --env TZ=Europe/Bucharest \
-  --env HBOX_AUTH_API_KEY_PEPPER=$(openssl rand -base64 48) \
+  --env HBOX_AUTH_API_KEY_PEPPER=$(cat hbox.pepper) \
   --volume /path/to/data/folder/:/data \
   ghcr.io/sysadminsmedia/homebox:latest
 # ghcr.io/sysadminsmedia/homebox:latest-rootless


### PR DESCRIPTION
## What type of PR is this?

- bug

## What this PR does / why we need it:

I ran through the Quickstart instructions and hit this error.

```
panic: auth.api_key_pepper must be set to at least 32 bytes; generate with `openssl rand -base64 48` and provide via HBOX_AUTH_API_KEY_PEPPER. Rotating it invalidates all issued API keys
```

This PR updates the Quickstart instructions to bypass that error.