### PR TITLE
fix broken internal links in contribute docs

### DIFF
--- a/docs/src/content/docs/en/contribute/development/index.mdx
+++ b/docs/src/content/docs/en/contribute/development/index.mdx
@@ -27,8 +27,6 @@ The frontend is written in Vue.js with Vite and Nuxt and is located in the `fron
  single-page application that provides a user interface for interacting with Homebox. It is built on top of the
 [Homebox API](/docs/api).
 
-Extensive frontend documentation can be found in the [frontend topic](/en/contribute/development/frontend).
-
 ## Running Locally
 To run Homebox locally, for development purposes, you'll need to run both the backend and frontend. You can run them in two separate terminals:
 - `task go:run`

--- a/docs/src/content/docs/en/contribute/translate/index.mdx
+++ b/docs/src/content/docs/en/contribute/translate/index.mdx
@@ -17,7 +17,7 @@ If you just want something simple, you can do it from your browser, you can tran
 >
 > Without this key, the language name will not be displayed correctly in any language.
 
-To translate the documentation, please see the [documentation translation guide](/docs/en/contribute/translate/docs).
+To translate the documentation, please see the [documentation translation guide](/en/contribute/translate/documentation/).
 
 ## App Translation Status
 [![Translation status](https://translate.sysadminsmedia.com/widget/homebox/frontend/multi-auto.svg)](https://translate.sysadminsmedia.com/engage/homebox/)


### PR DESCRIPTION
## What type of PR is this?

_(REQUIRED)_

- documentation

## What this PR does / why we need it:

_(REQUIRED)_

Fixes two broken internal links in the contributor documentation (they 404 on the published docs site):

- `docs/src/content/docs/en/contribute/development/index.mdx`: removed the sentence pointing to a non-existent "frontend topic" page (`/en/contribute/development/frontend`). No such page exists under `src/content/docs/en/contribute/development/` (only `backend/` exists).
- `docs/src/content/docs/en/contribute/translate/index.mdx`: corrected the "documentation translation guide" link from `/docs/en/contribute/translate/docs` (wrong `/docs/` prefix and non-existent slug) to `/en/contribute/translate/documentation/`, which matches the actual page.

Both targets were verified against the documentation content tree in `docs/src/content/docs/en/`.

## Which issue(s) this PR fixes:

_(REQUIRED)_

No issue created for this documentation-only fix.

## Special notes for your reviewer:

This is a documentation-only change (2 files, no source/config/test changes).

## Testing

_(fill-in or delete this section)_

Static verification only: confirmed the corrected URL maps to an existing page in `docs/src/content/docs/en/contribute/translate/documentation.mdx` and that no `frontend` page exists for the removed link. The docs dev server was not run as part of this documentation-only change.