### PR TITLE
fix(taskfile): codegen tasks never detect source changes

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,10 +37,15 @@ tasks:
       - cp -r ./docs/openapi-3.json ../../../../docs/public/api/openapi-3.0.json
       - cp -r ./docs/openapi-3.yaml ../../../../docs/public/api/openapi-3.0.yaml
     sources:
-      - "./backend/app/api/**/*"
-      - "./backend/internal/data/**"
-      - "./backend/internal/core/services/**/*"
-      - "./backend/app/tools/typegen/main.go"
+      # Relative to `dir:` above, not the repo root. Deliberately excludes
+      # static/, where swag writes its own output - covering it would make this
+      # task perpetually out-of-date instead of perpetually up-to-date.
+      - "../*.go"
+      - "../handlers/**/*.go"
+      - "../providers/**/*.go"
+      - "../../../internal/data/**/*.go"
+      - "../../../internal/core/services/**/*.go"
+      - "../../tools/typegen/main.go"
   typescript-types:
     desc: Generates typescript types from swagger definition
     cmds:
@@ -157,7 +162,8 @@ tasks:
     cmds:
       - CGO_ENABLED=0 go generate ./...
     sources:
-      - "./backend/internal/data/ent/schema/**/*"
+      # Relative to `dir:` above, not the repo root.
+      - "./data/ent/schema/**/*"
 
   ui:watch:
     desc: Starts the vitest test runner in watch mode


### PR DESCRIPTION
## Problem

`swag` and `db:generate` both set a `dir:` but declare `sources:` relative to the **repo root**:

```yaml
db:generate:
  dir: backend/internal/
  sources:
    - "./backend/internal/data/ent/schema/**/*"   # -> backend/internal/backend/internal/...
```

go-task resolves `sources` relative to `dir`, so these globs match nothing. After the first run each task stores a checksum for an empty file set and reports "up to date" from then on — permanently.

Both consequences are silent, which is what makes this worth fixing:

- Editing an **ent schema** and running `task generate` regenerates nothing.
- Editing an **API handler** leaves `swagger.json` and the generated frontend TypeScript types stale, so the UI ends up typed against an API that no longer matches.

I hit the second one while adding endpoints: they were missing from the generated client, and `task swag --force` was the only way to get them. That is what led me here.

## Reproducing on current `main` (`acd9a233`)

```console
$ task db:generate                     # establish a baseline
$ task db:generate --status; echo $?
0                                      # up to date, correct so far

$ echo "// probe" >> backend/internal/data/ent/schema/tag.go
$ task db:generate --status; echo $?
0                                      # WRONG - a schema edit is not noticed
```

Same for `swag`, with an edit to any handler, repo or service file.

## Fix

Write the globs relative to `dir`.

The `swag` globs are also narrowed to `*.go` under the input directories, deliberately leaving out `static/`. That part is not cosmetic: `swag` writes its own output into `static/docs/`, so a glob covering `static/` makes the task perpetually *out-of-date* instead of perpetually up-to-date — wrong in the other direction. (`excludes:` did not appear to be honoured on go-task 3.53.1, so narrowing seemed the more reliable approach. Happy to switch if you know otherwise.)

## Verification

After the change, on a clean branch off `main`:

| edit | `--status` before | after |
| --- | --- | --- |
| `backend/internal/data/ent/schema/tag.go` | up to date | out of date |
| `backend/app/api/handlers/v1/v1_ctrl_tags.go` | up to date | out of date |
| `backend/internal/core/services/service_user.go` | up to date | out of date |

Each then returns to up-to-date once the task runs.

`task generate` produces **byte-identical** output before and after, so this changes only *when* the tasks run, never what they produce.

One gotcha for anyone verifying: `--force` does not persist the checksum, so `--status` immediately after `--force` always reports out-of-date. Use a plain run when checking.

---

Found and fixed with the help of Claude AI while adapting Homebox for a self-hosted deployment. Thanks for maintaining this project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)