### PR TITLE
fix(maintenance): duplicate from the global page uses the entry's own item

### DIFF
--- a/frontend/components/Maintenance/ListView.vue
+++ b/frontend/components/Maintenance/ListView.vue
@@ -39,6 +39,29 @@
     },
   });
 
+  /**
+   * The item a duplicated entry belongs to.
+   *
+   * On an item's own Maintenance tab that is `currentItemId`. On the GLOBAL Maintenance
+   * page there is no current item, and the duplicate dialog was handed
+   * `props.currentItemId!` — a non-null assertion, which only silences TypeScript and
+   * supplies no runtime value. `EditModal` then created maintenance for `undefined` and
+   * the request failed with "Failed to create entry."
+   *
+   * Each entry already carries its own `itemID`; the template beside this uses it to link
+   * to the item. Preferring `currentItemId` keeps the item view behaving exactly as it
+   * did, and falls back to the entry's own item where there is no current one.
+   *
+   * `unknown` rather than the entry type because the template's `e` is inferred as
+   * `true | MaintenanceEntryWithDetails[] | undefined` throughout this component - a
+   * pre-existing typing problem this file already carries 25 errors for. Narrowing at the
+   * call site would add a 26th of the same kind; taking `unknown` and asserting here adds
+   * none. Worth fixing properly, but not from inside this bug.
+   */
+  function duplicateItemId(entry: unknown): string {
+    return props.currentItemId ?? (entry as MaintenanceEntryWithDetails).itemID;
+  }
+
   const { data: maintenanceDataList, refresh: refreshList } = useAsyncData(
     async () => {
       const { data } =
@@ -241,7 +264,11 @@
             variant="outline"
             @click="
               openDialog(DialogID.EditMaintenance, {
-                params: { type: 'duplicate', maintenanceEntry: e, itemId: props.currentItemId! },
+                params: {
+                  type: 'duplicate',
+                  maintenanceEntry: e,
+                  itemId: duplicateItemId(e),
+                },
                 onClose: result => {
                   if (result) {
                     refreshList();


### PR DESCRIPTION
## What

The Duplicate button on the global Maintenance page now passes the entry's own `itemID`.

Fixes #1698.

## The bug

The dialog was handed `props.currentItemId!`. On the global page there is no current item, and **the non-null assertion only silences TypeScript** — it supplies no runtime value. `EditModal` then set `entry.itemIds = [undefined]` and tried to create maintenance for nothing, which is the *"Failed to create entry."* toast.

That is also why it worked from an item's own Maintenance tab: that view supplies `currentItemId`. The reporter's diagnosis was exact.

## The fix

Each entry already carries its own `itemID` — the template a few lines above uses it to link to the item, so it is present in exactly the view where `currentItemId` is not.

`props.currentItemId ?? entry.itemID` keeps the item view behaving **identically** to before and only changes the global page, where the value was previously `undefined`.

## One thing worth flagging: the helper takes `unknown`

Not out of laziness. The template's `e` is inferred as `true | MaintenanceEntryWithDetails[] | undefined` throughout this component — a pre-existing typing problem the file already carries **25** errors for.

Narrowing at the call site (`duplicateItemId(e as MaintenanceEntryWithDetails)`) adds a 26th, of the identical `TS2352` kind the file already produces for every other `e` cast. Taking `unknown` and asserting inside the helper adds **none**: the repo's total is unchanged at 196 before and after.

The right fix is typing `e` properly across this component, and that is a different change from this bug — I did not want to bundle a refactor into a one-line fix, or to leave a new error behind either.

## Verification

- `pnpm lint` — clean
- `pnpm typecheck` — **196 errors before, 196 after** (all pre-existing; none in scope here)
- Frontend-only; no API, schema or backend change

I could not exercise the dialog end to end without a running instance, so this rests on the reporter's source-level diagnosis plus reading `EditModal`'s use of `params.itemId` — both of which line up. Happy to add a component test if you would like one, though I did not find an existing pattern for these dialogs to follow.