### PR TITLE
fix: make repo docker-compose.yml startable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
             - linux/arm64
             - linux/arm
     environment:
-      - HBOX_LOGGER_LEVEL=-1
+      - HBOX_LOG_LEVEL=-1
+      - HBOX_AUTH_API_KEY_PEPPER=dev-only-pepper-not-for-production-use-32b+
     ports:
       - 3100:7745


### PR DESCRIPTION
## Problem

`docker compose up --build` at the repo root never starts. Two separate issues:

**1. Missing API key pepper — container panics**

`backend/app/api/main.go:120` requires the pepper unconditionally:

```go
if len(cfg.Auth.APIKeyPepper) < 32 {
    return fmt.Errorf("auth.api_key_pepper must be set to at least 32 bytes; ...")
}
```

The compose file never sets it, so the container panics and exits with code 2:

```
panic: auth.api_key_pepper must be set to at least 32 bytes; generate with
`openssl rand -base64 48` and provide via HBOX_AUTH_API_KEY_PEPPER.
```

**2. `HBOX_LOGGER_LEVEL` is not a recognised variable**

The config field is `LoggerConf.Level` under `Log`, so the env var is `HBOX_LOG_LEVEL` — which is what `Taskfile.yml` already uses. `api --help` confirms it:

```
HBOX_LOG_LEVEL   <string>   (default: info)
```

`HBOX_LOGGER_LEVEL` is silently ignored (unknown vars aren't errors), so the intended verbose logging never takes effect and the level stays at `info`.

## Fix

Sets `HBOX_LOG_LEVEL` and adds the pepper, reusing the same dev-only value already in `Taskfile.yml` so there's one convention for local dev:

```yaml
- HBOX_LOG_LEVEL=-1
- HBOX_AUTH_API_KEY_PEPPER=dev-only-pepper-not-for-production-use-32b+
```

I kept the existing `-1` value rather than changing it. `zerolog.ParseLevel` falls back to `strconv.Atoi`, so `-1` is valid and maps to `TraceLevel`. Happy to change it to `debug` to match `Taskfile.yml` if you'd prefer the readable form — it's a one-word change either way.

## Testing

Verified against the image built from this repo.

Before (current compose env):
```
$ docker run -e HBOX_LOGGER_LEVEL=-1 homebox
panic: auth.api_key_pepper must be set to at least 32 bytes ...
exit code: 2
```

After (fixed env):
```
$ docker run -e HBOX_LOG_LEVEL=-1 -e HBOX_AUTH_API_KEY_PEPPER=dev-only-... homebox
INF Server is running on :7745
INF request received  method=GET path=/api/v1/status
INF request finished  method=GET path=/api/v1/status status=200
```

Container stays up and the healthcheck passes.

Note: the file uses CRLF line endings, which I preserved — the diff is two lines.

---

Found and fixed with the help of Claude AI while adapting Homebox for a self-hosted deployment. Thanks for maintaining this project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)