### PR TITLE
docs: fix typo extenal -> external

### DIFF
--- a/docs/src/content/docs/en/advanced/external-label-service.mdx
+++ b/docs/src/content/docs/en/advanced/external-label-service.mdx
@@ -9,7 +9,7 @@ You can use an external web service to generate asset and location labels in hom
 
 ## Configuration
 
-The external service is configured using the `HBOX_LABEL_MAKER_LABEL_SERVICE_URL` enviroment variable.
+The external service is configured using the `HBOX_LABEL_MAKER_LABEL_SERVICE_URL` environment variable.
 
 ## Request
 

--- a/docs/src/content/docs/en/advanced/external-label-service.mdx
+++ b/docs/src/content/docs/en/advanced/external-label-service.mdx
@@ -9,7 +9,7 @@ You can use an external web service to generate asset and location labels in hom
 
 ## Configuration
 
-The extenal service is configured using the `HBOX_LABEL_MAKER_LABEL_SERVICE_URL` enviroment variable.
+The external service is configured using the `HBOX_LABEL_MAKER_LABEL_SERVICE_URL` enviroment variable.
 
 ## Request
 


### PR DESCRIPTION
Corrects the misspelling `extenal` -> `external` in `docs/src/content/docs/en/advanced/external-label-service.mdx`.

Documentation only, no behaviour change.