### PR TITLE
fix(devcontainer): bump Go feature to 1.26 to match go.mod

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,6 +29,6 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",
 	"features": {
-		"ghcr.io/devcontainers/features/go:1": "1.24"
+		"ghcr.io/devcontainers/features/go:1": "1.26"
 	}
 }


### PR DESCRIPTION
## Problem

`backend/go.mod` requires:

```
go 1.26.0
```

but `.devcontainer/devcontainer.json` pins the Go feature to `1.24`:

```json
"features": {
    "ghcr.io/devcontainers/features/go:1": "1.24"
}
```

So the devcontainer cannot build the backend — `task setup` / `go build ./app/api` fails on the Go version requirement. Since `CONTRIBUTING.md` points new contributors at the devcontainer as the recommended way to get started, this is the first thing a new contributor hits.

## Fix

Bumps the pinned feature version to `1.26` to match `go.mod`.

Happy to switch this to `"latest"` instead if you'd prefer the devcontainer not to need a bump on every Go release — that would avoid this drift recurring, but it's a policy call so I've kept the change minimal and matched the existing pin style.

## Related (not changed here)

`CONTRIBUTING.md` still lists "Go 1.19+" and "Node.js 16+" under prerequisites, which is also well behind `go.mod` and the Node 22 used in the Dockerfile. Left alone to keep this PR to one line — glad to send a separate docs PR if useful.

## Testing

Verified `go 1.26.0` in `backend/go.mod` on `main` (`acd9a233`) against the pinned `1.24` feature. Change is a one-line version bump with no behavioural effect outside the dev container.

---

Found and fixed with the help of Claude AI while adapting Homebox for a self-hosted deployment. Thanks for maintaining this project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)