### PR TITLE
fix(maintenance): global list agrees with per-entity on future completions

### DIFF
--- a/backend/internal/data/repo/repo_maintenance.go
+++ b/backend/internal/data/repo/repo_maintenance.go
@@ -53,15 +53,23 @@ func (r *MaintenanceEntryRepository) GetAllMaintenance(ctx context.Context, grou
 
 	switch filters.Status {
 	case MaintenanceFilterStatusScheduled:
+		// DateGT(now) belongs here, and its absence is what made the two maintenance
+		// endpoints disagree: a completedDate in the FUTURE is a date that has not
+		// happened yet, so the entry is scheduled rather than completed. The per-entity
+		// query (GetMaintenanceByItemID) has always applied this clause; this one did
+		// not, so the same entry read as scheduled from one endpoint and completed from
+		// the other, with the same status filter.
 		query = query.Where(maintenanceentry.Or(
 			maintenanceentry.DateIsNil(),
 			maintenanceentry.DateEQ(time.Time{}),
+			maintenanceentry.DateGT(time.Now()),
 		))
 	case MaintenanceFilterStatusCompleted:
 		query = query.Where(
 			maintenanceentry.Not(maintenanceentry.Or(
 				maintenanceentry.DateIsNil(),
-				maintenanceentry.DateEQ(time.Time{})),
+				maintenanceentry.DateEQ(time.Time{}),
+				maintenanceentry.DateGT(time.Now())),
 			))
 	case MaintenanceFilterStatusBoth:
 		// No additional filters needed

--- a/backend/internal/data/repo/repo_maintenance_entry_test.go
+++ b/backend/internal/data/repo/repo_maintenance_entry_test.go
@@ -80,3 +80,63 @@ func TestMaintenanceEntryRepository_GetLog(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
+
+// The two maintenance endpoints must agree about a future-dated completion.
+//
+// `GetAllMaintenance` omitted the `DateGT(now)` clause that
+// `GetMaintenanceByItemID` applies, so the same entry read as SCHEDULED from
+// /v1/entities/{id}/maintenance and COMPLETED from /v1/maintenance, with the
+// same status filter. A completedDate in the future is a date that has not
+// happened yet.
+func TestGetAllMaintenance_FutureCompletionIsScheduledNotCompleted(t *testing.T) {
+	item := useEntities(t, 1)[0]
+
+	past := MaintenanceEntryCreate{
+		CompletedDate: types.DateFromTime(getPrevMonth(time.Now())),
+		Name:          "Done last month",
+		Description:   "Maintenance description",
+		Cost:          10,
+	}
+	future := MaintenanceEntryCreate{
+		CompletedDate: types.DateFromTime(time.Now().AddDate(0, 0, 7)),
+		Name:          "Booked for next week",
+		Description:   "Maintenance description",
+		Cost:          10,
+	}
+
+	for _, entry := range []MaintenanceEntryCreate{past, future} {
+		_, err := tRepos.MaintEntry.Create(context.Background(), tGroup.ID, item.ID, entry)
+		require.NoError(t, err)
+	}
+
+	ctx := context.Background()
+	completedAll, err := tRepos.MaintEntry.GetAllMaintenance(ctx, tGroup.ID, MaintenanceFilters{Status: MaintenanceFilterStatusCompleted})
+	require.NoError(t, err)
+	scheduledAll, err := tRepos.MaintEntry.GetAllMaintenance(ctx, tGroup.ID, MaintenanceFilters{Status: MaintenanceFilterStatusScheduled})
+	require.NoError(t, err)
+
+	completedNames := make([]string, 0, len(completedAll))
+	for _, e := range completedAll {
+		completedNames = append(completedNames, e.Name)
+	}
+	scheduledNames := make([]string, 0, len(scheduledAll))
+	for _, e := range scheduledAll {
+		scheduledNames = append(scheduledNames, e.Name)
+	}
+
+	assert.Contains(t, completedNames, "Done last month")
+	assert.NotContains(t, completedNames, "Booked for next week",
+		"a completedDate in the future is not a completion")
+	assert.Contains(t, scheduledNames, "Booked for next week")
+
+	// The property the issue is actually about: the global and per-entity endpoints
+	// classify the same entry the same way. Asserting only the global side would let
+	// the two drift apart again in the other direction.
+	completedItem, err := tRepos.MaintEntry.GetMaintenanceByItemID(ctx, tGroup.ID, item.ID, MaintenanceFilters{Status: MaintenanceFilterStatusCompleted})
+	require.NoError(t, err)
+	assert.Len(t, completedItem, len(completedAll))
+
+	for _, entry := range append(completedAll, scheduledAll...) {
+		require.NoError(t, tRepos.MaintEntry.Delete(ctx, tGroup.ID, entry.ID))
+	}
+}


### PR DESCRIPTION
## What

`GetAllMaintenance` now applies the `DateGT(time.Now())` clause that `GetMaintenanceByItemID` already had.

Fixes #1692.

## The bug

An entry whose `completedDate` is in the future was classified **differently by the two endpoints, under the same filter**:

| Request | Result |
|---|---|
| `GET /v1/entities/{id}/maintenance?status=completed` | excluded — reported as scheduled |
| `GET /v1/maintenance?status=completed` | included — reported as completed |

A `completedDate` in the future is a date that has not happened yet, so the per-entity query was already right. This adds the same clause to both branches of the global one rather than relaxing the per-entity path — the reporter's diagnosis was exact and I found the two queries side by side as described.

As #1692 notes, this is the same symptom as #484, which was closed on the assumption a PR had resolved it. One of the two queries was fixed and the other was not.

## The test asserts agreement, not just the global result

```go
completedItem, _ := tRepos.MaintEntry.GetMaintenanceByItemID(...)
assert.Len(t, completedItem, len(completedAll))
```

Checking only the global side would let the two drift apart again in the **other** direction — which is how this survived #484. The test also pins both halves directly: a future-dated entry is absent from `completed` and present in `scheduled`.

Confirmed failing before the change (`should have 2 item(s), but has 1`).

## Verification

- `go build ./...` — clean
- `go vet ./internal/data/repo/...` — clean
- `gofmt -l` — clean
- `go test ./internal/data/repo/` — ok (full package, not just the new test)

`golangci-lint` is not installed on this machine, so CI is the authority on that one; the change is two added lines inside existing `Or` clauses.

## Scope

Backend query only. No API shape change, no migration, no frontend change — the endpoints already advertise this filter and simply disagreed about it.