### PR TITLE
feat: add default image to entity templates

### DIFF
--- a/backend/app/api/handlers/v1/v1_ctrl_entities_attachments.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_entities_attachments.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/url"
@@ -12,6 +13,7 @@ import (
 	"github.com/hay-kot/httpkit/server"
 	"github.com/rs/zerolog/log"
 	"github.com/sysadminsmedia/homebox/backend/internal/core/services"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/attachment"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/repo"
 	"github.com/sysadminsmedia/homebox/backend/internal/sys/validate"
@@ -31,6 +33,17 @@ func sanitizeAttachmentName(name string) string {
 	name = strings.ReplaceAll(name, "/", "")
 	name = strings.ReplaceAll(name, "\\", "")
 	return name
+}
+
+// isImageExtension reports whether a file name looks like an image Homebox can
+// display and thumbnail.
+func isImageExtension(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp", ".tiff", ".avif", ".ico", ".heic", ".jxl":
+		return true
+	default:
+		return false
+	}
 }
 
 // HandleEntityAttachmentCreate godoc
@@ -96,12 +109,9 @@ func (ctrl *V1Controller) HandleEntityAttachmentCreate() errchain.HandlerFunc {
 
 		attachmentType := r.FormValue("type")
 		if attachmentType == "" {
-			ext := filepath.Ext(attachmentName)
-
-			switch strings.ToLower(ext) {
-			case ".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp", ".tiff", ".avif", ".ico", ".heic", ".jxl":
+			if isImageExtension(attachmentName) {
 				attachmentType = attachment.TypePhoto.String()
-			default:
+			} else {
 				attachmentType = attachment.TypeAttachment.String()
 			}
 		}
@@ -187,6 +197,83 @@ func (ctrl *V1Controller) HandleEntityAttachmentUpdate() errchain.HandlerFunc {
 	return ctrl.handleEntityAttachmentsHandler
 }
 
+// serveAttachmentContent streams a stored attachment to the client. Entity
+// attachments and entity template images resolve the attachment row
+// differently but are served identically once it is in hand.
+func (ctrl *V1Controller) serveAttachmentContent(ctx context.Context, w http.ResponseWriter, r *http.Request, doc *ent.Attachment) error {
+	ctx, span := startEntityCtrlSpan(ctx, "controller.V1.serveAttachmentContent")
+	defer span.End()
+
+	if doc.MimeType == repo.MimeTypeLinkURL {
+		parsed, ok := parseExternalHTTPURL(doc.Path)
+		if !ok {
+			err := errors.New("invalid external URL attachment")
+			recordCtrlSpanError(span, err)
+			return validate.NewRequestError(err, http.StatusUnprocessableEntity)
+		}
+
+		http.Redirect(w, r, parsed.String(), http.StatusFound)
+		return nil
+	}
+
+	bucketCtx, bucketSpan := startEntityCtrlSpan(ctx, "controller.V1.serveAttachmentContent.openBucket")
+	bucket, err := blob.OpenBucket(bucketCtx, ctrl.repo.Attachments.GetConnString())
+	if err != nil {
+		recordCtrlSpanError(bucketSpan, err)
+		bucketSpan.End()
+		recordCtrlSpanError(span, err)
+		log.Err(err).Msg("failed to open bucket")
+		return validate.NewRequestError(err, http.StatusInternalServerError)
+	}
+	bucketSpan.End()
+
+	readerCtx, readerSpan := startEntityCtrlSpan(ctx, "controller.V1.serveAttachmentContent.openReader")
+	file, err := bucket.NewReader(readerCtx, ctrl.repo.Attachments.GetFullPath(doc.Path), nil)
+	if err != nil {
+		recordCtrlSpanError(readerSpan, err)
+		readerSpan.End()
+		recordCtrlSpanError(span, err)
+		log.Err(err).Msg("failed to open file")
+		return validate.NewRequestError(err, http.StatusInternalServerError)
+	}
+	readerSpan.End()
+
+	defer func(file *blob.Reader) {
+		err := file.Close()
+		if err != nil {
+			log.Err(err).Msg("failed to close file")
+		}
+	}(file)
+	defer func(bucket *blob.Bucket) {
+		err := bucket.Close()
+		if err != nil {
+			log.Err(err).Msg("failed to close bucket")
+		}
+	}(bucket)
+
+	// Attachments are user-supplied and can be arbitrarily large (videos,
+	// scanned manuals). Without this the default 10s write timeout truncates
+	// them mid-transfer on slow links.
+	allowSlowResponse(w, r)
+
+	disposition := "attachment"
+	if isSafeInlineType(doc.MimeType) {
+		disposition = "inline"
+	}
+	disposition += "; filename*=UTF-8''" + url.QueryEscape(doc.Title)
+	w.Header().Set("Content-Disposition", disposition)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Frame-Options", "DENY")
+	w.Header().Set("X-Download-Options", "noopen")
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; img-src 'self'; style-src 'unsafe-inline'; sandbox;")
+
+	_, serveSpan := startEntityCtrlSpan(ctx, "controller.V1.serveAttachmentContent.serveContent",
+		attribute.String("attachment.disposition", disposition))
+	http.ServeContent(w, r, doc.Title, doc.CreatedAt, file)
+	serveSpan.End()
+	return nil
+}
+
 func (ctrl *V1Controller) handleEntityAttachmentsHandler(w http.ResponseWriter, r *http.Request) error {
 	spanCtx, span := startEntityCtrlSpan(r.Context(), "controller.V1.handleEntityAttachmentsHandler",
 		attribute.String("http.method", r.Method))
@@ -230,77 +317,7 @@ func (ctrl *V1Controller) handleEntityAttachmentsHandler(w http.ResponseWriter, 
 			attribute.String("attachment.title", doc.Title),
 		)
 
-		if doc.MimeType == repo.MimeTypeLinkURL {
-			parsed, ok := parseExternalHTTPURL(doc.Path)
-			if !ok {
-				err = errors.New("invalid external URL attachment")
-				recordCtrlSpanError(getSpan, err)
-				recordCtrlSpanError(span, err)
-				return validate.NewRequestError(err, http.StatusUnprocessableEntity)
-			}
-
-			http.Redirect(w, r, parsed.String(), http.StatusFound)
-			return nil
-		}
-
-		bucketCtx, bucketSpan := startEntityCtrlSpan(getCtx, "controller.V1.handleEntityAttachmentsHandler.openBucket")
-		bucket, err := blob.OpenBucket(bucketCtx, ctrl.repo.Attachments.GetConnString())
-		if err != nil {
-			recordCtrlSpanError(bucketSpan, err)
-			bucketSpan.End()
-			recordCtrlSpanError(getSpan, err)
-			recordCtrlSpanError(span, err)
-			log.Err(err).Msg("failed to open bucket")
-			return validate.NewRequestError(err, http.StatusInternalServerError)
-		}
-		bucketSpan.End()
-
-		readerCtx, readerSpan := startEntityCtrlSpan(getCtx, "controller.V1.handleEntityAttachmentsHandler.openReader")
-		file, err := bucket.NewReader(readerCtx, ctrl.repo.Attachments.GetFullPath(doc.Path), nil)
-		if err != nil {
-			recordCtrlSpanError(readerSpan, err)
-			readerSpan.End()
-			recordCtrlSpanError(getSpan, err)
-			recordCtrlSpanError(span, err)
-			log.Err(err).Msg("failed to open file")
-			return validate.NewRequestError(err, http.StatusInternalServerError)
-		}
-		readerSpan.End()
-
-		defer func(file *blob.Reader) {
-			err := file.Close()
-			if err != nil {
-				log.Err(err).Msg("failed to close file")
-			}
-		}(file)
-		defer func(bucket *blob.Bucket) {
-			err := bucket.Close()
-			if err != nil {
-				log.Err(err).Msg("failed to close bucket")
-			}
-		}(bucket)
-
-		// Attachments are user-supplied and can be arbitrarily large (videos,
-		// scanned manuals). Without this the default 10s write timeout truncates
-		// them mid-transfer on slow links.
-		allowSlowResponse(w, r)
-
-		disposition := "attachment"
-		if isSafeInlineType(doc.MimeType) {
-			disposition = "inline"
-		}
-		disposition += "; filename*=UTF-8''" + url.QueryEscape(doc.Title)
-		w.Header().Set("Content-Disposition", disposition)
-		w.Header().Set("X-Content-Type-Options", "nosniff")
-		w.Header().Set("X-Frame-Options", "DENY")
-		w.Header().Set("X-Download-Options", "noopen")
-		w.Header().Set("Content-Security-Policy", "default-src 'none'; img-src 'self'; style-src 'unsafe-inline'; sandbox;")
-
-		_, serveSpan := startEntityCtrlSpan(getCtx, "controller.V1.handleEntityAttachmentsHandler.serveContent",
-			attribute.String("attachment.disposition", disposition))
-		http.ServeContent(w, r, doc.Title, doc.CreatedAt, file)
-		serveSpan.End()
-		return nil
+		return ctrl.serveAttachmentContent(getCtx, w, r, doc)
 
 	case http.MethodDelete:
 		err = ctrl.svc.Entities.AttachmentDelete(spanCtx, ctx.GID, attachmentID)

--- a/backend/app/api/handlers/v1/v1_ctrl_entity_templates.go
+++ b/backend/app/api/handlers/v1/v1_ctrl_entity_templates.go
@@ -1,13 +1,17 @@
 package v1
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/google/uuid"
 	"github.com/hay-kot/httpkit/errchain"
+	"github.com/hay-kot/httpkit/server"
+	"github.com/rs/zerolog/log"
 	"github.com/samber/lo"
 	"github.com/sysadminsmedia/homebox/backend/internal/core/services"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/repo"
+	"github.com/sysadminsmedia/homebox/backend/internal/sys/validate"
 	"github.com/sysadminsmedia/homebox/backend/internal/web/adapters"
 )
 
@@ -114,6 +118,122 @@ type EntityTemplateCreateItemRequest struct {
 	Quantity     *float64    `json:"quantity"`
 }
 
+// HandleEntityTemplateImageUpload godoc
+//
+//	@Summary		Set Entity Template Default Image
+//	@Description	Stores an image on the template. Entities created from the template
+//				afterwards get it as their primary photo.
+//	@Tags			Entity Templates
+//	@Accept			multipart/form-data
+//	@Produce		json
+//	@Param			id		path		string	true	"Template ID"
+//	@Param			file	formData	file	true	"Image file"
+//	@Param			name	formData	string	true	"name of the file including extension"
+//	@Success		200		{object}	repo.EntityTemplateOut
+//	@Failure		422		{object}	validate.ErrorResponse
+//	@Router			/v1/templates/{id}/image [POST]
+//	@Security		Bearer
+func (ctrl *V1Controller) HandleEntityTemplateImageUpload() errchain.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		err := r.ParseMultipartForm(ctrl.maxUploadSize << 20)
+		if err != nil {
+			log.Err(err).Msg("failed to parse multipart form")
+			return multipartFormError(err)
+		}
+
+		errs := validate.NewFieldErrors()
+
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			switch {
+			case errors.Is(err, http.ErrMissingFile):
+				errs = errs.Append("file", "file is required")
+			default:
+				log.Err(err).Msg("failed to get file from form")
+				return validate.NewRequestError(err, http.StatusInternalServerError)
+			}
+		}
+
+		name := r.FormValue("name")
+		if name == "" {
+			errs = errs.Append("name", "name is required")
+		}
+
+		if !errs.Nil() {
+			return server.JSON(w, http.StatusUnprocessableEntity, errs)
+		}
+
+		name = sanitizeAttachmentName(name)
+		if !isImageExtension(name) {
+			errs = errs.Append("file", "file must be an image")
+			return server.JSON(w, http.StatusUnprocessableEntity, errs)
+		}
+
+		id, err := ctrl.routeID(r)
+		if err != nil {
+			return err
+		}
+
+		auth := services.NewContext(r.Context())
+		out, err := ctrl.repo.EntityTemplates.SetDefaultImage(auth, auth.GID, id, repo.ItemCreateAttachment{
+			Title:   name,
+			Content: file,
+		})
+		if err != nil {
+			log.Err(err).Msg("failed to set template image")
+			return validate.NewRequestError(err, http.StatusInternalServerError)
+		}
+
+		return server.JSON(w, http.StatusOK, out)
+	}
+}
+
+// HandleEntityTemplateImageDelete godoc
+//
+//	@Summary		Delete Entity Template Default Image
+//	@Description	Removes the template's default image. Entities already created from
+//				the template keep the copy they were given.
+//	@Tags			Entity Templates
+//	@Produce		json
+//	@Param			id	path		string	true	"Template ID"
+//	@Success		200	{object}	repo.EntityTemplateOut
+//	@Router			/v1/templates/{id}/image [DELETE]
+//	@Security		Bearer
+func (ctrl *V1Controller) HandleEntityTemplateImageDelete() errchain.HandlerFunc {
+	fn := func(r *http.Request, id uuid.UUID) (repo.EntityTemplateOut, error) {
+		auth := services.NewContext(r.Context())
+		return ctrl.repo.EntityTemplates.ClearDefaultImage(auth, auth.GID, id)
+	}
+
+	return adapters.CommandID("id", fn, http.StatusOK)
+}
+
+// HandleEntityTemplateImageGet godoc
+//
+//	@Summary	Get Entity Template Default Image
+//	@Tags		Entity Templates
+//	@Produce	application/octet-stream
+//	@Param		id	path	string	true	"Template ID"
+//	@Success	200	{file}	file
+//	@Router		/v1/templates/{id}/image [GET]
+//	@Security	Bearer
+func (ctrl *V1Controller) HandleEntityTemplateImageGet() errchain.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		id, err := ctrl.routeID(r)
+		if err != nil {
+			return err
+		}
+
+		auth := services.NewContext(r.Context())
+		doc, err := ctrl.repo.EntityTemplates.GetDefaultImage(auth, auth.GID, id)
+		if err != nil {
+			return validate.NewRequestError(err, http.StatusNotFound)
+		}
+
+		return ctrl.serveAttachmentContent(auth, w, r, doc)
+	}
+}
+
 // HandleEntityTemplatesCreateItem godoc
 //
 //	@Summary	Create Entity from Template
@@ -151,6 +271,7 @@ func (ctrl *V1Controller) HandleEntityTemplatesCreateItem() errchain.HandlerFunc
 
 		// Create entity with all template data in a single transaction
 		return ctrl.repo.Entities.CreateFromTemplate(r.Context(), auth.GID, repo.EntityCreateFromTemplate{
+			TemplateID:       templateID,
 			Name:             body.Name,
 			Description:      body.Description,
 			Quantity:         quantity,

--- a/backend/app/api/routes.go
+++ b/backend/app/api/routes.go
@@ -233,6 +233,8 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 		r.Put("/templates/{id}", chain.ToHandlerFunc(v1Ctrl.HandleEntityTemplatesUpdate(), userMW...))
 		r.Delete("/templates/{id}", chain.ToHandlerFunc(v1Ctrl.HandleEntityTemplatesDelete(), userMW...))
 		r.Post("/templates/{id}/create-item", chain.ToHandlerFunc(v1Ctrl.HandleEntityTemplatesCreateItem(), userMW...))
+		r.Post("/templates/{id}/image", chain.ToHandlerFunc(v1Ctrl.HandleEntityTemplateImageUpload(), userMW...))
+		r.Delete("/templates/{id}/image", chain.ToHandlerFunc(v1Ctrl.HandleEntityTemplateImageDelete(), userMW...))
 
 		// Maintenance
 		r.Get("/maintenance", chain.ToHandlerFunc(v1Ctrl.HandleMaintenanceGetAll(), userMW...))
@@ -260,6 +262,7 @@ func (a *app) mountRoutes(r *chi.Mux, chain *errchain.ErrChain, repos *repo.AllR
 			"/entities/{id}/attachments/{attachment_id}",
 			chain.ToHandlerFunc(v1Ctrl.HandleEntityAttachmentGet(), assetMW...),
 		)
+		r.Get("/templates/{id}/image", chain.ToHandlerFunc(v1Ctrl.HandleEntityTemplateImageGet(), assetMW...))
 
 		// Labelmaker
 		r.Get("/labelmaker/entity/{id}", chain.ToHandlerFunc(v1Ctrl.HandleGetItemLabel(), userMW...))

--- a/backend/app/api/static/docs/docs.go
+++ b/backend/app/api/static/docs/docs.go
@@ -2623,6 +2623,126 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/templates/{id}/image": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "Entity Templates"
+                ],
+                "summary": "Get Entity Template Default Image",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Template ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "file"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Stores an image on the template. Entities created from the template",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Entity Templates"
+                ],
+                "summary": "Set Entity Template Default Image",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Template ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "Image file",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "name of the file including extension",
+                        "name": "name",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/repo.EntityTemplateOut"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/validate.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Removes the template's default image. Entities already created from",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Entity Templates"
+                ],
+                "summary": "Delete Entity Template Default Image",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Template ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/repo.EntityTemplateOut"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/users/change-password": {
             "put": {
                 "security": [
@@ -3367,6 +3487,14 @@ const docTemplate = `{
                         }
                     ]
                 },
+                "entity_template": {
+                    "description": "EntityTemplate holds the value of the entity_template edge.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/ent.EntityTemplate"
+                        }
+                    ]
+                },
                 "thumbnail": {
                     "description": "Thumbnail holds the value of the thumbnail edge.",
                     "allOf": [
@@ -3810,6 +3938,14 @@ const docTemplate = `{
         "ent.EntityTemplateEdges": {
             "type": "object",
             "properties": {
+                "default_image": {
+                    "description": "DefaultImage holds the value of the default_image edge.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/ent.Attachment"
+                        }
+                    ]
+                },
                 "fields": {
                     "description": "Fields holds the value of the fields edge.",
                     "type": "array",
@@ -5257,6 +5393,14 @@ const docTemplate = `{
                 "defaultDescription": {
                     "type": "string"
                 },
+                "defaultImage": {
+                    "description": "Default image applied to entities created from this template",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/repo.TemplateImageSummary"
+                        }
+                    ]
+                },
                 "defaultInsured": {
                     "type": "boolean"
                 },
@@ -6123,6 +6267,24 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "repo.TemplateImageSummary": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "mimeType": {
+                    "type": "string"
+                },
+                "thumbnailId": {
+                    "type": "string",
+                    "x-nullable": true
+                },
+                "title": {
                     "type": "string"
                 }
             }

--- a/backend/app/api/static/docs/docs.go
+++ b/backend/app/api/static/docs/docs.go
@@ -5399,7 +5399,8 @@ const docTemplate = `{
                         {
                             "$ref": "#/definitions/repo.TemplateImageSummary"
                         }
-                    ]
+                    ],
+                    "x-nullable": true
                 },
                 "defaultInsured": {
                     "type": "boolean"

--- a/backend/app/api/static/docs/openapi-3.json
+++ b/backend/app/api/static/docs/openapi-3.json
@@ -2823,6 +2823,148 @@
                 }
             }
         },
+        "/v1/templates/{id}/image": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "tags": [
+                    "Entity Templates"
+                ],
+                "summary": "Get Entity Template Default Image",
+                "parameters": [
+                    {
+                        "description": "Template ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/octet-stream": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Stores an image on the template. Entities created from the template",
+                "tags": [
+                    "Entity Templates"
+                ],
+                "summary": "Set Entity Template Default Image",
+                "parameters": [
+                    {
+                        "description": "Template ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "file": {
+                                        "description": "Image file",
+                                        "type": "string",
+                                        "format": "binary"
+                                    },
+                                    "name": {
+                                        "description": "name of the file including extension",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "file",
+                                    "name"
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/repo.EntityTemplateOut"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/validate.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Removes the template's default image. Entities already created from",
+                "tags": [
+                    "Entity Templates"
+                ],
+                "summary": "Delete Entity Template Default Image",
+                "parameters": [
+                    {
+                        "description": "Template ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/repo.EntityTemplateOut"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v1/users/change-password": {
             "put": {
                 "security": [
@@ -3606,6 +3748,14 @@
                             }
                         ]
                     },
+                    "entity_template": {
+                        "description": "EntityTemplate holds the value of the entity_template edge.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ent.EntityTemplate"
+                            }
+                        ]
+                    },
                     "thumbnail": {
                         "description": "Thumbnail holds the value of the thumbnail edge.",
                         "allOf": [
@@ -4049,6 +4199,14 @@
             "ent.EntityTemplateEdges": {
                 "type": "object",
                 "properties": {
+                    "default_image": {
+                        "description": "DefaultImage holds the value of the default_image edge.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ent.Attachment"
+                            }
+                        ]
+                    },
                     "fields": {
                         "description": "Fields holds the value of the fields edge.",
                         "type": "array",
@@ -5496,6 +5654,14 @@
                     "defaultDescription": {
                         "type": "string"
                     },
+                    "defaultImage": {
+                        "description": "Default image applied to entities created from this template",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/repo.TemplateImageSummary"
+                            }
+                        ]
+                    },
                     "defaultInsured": {
                         "type": "boolean"
                     },
@@ -6362,6 +6528,24 @@
                         "type": "string"
                     },
                     "type": {
+                        "type": "string"
+                    }
+                }
+            },
+            "repo.TemplateImageSummary": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "mimeType": {
+                        "type": "string"
+                    },
+                    "thumbnailId": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "title": {
                         "type": "string"
                     }
                 }

--- a/backend/app/api/static/docs/openapi-3.json
+++ b/backend/app/api/static/docs/openapi-3.json
@@ -5660,7 +5660,8 @@
                             {
                                 "$ref": "#/components/schemas/repo.TemplateImageSummary"
                             }
-                        ]
+                        ],
+                        "nullable": true
                     },
                     "defaultInsured": {
                         "type": "boolean"

--- a/backend/app/api/static/docs/openapi-3.yaml
+++ b/backend/app/api/static/docs/openapi-3.yaml
@@ -3596,6 +3596,7 @@ components:
           description: Default image applied to entities created from this template
           allOf:
             - $ref: "#/components/schemas/repo.TemplateImageSummary"
+          nullable: true
         defaultInsured:
           type: boolean
         defaultLifetimeWarranty:

--- a/backend/app/api/static/docs/openapi-3.yaml
+++ b/backend/app/api/static/docs/openapi-3.yaml
@@ -1675,6 +1675,93 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/repo.EntityOut"
+  "/v1/templates/{id}/image":
+    get:
+      security:
+        - Bearer: []
+      tags:
+        - Entity Templates
+      summary: Get Entity Template Default Image
+      parameters:
+        - description: Template ID
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+    post:
+      security:
+        - Bearer: []
+      description: Stores an image on the template. Entities created from the template
+      tags:
+        - Entity Templates
+      summary: Set Entity Template Default Image
+      parameters:
+        - description: Template ID
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  description: Image file
+                  type: string
+                  format: binary
+                name:
+                  description: name of the file including extension
+                  type: string
+              required:
+                - file
+                - name
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/repo.EntityTemplateOut"
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/validate.ErrorResponse"
+    delete:
+      security:
+        - Bearer: []
+      description: Removes the template's default image. Entities already created from
+      tags:
+        - Entity Templates
+      summary: Delete Entity Template Default Image
+      parameters:
+        - description: Template ID
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/repo.EntityTemplateOut"
   /v1/users/change-password:
     put:
       security:
@@ -2171,6 +2258,10 @@ components:
           description: Entity holds the value of the entity edge.
           allOf:
             - $ref: "#/components/schemas/ent.Entity"
+        entity_template:
+          description: EntityTemplate holds the value of the entity_template edge.
+          allOf:
+            - $ref: "#/components/schemas/ent.EntityTemplate"
         thumbnail:
           description: Thumbnail holds the value of the thumbnail edge.
           allOf:
@@ -2485,6 +2576,10 @@ components:
     ent.EntityTemplateEdges:
       type: object
       properties:
+        default_image:
+          description: DefaultImage holds the value of the default_image edge.
+          allOf:
+            - $ref: "#/components/schemas/ent.Attachment"
         fields:
           description: Fields holds the value of the fields edge.
           type: array
@@ -3497,6 +3592,10 @@ components:
           type: string
         defaultDescription:
           type: string
+        defaultImage:
+          description: Default image applied to entities created from this template
+          allOf:
+            - $ref: "#/components/schemas/repo.TemplateImageSummary"
         defaultInsured:
           type: boolean
         defaultLifetimeWarranty:
@@ -4089,6 +4188,18 @@ components:
         timeValue:
           type: string
         type:
+          type: string
+    repo.TemplateImageSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        mimeType:
+          type: string
+        thumbnailId:
+          type: string
+          nullable: true
+        title:
           type: string
     repo.TemplateLocationSummary:
       type: object

--- a/backend/app/api/static/docs/swagger.json
+++ b/backend/app/api/static/docs/swagger.json
@@ -5396,7 +5396,8 @@
                         {
                             "$ref": "#/definitions/repo.TemplateImageSummary"
                         }
-                    ]
+                    ],
+                    "x-nullable": true
                 },
                 "defaultInsured": {
                     "type": "boolean"

--- a/backend/app/api/static/docs/swagger.json
+++ b/backend/app/api/static/docs/swagger.json
@@ -2620,6 +2620,126 @@
                 }
             }
         },
+        "/v1/templates/{id}/image": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "Entity Templates"
+                ],
+                "summary": "Get Entity Template Default Image",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Template ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "file"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Stores an image on the template. Entities created from the template",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Entity Templates"
+                ],
+                "summary": "Set Entity Template Default Image",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Template ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "Image file",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "name of the file including extension",
+                        "name": "name",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/repo.EntityTemplateOut"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/validate.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Removes the template's default image. Entities already created from",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Entity Templates"
+                ],
+                "summary": "Delete Entity Template Default Image",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Template ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/repo.EntityTemplateOut"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/users/change-password": {
             "put": {
                 "security": [
@@ -3364,6 +3484,14 @@
                         }
                     ]
                 },
+                "entity_template": {
+                    "description": "EntityTemplate holds the value of the entity_template edge.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/ent.EntityTemplate"
+                        }
+                    ]
+                },
                 "thumbnail": {
                     "description": "Thumbnail holds the value of the thumbnail edge.",
                     "allOf": [
@@ -3807,6 +3935,14 @@
         "ent.EntityTemplateEdges": {
             "type": "object",
             "properties": {
+                "default_image": {
+                    "description": "DefaultImage holds the value of the default_image edge.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/ent.Attachment"
+                        }
+                    ]
+                },
                 "fields": {
                     "description": "Fields holds the value of the fields edge.",
                     "type": "array",
@@ -5254,6 +5390,14 @@
                 "defaultDescription": {
                     "type": "string"
                 },
+                "defaultImage": {
+                    "description": "Default image applied to entities created from this template",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/repo.TemplateImageSummary"
+                        }
+                    ]
+                },
                 "defaultInsured": {
                     "type": "boolean"
                 },
@@ -6120,6 +6264,24 @@
                     "type": "string"
                 },
                 "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "repo.TemplateImageSummary": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "mimeType": {
+                    "type": "string"
+                },
+                "thumbnailId": {
+                    "type": "string",
+                    "x-nullable": true
+                },
+                "title": {
                     "type": "string"
                 }
             }

--- a/backend/app/api/static/docs/swagger.yaml
+++ b/backend/app/api/static/docs/swagger.yaml
@@ -120,6 +120,10 @@ definitions:
         allOf:
         - $ref: '#/definitions/ent.Entity'
         description: Entity holds the value of the entity edge.
+      entity_template:
+        allOf:
+        - $ref: '#/definitions/ent.EntityTemplate'
+        description: EntityTemplate holds the value of the entity_template edge.
       thumbnail:
         allOf:
         - $ref: '#/definitions/ent.Attachment'
@@ -430,6 +434,10 @@ definitions:
     type: object
   ent.EntityTemplateEdges:
     properties:
+      default_image:
+        allOf:
+        - $ref: '#/definitions/ent.Attachment'
+        description: DefaultImage holds the value of the default_image edge.
       fields:
         description: Fields holds the value of the fields edge.
         items:
@@ -1431,6 +1439,10 @@ definitions:
         type: string
       defaultDescription:
         type: string
+      defaultImage:
+        allOf:
+        - $ref: '#/definitions/repo.TemplateImageSummary'
+        description: Default image applied to entities created from this template
       defaultInsured:
         type: boolean
       defaultLifetimeWarranty:
@@ -2023,6 +2035,18 @@ definitions:
       timeValue:
         type: string
       type:
+        type: string
+    type: object
+  repo.TemplateImageSummary:
+    properties:
+      id:
+        type: string
+      mimeType:
+        type: string
+      thumbnailId:
+        type: string
+        x-nullable: true
+      title:
         type: string
     type: object
   repo.TemplateLocationSummary:
@@ -3969,6 +3993,83 @@ paths:
       security:
       - Bearer: []
       summary: Create Entity from Template
+      tags:
+      - Entity Templates
+  /v1/templates/{id}/image:
+    delete:
+      description: Removes the template's default image. Entities already created
+        from
+      parameters:
+      - description: Template ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/repo.EntityTemplateOut'
+      security:
+      - Bearer: []
+      summary: Delete Entity Template Default Image
+      tags:
+      - Entity Templates
+    get:
+      parameters:
+      - description: Template ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/octet-stream
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: file
+      security:
+      - Bearer: []
+      summary: Get Entity Template Default Image
+      tags:
+      - Entity Templates
+    post:
+      consumes:
+      - multipart/form-data
+      description: Stores an image on the template. Entities created from the template
+      parameters:
+      - description: Template ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Image file
+        in: formData
+        name: file
+        required: true
+        type: file
+      - description: name of the file including extension
+        in: formData
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/repo.EntityTemplateOut'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/validate.ErrorResponse'
+      security:
+      - Bearer: []
+      summary: Set Entity Template Default Image
       tags:
       - Entity Templates
   /v1/users/change-password:

--- a/backend/app/api/static/docs/swagger.yaml
+++ b/backend/app/api/static/docs/swagger.yaml
@@ -1443,6 +1443,7 @@ definitions:
         allOf:
         - $ref: '#/definitions/repo.TemplateImageSummary'
         description: Default image applied to entities created from this template
+        x-nullable: true
       defaultInsured:
         type: boolean
       defaultLifetimeWarranty:

--- a/backend/internal/data/ent/attachment.go
+++ b/backend/internal/data/ent/attachment.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/attachment"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entity"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entitytemplate"
 )
 
 // Attachment is the model entity for the Attachment schema.
@@ -35,10 +36,11 @@ type Attachment struct {
 	MimeType string `json:"mime_type,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the AttachmentQuery when eager-loading is set.
-	Edges                AttachmentEdges `json:"edges"`
-	attachment_thumbnail *uuid.UUID
-	entity_attachments   *uuid.UUID
-	selectValues         sql.SelectValues
+	Edges                         AttachmentEdges `json:"edges"`
+	attachment_thumbnail          *uuid.UUID
+	entity_attachments            *uuid.UUID
+	entity_template_default_image *uuid.UUID
+	selectValues                  sql.SelectValues
 }
 
 // AttachmentEdges holds the relations/edges for other nodes in the graph.
@@ -47,9 +49,11 @@ type AttachmentEdges struct {
 	Entity *Entity `json:"entity,omitempty"`
 	// Thumbnail holds the value of the thumbnail edge.
 	Thumbnail *Attachment `json:"thumbnail,omitempty"`
+	// EntityTemplate holds the value of the entity_template edge.
+	EntityTemplate *EntityTemplate `json:"entity_template,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [2]bool
+	loadedTypes [3]bool
 }
 
 // EntityOrErr returns the Entity value or an error if the edge
@@ -74,6 +78,17 @@ func (e AttachmentEdges) ThumbnailOrErr() (*Attachment, error) {
 	return nil, &NotLoadedError{edge: "thumbnail"}
 }
 
+// EntityTemplateOrErr returns the EntityTemplate value or an error if the edge
+// was not loaded in eager-loading, or loaded but was not found.
+func (e AttachmentEdges) EntityTemplateOrErr() (*EntityTemplate, error) {
+	if e.EntityTemplate != nil {
+		return e.EntityTemplate, nil
+	} else if e.loadedTypes[2] {
+		return nil, &NotFoundError{label: entitytemplate.Label}
+	}
+	return nil, &NotLoadedError{edge: "entity_template"}
+}
+
 // scanValues returns the types for scanning values from sql.Rows.
 func (*Attachment) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
@@ -90,6 +105,8 @@ func (*Attachment) scanValues(columns []string) ([]any, error) {
 		case attachment.ForeignKeys[0]: // attachment_thumbnail
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
 		case attachment.ForeignKeys[1]: // entity_attachments
+			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
+		case attachment.ForeignKeys[2]: // entity_template_default_image
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
 		default:
 			values[i] = new(sql.UnknownType)
@@ -168,6 +185,13 @@ func (_m *Attachment) assignValues(columns []string, values []any) error {
 				_m.entity_attachments = new(uuid.UUID)
 				*_m.entity_attachments = *value.S.(*uuid.UUID)
 			}
+		case attachment.ForeignKeys[2]:
+			if value, ok := values[i].(*sql.NullScanner); !ok {
+				return fmt.Errorf("unexpected type %T for field entity_template_default_image", values[i])
+			} else if value.Valid {
+				_m.entity_template_default_image = new(uuid.UUID)
+				*_m.entity_template_default_image = *value.S.(*uuid.UUID)
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -189,6 +213,11 @@ func (_m *Attachment) QueryEntity() *EntityQuery {
 // QueryThumbnail queries the "thumbnail" edge of the Attachment entity.
 func (_m *Attachment) QueryThumbnail() *AttachmentQuery {
 	return NewAttachmentClient(_m.config).QueryThumbnail(_m)
+}
+
+// QueryEntityTemplate queries the "entity_template" edge of the Attachment entity.
+func (_m *Attachment) QueryEntityTemplate() *EntityTemplateQuery {
+	return NewAttachmentClient(_m.config).QueryEntityTemplate(_m)
 }
 
 // Update returns a builder for updating this Attachment.

--- a/backend/internal/data/ent/attachment/attachment.go
+++ b/backend/internal/data/ent/attachment/attachment.go
@@ -34,6 +34,8 @@ const (
 	EdgeEntity = "entity"
 	// EdgeThumbnail holds the string denoting the thumbnail edge name in mutations.
 	EdgeThumbnail = "thumbnail"
+	// EdgeEntityTemplate holds the string denoting the entity_template edge name in mutations.
+	EdgeEntityTemplate = "entity_template"
 	// Table holds the table name of the attachment in the database.
 	Table = "attachments"
 	// EntityTable is the table that holds the entity relation/edge.
@@ -47,6 +49,13 @@ const (
 	ThumbnailTable = "attachments"
 	// ThumbnailColumn is the table column denoting the thumbnail relation/edge.
 	ThumbnailColumn = "attachment_thumbnail"
+	// EntityTemplateTable is the table that holds the entity_template relation/edge.
+	EntityTemplateTable = "attachments"
+	// EntityTemplateInverseTable is the table name for the EntityTemplate entity.
+	// It exists in this package in order to avoid circular dependency with the "entitytemplate" package.
+	EntityTemplateInverseTable = "entity_templates"
+	// EntityTemplateColumn is the table column denoting the entity_template relation/edge.
+	EntityTemplateColumn = "entity_template_default_image"
 )
 
 // Columns holds all SQL columns for attachment fields.
@@ -66,6 +75,7 @@ var Columns = []string{
 var ForeignKeys = []string{
 	"attachment_thumbnail",
 	"entity_attachments",
+	"entity_template_default_image",
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -188,6 +198,13 @@ func ByThumbnailField(field string, opts ...sql.OrderTermOption) OrderOption {
 		sqlgraph.OrderByNeighborTerms(s, newThumbnailStep(), sql.OrderByField(field, opts...))
 	}
 }
+
+// ByEntityTemplateField orders the results by entity_template field.
+func ByEntityTemplateField(field string, opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newEntityTemplateStep(), sql.OrderByField(field, opts...))
+	}
+}
 func newEntityStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
@@ -200,5 +217,12 @@ func newThumbnailStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(Table, FieldID),
 		sqlgraph.Edge(sqlgraph.O2O, false, ThumbnailTable, ThumbnailColumn),
+	)
+}
+func newEntityTemplateStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(EntityTemplateInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, true, EntityTemplateTable, EntityTemplateColumn),
 	)
 }

--- a/backend/internal/data/ent/attachment/where.go
+++ b/backend/internal/data/ent/attachment/where.go
@@ -437,6 +437,29 @@ func HasThumbnailWith(preds ...predicate.Attachment) predicate.Attachment {
 	})
 }
 
+// HasEntityTemplate applies the HasEdge predicate on the "entity_template" edge.
+func HasEntityTemplate() predicate.Attachment {
+	return predicate.Attachment(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2O, true, EntityTemplateTable, EntityTemplateColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasEntityTemplateWith applies the HasEdge predicate on the "entity_template" edge with a given conditions (other predicates).
+func HasEntityTemplateWith(preds ...predicate.EntityTemplate) predicate.Attachment {
+	return predicate.Attachment(func(s *sql.Selector) {
+		step := newEntityTemplateStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Attachment) predicate.Attachment {
 	return predicate.Attachment(sql.AndPredicates(predicates...))

--- a/backend/internal/data/ent/attachment_create.go
+++ b/backend/internal/data/ent/attachment_create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/attachment"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entity"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entitytemplate"
 )
 
 // AttachmentCreate is the builder for creating a Attachment entity.
@@ -170,6 +171,25 @@ func (_c *AttachmentCreate) SetNillableThumbnailID(id *uuid.UUID) *AttachmentCre
 // SetThumbnail sets the "thumbnail" edge to the Attachment entity.
 func (_c *AttachmentCreate) SetThumbnail(v *Attachment) *AttachmentCreate {
 	return _c.SetThumbnailID(v.ID)
+}
+
+// SetEntityTemplateID sets the "entity_template" edge to the EntityTemplate entity by ID.
+func (_c *AttachmentCreate) SetEntityTemplateID(id uuid.UUID) *AttachmentCreate {
+	_c.mutation.SetEntityTemplateID(id)
+	return _c
+}
+
+// SetNillableEntityTemplateID sets the "entity_template" edge to the EntityTemplate entity by ID if the given value is not nil.
+func (_c *AttachmentCreate) SetNillableEntityTemplateID(id *uuid.UUID) *AttachmentCreate {
+	if id != nil {
+		_c = _c.SetEntityTemplateID(*id)
+	}
+	return _c
+}
+
+// SetEntityTemplate sets the "entity_template" edge to the EntityTemplate entity.
+func (_c *AttachmentCreate) SetEntityTemplate(v *EntityTemplate) *AttachmentCreate {
+	return _c.SetEntityTemplateID(v.ID)
 }
 
 // Mutation returns the AttachmentMutation object of the builder.
@@ -364,6 +384,23 @@ func (_c *AttachmentCreate) createSpec() (*Attachment, *sqlgraph.CreateSpec) {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.attachment_thumbnail = &nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.EntityTemplateIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2O,
+			Inverse: true,
+			Table:   attachment.EntityTemplateTable,
+			Columns: []string{attachment.EntityTemplateColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(entitytemplate.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_node.entity_template_default_image = &nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec

--- a/backend/internal/data/ent/attachment_query.go
+++ b/backend/internal/data/ent/attachment_query.go
@@ -14,19 +14,21 @@ import (
 	"github.com/google/uuid"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/attachment"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entity"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entitytemplate"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/predicate"
 )
 
 // AttachmentQuery is the builder for querying Attachment entities.
 type AttachmentQuery struct {
 	config
-	ctx           *QueryContext
-	order         []attachment.OrderOption
-	inters        []Interceptor
-	predicates    []predicate.Attachment
-	withEntity    *EntityQuery
-	withThumbnail *AttachmentQuery
-	withFKs       bool
+	ctx                *QueryContext
+	order              []attachment.OrderOption
+	inters             []Interceptor
+	predicates         []predicate.Attachment
+	withEntity         *EntityQuery
+	withThumbnail      *AttachmentQuery
+	withEntityTemplate *EntityTemplateQuery
+	withFKs            bool
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
 	path func(context.Context) (*sql.Selector, error)
@@ -100,6 +102,28 @@ func (_q *AttachmentQuery) QueryThumbnail() *AttachmentQuery {
 			sqlgraph.From(attachment.Table, attachment.FieldID, selector),
 			sqlgraph.To(attachment.Table, attachment.FieldID),
 			sqlgraph.Edge(sqlgraph.O2O, false, attachment.ThumbnailTable, attachment.ThumbnailColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryEntityTemplate chains the current query on the "entity_template" edge.
+func (_q *AttachmentQuery) QueryEntityTemplate() *EntityTemplateQuery {
+	query := (&EntityTemplateClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(attachment.Table, attachment.FieldID, selector),
+			sqlgraph.To(entitytemplate.Table, entitytemplate.FieldID),
+			sqlgraph.Edge(sqlgraph.O2O, true, attachment.EntityTemplateTable, attachment.EntityTemplateColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
@@ -294,13 +318,14 @@ func (_q *AttachmentQuery) Clone() *AttachmentQuery {
 		return nil
 	}
 	return &AttachmentQuery{
-		config:        _q.config,
-		ctx:           _q.ctx.Clone(),
-		order:         append([]attachment.OrderOption{}, _q.order...),
-		inters:        append([]Interceptor{}, _q.inters...),
-		predicates:    append([]predicate.Attachment{}, _q.predicates...),
-		withEntity:    _q.withEntity.Clone(),
-		withThumbnail: _q.withThumbnail.Clone(),
+		config:             _q.config,
+		ctx:                _q.ctx.Clone(),
+		order:              append([]attachment.OrderOption{}, _q.order...),
+		inters:             append([]Interceptor{}, _q.inters...),
+		predicates:         append([]predicate.Attachment{}, _q.predicates...),
+		withEntity:         _q.withEntity.Clone(),
+		withThumbnail:      _q.withThumbnail.Clone(),
+		withEntityTemplate: _q.withEntityTemplate.Clone(),
 		// clone intermediate query.
 		sql:  _q.sql.Clone(),
 		path: _q.path,
@@ -326,6 +351,17 @@ func (_q *AttachmentQuery) WithThumbnail(opts ...func(*AttachmentQuery)) *Attach
 		opt(query)
 	}
 	_q.withThumbnail = query
+	return _q
+}
+
+// WithEntityTemplate tells the query-builder to eager-load the nodes that are connected to
+// the "entity_template" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *AttachmentQuery) WithEntityTemplate(opts ...func(*EntityTemplateQuery)) *AttachmentQuery {
+	query := (&EntityTemplateClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withEntityTemplate = query
 	return _q
 }
 
@@ -408,12 +444,13 @@ func (_q *AttachmentQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*A
 		nodes       = []*Attachment{}
 		withFKs     = _q.withFKs
 		_spec       = _q.querySpec()
-		loadedTypes = [2]bool{
+		loadedTypes = [3]bool{
 			_q.withEntity != nil,
 			_q.withThumbnail != nil,
+			_q.withEntityTemplate != nil,
 		}
 	)
-	if _q.withEntity != nil || _q.withThumbnail != nil {
+	if _q.withEntity != nil || _q.withThumbnail != nil || _q.withEntityTemplate != nil {
 		withFKs = true
 	}
 	if withFKs {
@@ -446,6 +483,12 @@ func (_q *AttachmentQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*A
 	if query := _q.withThumbnail; query != nil {
 		if err := _q.loadThumbnail(ctx, query, nodes, nil,
 			func(n *Attachment, e *Attachment) { n.Edges.Thumbnail = e }); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withEntityTemplate; query != nil {
+		if err := _q.loadEntityTemplate(ctx, query, nodes, nil,
+			func(n *Attachment, e *EntityTemplate) { n.Edges.EntityTemplate = e }); err != nil {
 			return nil, err
 		}
 	}
@@ -509,6 +552,38 @@ func (_q *AttachmentQuery) loadThumbnail(ctx context.Context, query *AttachmentQ
 		nodes, ok := nodeids[n.ID]
 		if !ok {
 			return fmt.Errorf(`unexpected foreign-key "attachment_thumbnail" returned %v`, n.ID)
+		}
+		for i := range nodes {
+			assign(nodes[i], n)
+		}
+	}
+	return nil
+}
+func (_q *AttachmentQuery) loadEntityTemplate(ctx context.Context, query *EntityTemplateQuery, nodes []*Attachment, init func(*Attachment), assign func(*Attachment, *EntityTemplate)) error {
+	ids := make([]uuid.UUID, 0, len(nodes))
+	nodeids := make(map[uuid.UUID][]*Attachment)
+	for i := range nodes {
+		if nodes[i].entity_template_default_image == nil {
+			continue
+		}
+		fk := *nodes[i].entity_template_default_image
+		if _, ok := nodeids[fk]; !ok {
+			ids = append(ids, fk)
+		}
+		nodeids[fk] = append(nodeids[fk], nodes[i])
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	query.Where(entitytemplate.IDIn(ids...))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nodeids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected foreign-key "entity_template_default_image" returned %v`, n.ID)
 		}
 		for i := range nodes {
 			assign(nodes[i], n)

--- a/backend/internal/data/ent/attachment_update.go
+++ b/backend/internal/data/ent/attachment_update.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/attachment"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entity"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entitytemplate"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/predicate"
 )
 
@@ -144,6 +145,25 @@ func (_u *AttachmentUpdate) SetThumbnail(v *Attachment) *AttachmentUpdate {
 	return _u.SetThumbnailID(v.ID)
 }
 
+// SetEntityTemplateID sets the "entity_template" edge to the EntityTemplate entity by ID.
+func (_u *AttachmentUpdate) SetEntityTemplateID(id uuid.UUID) *AttachmentUpdate {
+	_u.mutation.SetEntityTemplateID(id)
+	return _u
+}
+
+// SetNillableEntityTemplateID sets the "entity_template" edge to the EntityTemplate entity by ID if the given value is not nil.
+func (_u *AttachmentUpdate) SetNillableEntityTemplateID(id *uuid.UUID) *AttachmentUpdate {
+	if id != nil {
+		_u = _u.SetEntityTemplateID(*id)
+	}
+	return _u
+}
+
+// SetEntityTemplate sets the "entity_template" edge to the EntityTemplate entity.
+func (_u *AttachmentUpdate) SetEntityTemplate(v *EntityTemplate) *AttachmentUpdate {
+	return _u.SetEntityTemplateID(v.ID)
+}
+
 // Mutation returns the AttachmentMutation object of the builder.
 func (_u *AttachmentUpdate) Mutation() *AttachmentMutation {
 	return _u.mutation
@@ -158,6 +178,12 @@ func (_u *AttachmentUpdate) ClearEntity() *AttachmentUpdate {
 // ClearThumbnail clears the "thumbnail" edge to the Attachment entity.
 func (_u *AttachmentUpdate) ClearThumbnail() *AttachmentUpdate {
 	_u.mutation.ClearThumbnail()
+	return _u
+}
+
+// ClearEntityTemplate clears the "entity_template" edge to the EntityTemplate entity.
+func (_u *AttachmentUpdate) ClearEntityTemplate() *AttachmentUpdate {
+	_u.mutation.ClearEntityTemplate()
 	return _u
 }
 
@@ -288,6 +314,35 @@ func (_u *AttachmentUpdate) sqlSave(ctx context.Context) (_node int, err error) 
 			Bidi:    true,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(attachment.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.EntityTemplateCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2O,
+			Inverse: true,
+			Table:   attachment.EntityTemplateTable,
+			Columns: []string{attachment.EntityTemplateColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(entitytemplate.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.EntityTemplateIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2O,
+			Inverse: true,
+			Table:   attachment.EntityTemplateTable,
+			Columns: []string{attachment.EntityTemplateColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(entitytemplate.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -429,6 +484,25 @@ func (_u *AttachmentUpdateOne) SetThumbnail(v *Attachment) *AttachmentUpdateOne 
 	return _u.SetThumbnailID(v.ID)
 }
 
+// SetEntityTemplateID sets the "entity_template" edge to the EntityTemplate entity by ID.
+func (_u *AttachmentUpdateOne) SetEntityTemplateID(id uuid.UUID) *AttachmentUpdateOne {
+	_u.mutation.SetEntityTemplateID(id)
+	return _u
+}
+
+// SetNillableEntityTemplateID sets the "entity_template" edge to the EntityTemplate entity by ID if the given value is not nil.
+func (_u *AttachmentUpdateOne) SetNillableEntityTemplateID(id *uuid.UUID) *AttachmentUpdateOne {
+	if id != nil {
+		_u = _u.SetEntityTemplateID(*id)
+	}
+	return _u
+}
+
+// SetEntityTemplate sets the "entity_template" edge to the EntityTemplate entity.
+func (_u *AttachmentUpdateOne) SetEntityTemplate(v *EntityTemplate) *AttachmentUpdateOne {
+	return _u.SetEntityTemplateID(v.ID)
+}
+
 // Mutation returns the AttachmentMutation object of the builder.
 func (_u *AttachmentUpdateOne) Mutation() *AttachmentMutation {
 	return _u.mutation
@@ -443,6 +517,12 @@ func (_u *AttachmentUpdateOne) ClearEntity() *AttachmentUpdateOne {
 // ClearThumbnail clears the "thumbnail" edge to the Attachment entity.
 func (_u *AttachmentUpdateOne) ClearThumbnail() *AttachmentUpdateOne {
 	_u.mutation.ClearThumbnail()
+	return _u
+}
+
+// ClearEntityTemplate clears the "entity_template" edge to the EntityTemplate entity.
+func (_u *AttachmentUpdateOne) ClearEntityTemplate() *AttachmentUpdateOne {
+	_u.mutation.ClearEntityTemplate()
 	return _u
 }
 
@@ -603,6 +683,35 @@ func (_u *AttachmentUpdateOne) sqlSave(ctx context.Context) (_node *Attachment, 
 			Bidi:    true,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(attachment.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.EntityTemplateCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2O,
+			Inverse: true,
+			Table:   attachment.EntityTemplateTable,
+			Columns: []string{attachment.EntityTemplateColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(entitytemplate.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.EntityTemplateIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2O,
+			Inverse: true,
+			Table:   attachment.EntityTemplateTable,
+			Columns: []string{attachment.EntityTemplateColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(entitytemplate.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {

--- a/backend/internal/data/ent/client.go
+++ b/backend/internal/data/ent/client.go
@@ -637,6 +637,22 @@ func (c *AttachmentClient) QueryThumbnail(_m *Attachment) *AttachmentQuery {
 	return query
 }
 
+// QueryEntityTemplate queries the entity_template edge of a Attachment.
+func (c *AttachmentClient) QueryEntityTemplate(_m *Attachment) *EntityTemplateQuery {
+	query := (&EntityTemplateClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(attachment.Table, attachment.FieldID, id),
+			sqlgraph.To(entitytemplate.Table, entitytemplate.FieldID),
+			sqlgraph.Edge(sqlgraph.O2O, true, attachment.EntityTemplateTable, attachment.EntityTemplateColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // Hooks returns the client hooks.
 func (c *AttachmentClient) Hooks() []Hook {
 	return c.hooks.Attachment
@@ -1535,6 +1551,22 @@ func (c *EntityTemplateClient) QueryLocation(_m *EntityTemplate) *EntityQuery {
 			sqlgraph.From(entitytemplate.Table, entitytemplate.FieldID, id),
 			sqlgraph.To(entity.Table, entity.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, false, entitytemplate.LocationTable, entitytemplate.LocationColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryDefaultImage queries the default_image edge of a EntityTemplate.
+func (c *EntityTemplateClient) QueryDefaultImage(_m *EntityTemplate) *AttachmentQuery {
+	query := (&AttachmentClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(entitytemplate.Table, entitytemplate.FieldID, id),
+			sqlgraph.To(attachment.Table, attachment.FieldID),
+			sqlgraph.Edge(sqlgraph.O2O, false, entitytemplate.DefaultImageTable, entitytemplate.DefaultImageColumn),
 		)
 		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
 		return fromV, nil

--- a/backend/internal/data/ent/entitytemplate.go
+++ b/backend/internal/data/ent/entitytemplate.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"github.com/google/uuid"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/attachment"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entity"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entitytemplate"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/group"
@@ -71,9 +72,11 @@ type EntityTemplateEdges struct {
 	Fields []*TemplateField `json:"fields,omitempty"`
 	// Location holds the value of the location edge.
 	Location *Entity `json:"location,omitempty"`
+	// DefaultImage holds the value of the default_image edge.
+	DefaultImage *Attachment `json:"default_image,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [3]bool
+	loadedTypes [4]bool
 }
 
 // GroupOrErr returns the Group value or an error if the edge
@@ -105,6 +108,17 @@ func (e EntityTemplateEdges) LocationOrErr() (*Entity, error) {
 		return nil, &NotFoundError{label: entity.Label}
 	}
 	return nil, &NotLoadedError{edge: "location"}
+}
+
+// DefaultImageOrErr returns the DefaultImage value or an error if the edge
+// was not loaded in eager-loading, or loaded but was not found.
+func (e EntityTemplateEdges) DefaultImageOrErr() (*Attachment, error) {
+	if e.DefaultImage != nil {
+		return e.DefaultImage, nil
+	} else if e.loadedTypes[3] {
+		return nil, &NotFoundError{label: attachment.Label}
+	}
+	return nil, &NotLoadedError{edge: "default_image"}
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -293,6 +307,11 @@ func (_m *EntityTemplate) QueryFields() *TemplateFieldQuery {
 // QueryLocation queries the "location" edge of the EntityTemplate entity.
 func (_m *EntityTemplate) QueryLocation() *EntityQuery {
 	return NewEntityTemplateClient(_m.config).QueryLocation(_m)
+}
+
+// QueryDefaultImage queries the "default_image" edge of the EntityTemplate entity.
+func (_m *EntityTemplate) QueryDefaultImage() *AttachmentQuery {
+	return NewEntityTemplateClient(_m.config).QueryDefaultImage(_m)
 }
 
 // Update returns a builder for updating this EntityTemplate.

--- a/backend/internal/data/ent/entitytemplate/entitytemplate.go
+++ b/backend/internal/data/ent/entitytemplate/entitytemplate.go
@@ -55,6 +55,8 @@ const (
 	EdgeFields = "fields"
 	// EdgeLocation holds the string denoting the location edge name in mutations.
 	EdgeLocation = "location"
+	// EdgeDefaultImage holds the string denoting the default_image edge name in mutations.
+	EdgeDefaultImage = "default_image"
 	// Table holds the table name of the entitytemplate in the database.
 	Table = "entity_templates"
 	// GroupTable is the table that holds the group relation/edge.
@@ -78,6 +80,13 @@ const (
 	LocationInverseTable = "entities"
 	// LocationColumn is the table column denoting the location relation/edge.
 	LocationColumn = "entity_template_location"
+	// DefaultImageTable is the table that holds the default_image relation/edge.
+	DefaultImageTable = "attachments"
+	// DefaultImageInverseTable is the table name for the Attachment entity.
+	// It exists in this package in order to avoid circular dependency with the "attachment" package.
+	DefaultImageInverseTable = "attachments"
+	// DefaultImageColumn is the table column denoting the default_image relation/edge.
+	DefaultImageColumn = "entity_template_default_image"
 )
 
 // Columns holds all SQL columns for entitytemplate fields.
@@ -278,6 +287,13 @@ func ByLocationField(field string, opts ...sql.OrderTermOption) OrderOption {
 		sqlgraph.OrderByNeighborTerms(s, newLocationStep(), sql.OrderByField(field, opts...))
 	}
 }
+
+// ByDefaultImageField orders the results by default_image field.
+func ByDefaultImageField(field string, opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newDefaultImageStep(), sql.OrderByField(field, opts...))
+	}
+}
 func newGroupStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
@@ -297,5 +313,12 @@ func newLocationStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(LocationInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2O, false, LocationTable, LocationColumn),
+	)
+}
+func newDefaultImageStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(DefaultImageInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, DefaultImageTable, DefaultImageColumn),
 	)
 }

--- a/backend/internal/data/ent/entitytemplate/where.go
+++ b/backend/internal/data/ent/entitytemplate/where.go
@@ -975,6 +975,29 @@ func HasLocationWith(preds ...predicate.Entity) predicate.EntityTemplate {
 	})
 }
 
+// HasDefaultImage applies the HasEdge predicate on the "default_image" edge.
+func HasDefaultImage() predicate.EntityTemplate {
+	return predicate.EntityTemplate(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2O, false, DefaultImageTable, DefaultImageColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasDefaultImageWith applies the HasEdge predicate on the "default_image" edge with a given conditions (other predicates).
+func HasDefaultImageWith(preds ...predicate.Attachment) predicate.EntityTemplate {
+	return predicate.EntityTemplate(func(s *sql.Selector) {
+		step := newDefaultImageStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.EntityTemplate) predicate.EntityTemplate {
 	return predicate.EntityTemplate(sql.AndPredicates(predicates...))

--- a/backend/internal/data/ent/entitytemplate_create.go
+++ b/backend/internal/data/ent/entitytemplate_create.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/google/uuid"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/attachment"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entity"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entitytemplate"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/group"
@@ -303,6 +304,25 @@ func (_c *EntityTemplateCreate) SetNillableLocationID(id *uuid.UUID) *EntityTemp
 // SetLocation sets the "location" edge to the Entity entity.
 func (_c *EntityTemplateCreate) SetLocation(v *Entity) *EntityTemplateCreate {
 	return _c.SetLocationID(v.ID)
+}
+
+// SetDefaultImageID sets the "default_image" edge to the Attachment entity by ID.
+func (_c *EntityTemplateCreate) SetDefaultImageID(id uuid.UUID) *EntityTemplateCreate {
+	_c.mutation.SetDefaultImageID(id)
+	return _c
+}
+
+// SetNillableDefaultImageID sets the "default_image" edge to the Attachment entity by ID if the given value is not nil.
+func (_c *EntityTemplateCreate) SetNillableDefaultImageID(id *uuid.UUID) *EntityTemplateCreate {
+	if id != nil {
+		_c = _c.SetDefaultImageID(*id)
+	}
+	return _c
+}
+
+// SetDefaultImage sets the "default_image" edge to the Attachment entity.
+func (_c *EntityTemplateCreate) SetDefaultImage(v *Attachment) *EntityTemplateCreate {
+	return _c.SetDefaultImageID(v.ID)
 }
 
 // Mutation returns the EntityTemplateMutation object of the builder.
@@ -601,6 +621,22 @@ func (_c *EntityTemplateCreate) createSpec() (*EntityTemplate, *sqlgraph.CreateS
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.entity_template_location = &nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.DefaultImageIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2O,
+			Inverse: false,
+			Table:   entitytemplate.DefaultImageTable,
+			Columns: []string{entitytemplate.DefaultImageColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(attachment.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec

--- a/backend/internal/data/ent/entitytemplate_query.go
+++ b/backend/internal/data/ent/entitytemplate_query.go
@@ -13,6 +13,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/google/uuid"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/attachment"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entity"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entitytemplate"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/group"
@@ -23,14 +24,15 @@ import (
 // EntityTemplateQuery is the builder for querying EntityTemplate entities.
 type EntityTemplateQuery struct {
 	config
-	ctx          *QueryContext
-	order        []entitytemplate.OrderOption
-	inters       []Interceptor
-	predicates   []predicate.EntityTemplate
-	withGroup    *GroupQuery
-	withFields   *TemplateFieldQuery
-	withLocation *EntityQuery
-	withFKs      bool
+	ctx              *QueryContext
+	order            []entitytemplate.OrderOption
+	inters           []Interceptor
+	predicates       []predicate.EntityTemplate
+	withGroup        *GroupQuery
+	withFields       *TemplateFieldQuery
+	withLocation     *EntityQuery
+	withDefaultImage *AttachmentQuery
+	withFKs          bool
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
 	path func(context.Context) (*sql.Selector, error)
@@ -126,6 +128,28 @@ func (_q *EntityTemplateQuery) QueryLocation() *EntityQuery {
 			sqlgraph.From(entitytemplate.Table, entitytemplate.FieldID, selector),
 			sqlgraph.To(entity.Table, entity.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, false, entitytemplate.LocationTable, entitytemplate.LocationColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryDefaultImage chains the current query on the "default_image" edge.
+func (_q *EntityTemplateQuery) QueryDefaultImage() *AttachmentQuery {
+	query := (&AttachmentClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(entitytemplate.Table, entitytemplate.FieldID, selector),
+			sqlgraph.To(attachment.Table, attachment.FieldID),
+			sqlgraph.Edge(sqlgraph.O2O, false, entitytemplate.DefaultImageTable, entitytemplate.DefaultImageColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
@@ -320,14 +344,15 @@ func (_q *EntityTemplateQuery) Clone() *EntityTemplateQuery {
 		return nil
 	}
 	return &EntityTemplateQuery{
-		config:       _q.config,
-		ctx:          _q.ctx.Clone(),
-		order:        append([]entitytemplate.OrderOption{}, _q.order...),
-		inters:       append([]Interceptor{}, _q.inters...),
-		predicates:   append([]predicate.EntityTemplate{}, _q.predicates...),
-		withGroup:    _q.withGroup.Clone(),
-		withFields:   _q.withFields.Clone(),
-		withLocation: _q.withLocation.Clone(),
+		config:           _q.config,
+		ctx:              _q.ctx.Clone(),
+		order:            append([]entitytemplate.OrderOption{}, _q.order...),
+		inters:           append([]Interceptor{}, _q.inters...),
+		predicates:       append([]predicate.EntityTemplate{}, _q.predicates...),
+		withGroup:        _q.withGroup.Clone(),
+		withFields:       _q.withFields.Clone(),
+		withLocation:     _q.withLocation.Clone(),
+		withDefaultImage: _q.withDefaultImage.Clone(),
 		// clone intermediate query.
 		sql:  _q.sql.Clone(),
 		path: _q.path,
@@ -364,6 +389,17 @@ func (_q *EntityTemplateQuery) WithLocation(opts ...func(*EntityQuery)) *EntityT
 		opt(query)
 	}
 	_q.withLocation = query
+	return _q
+}
+
+// WithDefaultImage tells the query-builder to eager-load the nodes that are connected to
+// the "default_image" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *EntityTemplateQuery) WithDefaultImage(opts ...func(*AttachmentQuery)) *EntityTemplateQuery {
+	query := (&AttachmentClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withDefaultImage = query
 	return _q
 }
 
@@ -446,10 +482,11 @@ func (_q *EntityTemplateQuery) sqlAll(ctx context.Context, hooks ...queryHook) (
 		nodes       = []*EntityTemplate{}
 		withFKs     = _q.withFKs
 		_spec       = _q.querySpec()
-		loadedTypes = [3]bool{
+		loadedTypes = [4]bool{
 			_q.withGroup != nil,
 			_q.withFields != nil,
 			_q.withLocation != nil,
+			_q.withDefaultImage != nil,
 		}
 	)
 	if _q.withGroup != nil || _q.withLocation != nil {
@@ -492,6 +529,12 @@ func (_q *EntityTemplateQuery) sqlAll(ctx context.Context, hooks ...queryHook) (
 	if query := _q.withLocation; query != nil {
 		if err := _q.loadLocation(ctx, query, nodes, nil,
 			func(n *EntityTemplate, e *Entity) { n.Edges.Location = e }); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withDefaultImage; query != nil {
+		if err := _q.loadDefaultImage(ctx, query, nodes, nil,
+			func(n *EntityTemplate, e *Attachment) { n.Edges.DefaultImage = e }); err != nil {
 			return nil, err
 		}
 	}
@@ -590,6 +633,34 @@ func (_q *EntityTemplateQuery) loadLocation(ctx context.Context, query *EntityQu
 		for i := range nodes {
 			assign(nodes[i], n)
 		}
+	}
+	return nil
+}
+func (_q *EntityTemplateQuery) loadDefaultImage(ctx context.Context, query *AttachmentQuery, nodes []*EntityTemplate, init func(*EntityTemplate), assign func(*EntityTemplate, *Attachment)) error {
+	fks := make([]driver.Value, 0, len(nodes))
+	nodeids := make(map[uuid.UUID]*EntityTemplate)
+	for i := range nodes {
+		fks = append(fks, nodes[i].ID)
+		nodeids[nodes[i].ID] = nodes[i]
+	}
+	query.withFKs = true
+	query.Where(predicate.Attachment(func(s *sql.Selector) {
+		s.Where(sql.InValues(s.C(entitytemplate.DefaultImageColumn), fks...))
+	}))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		fk := n.entity_template_default_image
+		if fk == nil {
+			return fmt.Errorf(`foreign-key "entity_template_default_image" is nil for node %v`, n.ID)
+		}
+		node, ok := nodeids[*fk]
+		if !ok {
+			return fmt.Errorf(`unexpected referenced foreign-key "entity_template_default_image" returned %v for node %v`, *fk, n.ID)
+		}
+		assign(node, n)
 	}
 	return nil
 }

--- a/backend/internal/data/ent/entitytemplate_update.go
+++ b/backend/internal/data/ent/entitytemplate_update.go
@@ -13,6 +13,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
 	"github.com/google/uuid"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/attachment"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entity"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entitytemplate"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/group"
@@ -347,6 +348,25 @@ func (_u *EntityTemplateUpdate) SetLocation(v *Entity) *EntityTemplateUpdate {
 	return _u.SetLocationID(v.ID)
 }
 
+// SetDefaultImageID sets the "default_image" edge to the Attachment entity by ID.
+func (_u *EntityTemplateUpdate) SetDefaultImageID(id uuid.UUID) *EntityTemplateUpdate {
+	_u.mutation.SetDefaultImageID(id)
+	return _u
+}
+
+// SetNillableDefaultImageID sets the "default_image" edge to the Attachment entity by ID if the given value is not nil.
+func (_u *EntityTemplateUpdate) SetNillableDefaultImageID(id *uuid.UUID) *EntityTemplateUpdate {
+	if id != nil {
+		_u = _u.SetDefaultImageID(*id)
+	}
+	return _u
+}
+
+// SetDefaultImage sets the "default_image" edge to the Attachment entity.
+func (_u *EntityTemplateUpdate) SetDefaultImage(v *Attachment) *EntityTemplateUpdate {
+	return _u.SetDefaultImageID(v.ID)
+}
+
 // Mutation returns the EntityTemplateMutation object of the builder.
 func (_u *EntityTemplateUpdate) Mutation() *EntityTemplateMutation {
 	return _u.mutation
@@ -382,6 +402,12 @@ func (_u *EntityTemplateUpdate) RemoveFields(v ...*TemplateField) *EntityTemplat
 // ClearLocation clears the "location" edge to the Entity entity.
 func (_u *EntityTemplateUpdate) ClearLocation() *EntityTemplateUpdate {
 	_u.mutation.ClearLocation()
+	return _u
+}
+
+// ClearDefaultImage clears the "default_image" edge to the Attachment entity.
+func (_u *EntityTemplateUpdate) ClearDefaultImage() *EntityTemplateUpdate {
+	_u.mutation.ClearDefaultImage()
 	return _u
 }
 
@@ -657,6 +683,35 @@ func (_u *EntityTemplateUpdate) sqlSave(ctx context.Context) (_node int, err err
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(entity.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.DefaultImageCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2O,
+			Inverse: false,
+			Table:   entitytemplate.DefaultImageTable,
+			Columns: []string{entitytemplate.DefaultImageColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(attachment.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.DefaultImageIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2O,
+			Inverse: false,
+			Table:   entitytemplate.DefaultImageTable,
+			Columns: []string{entitytemplate.DefaultImageColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(attachment.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {
@@ -998,6 +1053,25 @@ func (_u *EntityTemplateUpdateOne) SetLocation(v *Entity) *EntityTemplateUpdateO
 	return _u.SetLocationID(v.ID)
 }
 
+// SetDefaultImageID sets the "default_image" edge to the Attachment entity by ID.
+func (_u *EntityTemplateUpdateOne) SetDefaultImageID(id uuid.UUID) *EntityTemplateUpdateOne {
+	_u.mutation.SetDefaultImageID(id)
+	return _u
+}
+
+// SetNillableDefaultImageID sets the "default_image" edge to the Attachment entity by ID if the given value is not nil.
+func (_u *EntityTemplateUpdateOne) SetNillableDefaultImageID(id *uuid.UUID) *EntityTemplateUpdateOne {
+	if id != nil {
+		_u = _u.SetDefaultImageID(*id)
+	}
+	return _u
+}
+
+// SetDefaultImage sets the "default_image" edge to the Attachment entity.
+func (_u *EntityTemplateUpdateOne) SetDefaultImage(v *Attachment) *EntityTemplateUpdateOne {
+	return _u.SetDefaultImageID(v.ID)
+}
+
 // Mutation returns the EntityTemplateMutation object of the builder.
 func (_u *EntityTemplateUpdateOne) Mutation() *EntityTemplateMutation {
 	return _u.mutation
@@ -1033,6 +1107,12 @@ func (_u *EntityTemplateUpdateOne) RemoveFields(v ...*TemplateField) *EntityTemp
 // ClearLocation clears the "location" edge to the Entity entity.
 func (_u *EntityTemplateUpdateOne) ClearLocation() *EntityTemplateUpdateOne {
 	_u.mutation.ClearLocation()
+	return _u
+}
+
+// ClearDefaultImage clears the "default_image" edge to the Attachment entity.
+func (_u *EntityTemplateUpdateOne) ClearDefaultImage() *EntityTemplateUpdateOne {
+	_u.mutation.ClearDefaultImage()
 	return _u
 }
 
@@ -1338,6 +1418,35 @@ func (_u *EntityTemplateUpdateOne) sqlSave(ctx context.Context) (_node *EntityTe
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(entity.FieldID, field.TypeUUID),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.DefaultImageCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2O,
+			Inverse: false,
+			Table:   entitytemplate.DefaultImageTable,
+			Columns: []string{entitytemplate.DefaultImageColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(attachment.FieldID, field.TypeUUID),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.DefaultImageIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2O,
+			Inverse: false,
+			Table:   entitytemplate.DefaultImageTable,
+			Columns: []string{entitytemplate.DefaultImageColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(attachment.FieldID, field.TypeUUID),
 			},
 		}
 		for _, k := range nodes {

--- a/backend/internal/data/ent/migrate/schema.go
+++ b/backend/internal/data/ent/migrate/schema.go
@@ -58,6 +58,7 @@ var (
 		{Name: "mime_type", Type: field.TypeString, Default: "application/octet-stream"},
 		{Name: "attachment_thumbnail", Type: field.TypeUUID, Unique: true, Nullable: true},
 		{Name: "entity_attachments", Type: field.TypeUUID, Nullable: true},
+		{Name: "entity_template_default_image", Type: field.TypeUUID, Unique: true, Nullable: true},
 	}
 	// AttachmentsTable holds the schema information for the "attachments" table.
 	AttachmentsTable = &schema.Table{
@@ -76,6 +77,12 @@ var (
 				Columns:    []*schema.Column{AttachmentsColumns[9]},
 				RefColumns: []*schema.Column{EntitiesColumns[0]},
 				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "attachments_entity_templates_default_image",
+				Columns:    []*schema.Column{AttachmentsColumns[10]},
+				RefColumns: []*schema.Column{EntityTemplatesColumns[0]},
+				OnDelete:   schema.SetNull,
 			},
 		},
 	}
@@ -683,6 +690,7 @@ func init() {
 	APIKeysTable.ForeignKeys[0].RefTable = UsersTable
 	AttachmentsTable.ForeignKeys[0].RefTable = AttachmentsTable
 	AttachmentsTable.ForeignKeys[1].RefTable = EntitiesTable
+	AttachmentsTable.ForeignKeys[2].RefTable = EntityTemplatesTable
 	AuthRolesTable.ForeignKeys[0].RefTable = AuthTokensTable
 	AuthTokensTable.ForeignKeys[0].RefTable = UsersTable
 	EntitiesTable.ForeignKeys[0].RefTable = EntitiesTable

--- a/backend/internal/data/ent/mutation.go
+++ b/backend/internal/data/ent/mutation.go
@@ -816,24 +816,26 @@ func (m *APIKeyMutation) ResetEdge(name string) error {
 // AttachmentMutation represents an operation that mutates the Attachment nodes in the graph.
 type AttachmentMutation struct {
 	config
-	op               Op
-	typ              string
-	id               *uuid.UUID
-	created_at       *time.Time
-	updated_at       *time.Time
-	_type            *attachment.Type
-	primary          *bool
-	title            *string
-	_path            *string
-	mime_type        *string
-	clearedFields    map[string]struct{}
-	entity           *uuid.UUID
-	clearedentity    bool
-	thumbnail        *uuid.UUID
-	clearedthumbnail bool
-	done             bool
-	oldValue         func(context.Context) (*Attachment, error)
-	predicates       []predicate.Attachment
+	op                     Op
+	typ                    string
+	id                     *uuid.UUID
+	created_at             *time.Time
+	updated_at             *time.Time
+	_type                  *attachment.Type
+	primary                *bool
+	title                  *string
+	_path                  *string
+	mime_type              *string
+	clearedFields          map[string]struct{}
+	entity                 *uuid.UUID
+	clearedentity          bool
+	thumbnail              *uuid.UUID
+	clearedthumbnail       bool
+	entity_template        *uuid.UUID
+	clearedentity_template bool
+	done                   bool
+	oldValue               func(context.Context) (*Attachment, error)
+	predicates             []predicate.Attachment
 }
 
 var _ ent.Mutation = (*AttachmentMutation)(nil)
@@ -1270,6 +1272,45 @@ func (m *AttachmentMutation) ResetThumbnail() {
 	m.clearedthumbnail = false
 }
 
+// SetEntityTemplateID sets the "entity_template" edge to the EntityTemplate entity by id.
+func (m *AttachmentMutation) SetEntityTemplateID(id uuid.UUID) {
+	m.entity_template = &id
+}
+
+// ClearEntityTemplate clears the "entity_template" edge to the EntityTemplate entity.
+func (m *AttachmentMutation) ClearEntityTemplate() {
+	m.clearedentity_template = true
+}
+
+// EntityTemplateCleared reports if the "entity_template" edge to the EntityTemplate entity was cleared.
+func (m *AttachmentMutation) EntityTemplateCleared() bool {
+	return m.clearedentity_template
+}
+
+// EntityTemplateID returns the "entity_template" edge ID in the mutation.
+func (m *AttachmentMutation) EntityTemplateID() (id uuid.UUID, exists bool) {
+	if m.entity_template != nil {
+		return *m.entity_template, true
+	}
+	return
+}
+
+// EntityTemplateIDs returns the "entity_template" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// EntityTemplateID instead. It exists only for internal usage by the builders.
+func (m *AttachmentMutation) EntityTemplateIDs() (ids []uuid.UUID) {
+	if id := m.entity_template; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetEntityTemplate resets all changes to the "entity_template" edge.
+func (m *AttachmentMutation) ResetEntityTemplate() {
+	m.entity_template = nil
+	m.clearedentity_template = false
+}
+
 // Where appends a list predicates to the AttachmentMutation builder.
 func (m *AttachmentMutation) Where(ps ...predicate.Attachment) {
 	m.predicates = append(m.predicates, ps...)
@@ -1505,12 +1546,15 @@ func (m *AttachmentMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *AttachmentMutation) AddedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
 	if m.entity != nil {
 		edges = append(edges, attachment.EdgeEntity)
 	}
 	if m.thumbnail != nil {
 		edges = append(edges, attachment.EdgeThumbnail)
+	}
+	if m.entity_template != nil {
+		edges = append(edges, attachment.EdgeEntityTemplate)
 	}
 	return edges
 }
@@ -1527,13 +1571,17 @@ func (m *AttachmentMutation) AddedIDs(name string) []ent.Value {
 		if id := m.thumbnail; id != nil {
 			return []ent.Value{*id}
 		}
+	case attachment.EdgeEntityTemplate:
+		if id := m.entity_template; id != nil {
+			return []ent.Value{*id}
+		}
 	}
 	return nil
 }
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *AttachmentMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
 	return edges
 }
 
@@ -1545,12 +1593,15 @@ func (m *AttachmentMutation) RemovedIDs(name string) []ent.Value {
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *AttachmentMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
 	if m.clearedentity {
 		edges = append(edges, attachment.EdgeEntity)
 	}
 	if m.clearedthumbnail {
 		edges = append(edges, attachment.EdgeThumbnail)
+	}
+	if m.clearedentity_template {
+		edges = append(edges, attachment.EdgeEntityTemplate)
 	}
 	return edges
 }
@@ -1563,6 +1614,8 @@ func (m *AttachmentMutation) EdgeCleared(name string) bool {
 		return m.clearedentity
 	case attachment.EdgeThumbnail:
 		return m.clearedthumbnail
+	case attachment.EdgeEntityTemplate:
+		return m.clearedentity_template
 	}
 	return false
 }
@@ -1577,6 +1630,9 @@ func (m *AttachmentMutation) ClearEdge(name string) error {
 	case attachment.EdgeThumbnail:
 		m.ClearThumbnail()
 		return nil
+	case attachment.EdgeEntityTemplate:
+		m.ClearEntityTemplate()
+		return nil
 	}
 	return fmt.Errorf("unknown Attachment unique edge %s", name)
 }
@@ -1590,6 +1646,9 @@ func (m *AttachmentMutation) ResetEdge(name string) error {
 		return nil
 	case attachment.EdgeThumbnail:
 		m.ResetThumbnail()
+		return nil
+	case attachment.EdgeEntityTemplate:
+		m.ResetEntityTemplate()
 		return nil
 	}
 	return fmt.Errorf("unknown Attachment edge %s", name)
@@ -6130,6 +6189,8 @@ type EntityTemplateMutation struct {
 	clearedfields             bool
 	location                  *uuid.UUID
 	clearedlocation           bool
+	default_image             *uuid.UUID
+	cleareddefault_image      bool
 	done                      bool
 	oldValue                  func(context.Context) (*EntityTemplate, error)
 	predicates                []predicate.EntityTemplate
@@ -7123,6 +7184,45 @@ func (m *EntityTemplateMutation) ResetLocation() {
 	m.clearedlocation = false
 }
 
+// SetDefaultImageID sets the "default_image" edge to the Attachment entity by id.
+func (m *EntityTemplateMutation) SetDefaultImageID(id uuid.UUID) {
+	m.default_image = &id
+}
+
+// ClearDefaultImage clears the "default_image" edge to the Attachment entity.
+func (m *EntityTemplateMutation) ClearDefaultImage() {
+	m.cleareddefault_image = true
+}
+
+// DefaultImageCleared reports if the "default_image" edge to the Attachment entity was cleared.
+func (m *EntityTemplateMutation) DefaultImageCleared() bool {
+	return m.cleareddefault_image
+}
+
+// DefaultImageID returns the "default_image" edge ID in the mutation.
+func (m *EntityTemplateMutation) DefaultImageID() (id uuid.UUID, exists bool) {
+	if m.default_image != nil {
+		return *m.default_image, true
+	}
+	return
+}
+
+// DefaultImageIDs returns the "default_image" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// DefaultImageID instead. It exists only for internal usage by the builders.
+func (m *EntityTemplateMutation) DefaultImageIDs() (ids []uuid.UUID) {
+	if id := m.default_image; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetDefaultImage resets all changes to the "default_image" edge.
+func (m *EntityTemplateMutation) ResetDefaultImage() {
+	m.default_image = nil
+	m.cleareddefault_image = false
+}
+
 // Where appends a list predicates to the EntityTemplateMutation builder.
 func (m *EntityTemplateMutation) Where(ps ...predicate.EntityTemplate) {
 	m.predicates = append(m.predicates, ps...)
@@ -7594,7 +7694,7 @@ func (m *EntityTemplateMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *EntityTemplateMutation) AddedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 4)
 	if m.group != nil {
 		edges = append(edges, entitytemplate.EdgeGroup)
 	}
@@ -7603,6 +7703,9 @@ func (m *EntityTemplateMutation) AddedEdges() []string {
 	}
 	if m.location != nil {
 		edges = append(edges, entitytemplate.EdgeLocation)
+	}
+	if m.default_image != nil {
+		edges = append(edges, entitytemplate.EdgeDefaultImage)
 	}
 	return edges
 }
@@ -7625,13 +7728,17 @@ func (m *EntityTemplateMutation) AddedIDs(name string) []ent.Value {
 		if id := m.location; id != nil {
 			return []ent.Value{*id}
 		}
+	case entitytemplate.EdgeDefaultImage:
+		if id := m.default_image; id != nil {
+			return []ent.Value{*id}
+		}
 	}
 	return nil
 }
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *EntityTemplateMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 4)
 	if m.removedfields != nil {
 		edges = append(edges, entitytemplate.EdgeFields)
 	}
@@ -7654,7 +7761,7 @@ func (m *EntityTemplateMutation) RemovedIDs(name string) []ent.Value {
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *EntityTemplateMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 4)
 	if m.clearedgroup {
 		edges = append(edges, entitytemplate.EdgeGroup)
 	}
@@ -7663,6 +7770,9 @@ func (m *EntityTemplateMutation) ClearedEdges() []string {
 	}
 	if m.clearedlocation {
 		edges = append(edges, entitytemplate.EdgeLocation)
+	}
+	if m.cleareddefault_image {
+		edges = append(edges, entitytemplate.EdgeDefaultImage)
 	}
 	return edges
 }
@@ -7677,6 +7787,8 @@ func (m *EntityTemplateMutation) EdgeCleared(name string) bool {
 		return m.clearedfields
 	case entitytemplate.EdgeLocation:
 		return m.clearedlocation
+	case entitytemplate.EdgeDefaultImage:
+		return m.cleareddefault_image
 	}
 	return false
 }
@@ -7690,6 +7802,9 @@ func (m *EntityTemplateMutation) ClearEdge(name string) error {
 		return nil
 	case entitytemplate.EdgeLocation:
 		m.ClearLocation()
+		return nil
+	case entitytemplate.EdgeDefaultImage:
+		m.ClearDefaultImage()
 		return nil
 	}
 	return fmt.Errorf("unknown EntityTemplate unique edge %s", name)
@@ -7707,6 +7822,9 @@ func (m *EntityTemplateMutation) ResetEdge(name string) error {
 		return nil
 	case entitytemplate.EdgeLocation:
 		m.ResetLocation()
+		return nil
+	case entitytemplate.EdgeDefaultImage:
+		m.ResetDefaultImage()
 		return nil
 	}
 	return fmt.Errorf("unknown EntityTemplate edge %s", name)

--- a/backend/internal/data/ent/schema/attachment.go
+++ b/backend/internal/data/ent/schema/attachment.go
@@ -37,5 +37,8 @@ func (Attachment) Edges() []ent.Edge {
 			Unique(),
 		edge.To("thumbnail", Attachment.Type).
 			Unique(),
+		edge.From("entity_template", EntityTemplate.Type).
+			Ref("default_image").
+			Unique(),
 	}
 }

--- a/backend/internal/data/ent/schema/entity_template.go
+++ b/backend/internal/data/ent/schema/entity_template.go
@@ -107,5 +107,11 @@ func (EntityTemplate) Edges() []ent.Edge {
 		// Default location for items created from this template
 		edge.To("location", Entity.Type).
 			Unique(),
+		// Default image applied to items created from this template. The
+		// attachment is owned by the template and has no entity edge; items
+		// created from the template get their own attachment row pointing at
+		// the same stored path.
+		edge.To("default_image", Attachment.Type).
+			Unique(),
 	}
 }

--- a/backend/internal/data/migrations/postgres/20260902120001_template_default_image.sql
+++ b/backend/internal/data/migrations/postgres/20260902120001_template_default_image.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+ALTER TABLE "attachments"
+    ADD COLUMN "entity_template_default_image" uuid NULL
+        CONSTRAINT "attachments_entity_templates_default_image"
+            REFERENCES "entity_templates" ("id") ON DELETE SET NULL;
+
+ALTER TABLE "attachments"
+    ADD CONSTRAINT "attachments_entity_template_default_image_key"
+        UNIQUE ("entity_template_default_image");

--- a/backend/internal/data/migrations/sqlite3/20260902120000_template_default_image.sql
+++ b/backend/internal/data/migrations/sqlite3/20260902120000_template_default_image.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose no transaction
+PRAGMA foreign_keys=OFF;
+
+ALTER TABLE attachments ADD COLUMN entity_template_default_image uuid
+    REFERENCES entity_templates(id) ON DELETE SET NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS attachments_entity_template_default_image_key
+    ON attachments(entity_template_default_image)
+    WHERE entity_template_default_image IS NOT NULL;
+
+PRAGMA foreign_keys=ON;

--- a/backend/internal/data/repo/repo_entities.go
+++ b/backend/internal/data/repo/repo_entities.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/attachment"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entity"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entityfield"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entitytemplate"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entitytype"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/group"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/maintenanceentry"
@@ -1109,6 +1110,10 @@ func (r *EntityRepository) Create(ctx context.Context, gid uuid.UUID, data Entit
 
 // EntityCreateFromTemplate contains all data needed to create an entity from a template.
 type EntityCreateFromTemplate struct {
+	// TemplateID is the template the entity is created from. It is resolved
+	// inside the transaction to pick up the template's default image, so the
+	// stored path never has to travel out through the API layer.
+	TemplateID       uuid.UUID
 	Name             string
 	Description      string
 	Manufacturer     string
@@ -1250,6 +1255,45 @@ func (r *EntityRepository) CreateFromTemplate(ctx context.Context, gid uuid.UUID
 		fieldsSpan.End()
 	}
 
+	// Apply the template's default image, if it has one. The new attachment
+	// points at the path the template's own attachment already uses: the file
+	// is stored once, and the path refcount in AttachmentRepo.delete keeps it
+	// alive until the template and every entity created from it let go of it.
+	var newImage *ent.Attachment
+	if data.TemplateID != uuid.Nil {
+		imgCtx, imgSpan := entityTracer().Start(ctx, "repo.EntityRepository.CreateFromTemplate.image")
+		templateImage, err := tx.EntityTemplate.Query().
+			Where(entitytemplate.ID(data.TemplateID)).
+			QueryDefaultImage().
+			Only(imgCtx)
+		switch {
+		case ent.IsNotFound(err):
+			// Template has no default image; nothing to apply.
+		case err != nil:
+			recordSpanError(imgSpan, err)
+			imgSpan.End()
+			recordSpanError(span, err)
+			return EntityOut{}, err
+		default:
+			newImage, err = tx.Attachment.Create().
+				SetEntityID(newEntityID).
+				SetType(attachment.TypePhoto).
+				SetTitle(templateImage.Title).
+				SetPath(templateImage.Path).
+				SetMimeType(templateImage.MimeType).
+				SetPrimary(true).
+				Save(imgCtx)
+			if err != nil {
+				recordSpanError(imgSpan, err)
+				imgSpan.End()
+				recordSpanError(span, err)
+				return EntityOut{}, err
+			}
+			imgSpan.SetAttributes(attribute.String("attachment.id", newImage.ID.String()))
+		}
+		imgSpan.End()
+	}
+
 	_, commitSpan := entityTracer().Start(ctx, "repo.EntityRepository.CreateFromTemplate.commit")
 	if err = tx.Commit(); err != nil {
 		recordSpanError(commitSpan, err)
@@ -1259,6 +1303,11 @@ func (r *EntityRepository) CreateFromTemplate(ctx context.Context, gid uuid.UUID
 	}
 	commitSpan.End()
 	committed = true
+
+	// Queued after commit so the worker cannot race the transaction.
+	if newImage != nil {
+		r.attachments.requestThumbnail(ctx, gid, newImage, newImage.Title)
+	}
 
 	r.publishMutationEvent(gid)
 	out, err := r.GetOne(ctx, newEntityID)

--- a/backend/internal/data/repo/repo_entity_templates.go
+++ b/backend/internal/data/repo/repo_entity_templates.go
@@ -9,6 +9,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/sysadminsmedia/homebox/backend/internal/core/services/reporting/eventbus"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/attachment"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entitytemplate"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/group"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/tag"
@@ -16,8 +17,9 @@ import (
 )
 
 type EntityTemplatesRepository struct {
-	db  *ent.Client
-	bus *eventbus.EventBus
+	db          *ent.Client
+	bus         *eventbus.EventBus
+	attachments *AttachmentRepo
 }
 
 type (
@@ -98,9 +100,18 @@ type (
 		UpdatedAt   time.Time `json:"updatedAt"`
 	}
 
+	TemplateImageSummary struct {
+		ID          uuid.UUID  `json:"id"`
+		Title       string     `json:"title"`
+		MimeType    string     `json:"mimeType"`
+		ThumbnailID *uuid.UUID `json:"thumbnailId" extensions:"x-nullable"`
+	}
+
 	EntityTemplateOut struct {
 		CreatedAt time.Time `json:"createdAt"`
 		UpdatedAt time.Time `json:"updatedAt"`
+		// Default image applied to entities created from this template
+		DefaultImage *TemplateImageSummary `json:"defaultImage"`
 		// Default location and tags
 		DefaultLocation        *TemplateLocationSummary `json:"defaultLocation"`
 		Name                   string                   `json:"name"`
@@ -169,6 +180,20 @@ func (r *EntityTemplatesRepository) mapTemplateOut(ctx context.Context, template
 		}
 	}
 
+	// Map the default image if present
+	var image *TemplateImageSummary
+	if template.Edges.DefaultImage != nil {
+		att := template.Edges.DefaultImage
+		image = &TemplateImageSummary{
+			ID:       att.ID,
+			Title:    att.Title,
+			MimeType: att.MimeType,
+		}
+		if thumb, err := att.QueryThumbnail().Only(ctx); err == nil {
+			image.ThumbnailID = &thumb.ID
+		}
+	}
+
 	// Fetch tags from database using stored IDs
 	tags := make([]TemplateTagSummary, 0)
 	if len(template.DefaultTagIds) > 0 {
@@ -201,6 +226,7 @@ func (r *EntityTemplatesRepository) mapTemplateOut(ctx context.Context, template
 		DefaultLifetimeWarranty: template.DefaultLifetimeWarranty,
 		DefaultWarrantyDetails:  template.DefaultWarrantyDetails,
 		DefaultLocation:         location,
+		DefaultImage:            image,
 		DefaultTags:             tags,
 		IncludeWarrantyFields:   template.IncludeWarrantyFields,
 		IncludePurchaseFields:   template.IncludePurchaseFields,
@@ -242,6 +268,7 @@ func (r *EntityTemplatesRepository) GetOne(ctx context.Context, gid uuid.UUID, i
 		).
 		WithFields().
 		WithLocation().
+		WithDefaultImage().
 		Only(ctx)
 
 	if err != nil {
@@ -420,24 +447,132 @@ func (r *EntityTemplatesRepository) Update(ctx context.Context, gid uuid.UUID, d
 	return r.GetOne(ctx, gid, template.ID)
 }
 
-// Delete deletes a template
-func (r *EntityTemplatesRepository) Delete(ctx context.Context, gid uuid.UUID, id uuid.UUID) error {
-	// Verify template belongs to group
-	_, err := r.db.EntityTemplate.Query().
+// GetDefaultImage returns the attachment backing the template's default image,
+// verified to belong to the specified group.
+func (r *EntityTemplatesRepository) GetDefaultImage(ctx context.Context, gid uuid.UUID, id uuid.UUID) (*ent.Attachment, error) {
+	return r.db.EntityTemplate.Query().
 		Where(
 			entitytemplate.ID(id),
 			entitytemplate.HasGroupWith(group.ID(gid)),
 		).
+		QueryDefaultImage().
+		Only(ctx)
+}
+
+// SetDefaultImage stores an image on the template and applies it to entities
+// created from it afterwards. Any image the template already had is removed
+// first so a template never accumulates orphaned attachments.
+func (r *EntityTemplatesRepository) SetDefaultImage(ctx context.Context, gid uuid.UUID, id uuid.UUID, doc ItemCreateAttachment) (EntityTemplateOut, error) {
+	template, err := r.db.EntityTemplate.Query().
+		Where(
+			entitytemplate.ID(id),
+			entitytemplate.HasGroupWith(group.ID(gid)),
+		).
+		WithDefaultImage().
+		Only(ctx)
+	if err != nil {
+		return EntityTemplateOut{}, err
+	}
+
+	grp, err := r.db.Group.Get(ctx, gid)
+	if err != nil {
+		return EntityTemplateOut{}, err
+	}
+
+	att, err := r.attachments.CreateUnlinked(ctx, grp, doc, attachment.TypePhoto)
+	if err != nil {
+		return EntityTemplateOut{}, err
+	}
+
+	// The edge is one-to-one, so the previous image has to let go of it before
+	// the new one can take it.
+	prev := template.Edges.DefaultImage
+	if prev != nil {
+		if _, err := template.Update().ClearDefaultImage().Save(ctx); err != nil {
+			if delErr := r.attachments.delete(ctx, att); delErr != nil {
+				log.Err(delErr).Msg("failed to clean up template image after update failure")
+			}
+			return EntityTemplateOut{}, err
+		}
+	}
+
+	if _, err = template.Update().SetDefaultImageID(att.ID).Save(ctx); err != nil {
+		// Roll the file back so a failed swap doesn't leave a stored blob that
+		// nothing references.
+		if delErr := r.attachments.delete(ctx, att); delErr != nil {
+			log.Err(delErr).Msg("failed to clean up template image after update failure")
+		}
+		return EntityTemplateOut{}, err
+	}
+
+	if prev != nil {
+		if err := r.attachments.delete(ctx, prev); err != nil {
+			log.Err(err).Msg("failed to delete replaced template image")
+		}
+	}
+
+	r.publishMutationEvent(gid)
+	return r.GetOne(ctx, gid, id)
+}
+
+// ClearDefaultImage removes the template's default image. Entities already
+// created from the template keep the copies they were given.
+func (r *EntityTemplatesRepository) ClearDefaultImage(ctx context.Context, gid uuid.UUID, id uuid.UUID) (EntityTemplateOut, error) {
+	template, err := r.db.EntityTemplate.Query().
+		Where(
+			entitytemplate.ID(id),
+			entitytemplate.HasGroupWith(group.ID(gid)),
+		).
+		WithDefaultImage().
+		Only(ctx)
+	if err != nil {
+		return EntityTemplateOut{}, err
+	}
+
+	if template.Edges.DefaultImage == nil {
+		return r.GetOne(ctx, gid, id)
+	}
+
+	if _, err := template.Update().ClearDefaultImage().Save(ctx); err != nil {
+		return EntityTemplateOut{}, err
+	}
+
+	if err := r.attachments.delete(ctx, template.Edges.DefaultImage); err != nil {
+		log.Err(err).Msg("failed to delete template image")
+	}
+
+	r.publishMutationEvent(gid)
+	return r.GetOne(ctx, gid, id)
+}
+
+// Delete deletes a template
+func (r *EntityTemplatesRepository) Delete(ctx context.Context, gid uuid.UUID, id uuid.UUID) error {
+	// Verify template belongs to group
+	template, err := r.db.EntityTemplate.Query().
+		Where(
+			entitytemplate.ID(id),
+			entitytemplate.HasGroupWith(group.ID(gid)),
+		).
+		WithDefaultImage().
 		Only(ctx)
 
 	if err != nil {
 		return err
 	}
+	image := template.Edges.DefaultImage
 
 	// Delete template (fields will be cascade deleted)
 	err = r.db.EntityTemplate.DeleteOneID(id).Exec(ctx)
 	if err != nil {
 		return err
+	}
+
+	// The image is owned by the template, so it goes with it. The file itself
+	// survives if entities created from this template still reference the path.
+	if image != nil {
+		if err := r.attachments.delete(ctx, image); err != nil {
+			log.Err(err).Msg("failed to delete template image")
+		}
 	}
 
 	r.publishMutationEvent(gid)

--- a/backend/internal/data/repo/repo_entity_templates.go
+++ b/backend/internal/data/repo/repo_entity_templates.go
@@ -111,7 +111,7 @@ type (
 		CreatedAt time.Time `json:"createdAt"`
 		UpdatedAt time.Time `json:"updatedAt"`
 		// Default image applied to entities created from this template
-		DefaultImage *TemplateImageSummary `json:"defaultImage"`
+		DefaultImage *TemplateImageSummary `json:"defaultImage" extensions:"x-nullable"`
 		// Default location and tags
 		DefaultLocation        *TemplateLocationSummary `json:"defaultLocation"`
 		Name                   string                   `json:"name"`
@@ -460,7 +460,7 @@ func (r *EntityTemplatesRepository) GetDefaultImage(ctx context.Context, gid uui
 }
 
 // SetDefaultImage stores an image on the template and applies it to entities
-// created from it afterwards. Any image the template already had is removed
+// created from it afterward. Any image the template already had is removed
 // first so a template never accumulates orphaned attachments.
 func (r *EntityTemplatesRepository) SetDefaultImage(ctx context.Context, gid uuid.UUID, id uuid.UUID, doc ItemCreateAttachment) (EntityTemplateOut, error) {
 	template, err := r.db.EntityTemplate.Query().
@@ -485,18 +485,42 @@ func (r *EntityTemplatesRepository) SetDefaultImage(ctx context.Context, gid uui
 	}
 
 	// The edge is one-to-one, so the previous image has to let go of it before
-	// the new one can take it.
+	// the new one can take it. Both writes go in one transaction: a partial
+	// swap would leave the template with no image while reporting failure, and
+	// strand the previous attachment where no group-scoped query can reach it.
 	prev := template.Edges.DefaultImage
-	if prev != nil {
-		if _, err := template.Update().ClearDefaultImage().Save(ctx); err != nil {
-			if delErr := r.attachments.delete(ctx, att); delErr != nil {
-				log.Err(delErr).Msg("failed to clean up template image after update failure")
-			}
-			return EntityTemplateOut{}, err
+
+	swap := func() error {
+		tx, err := r.db.Tx(ctx)
+		if err != nil {
+			return err
 		}
+		committed := false
+		defer func() {
+			if !committed {
+				if err := tx.Rollback(); err != nil {
+					log.Warn().Err(err).Msg("failed to roll back template image swap")
+				}
+			}
+		}()
+
+		if prev != nil {
+			if err := tx.EntityTemplate.UpdateOneID(id).ClearDefaultImage().Exec(ctx); err != nil {
+				return err
+			}
+		}
+		if err := tx.EntityTemplate.UpdateOneID(id).SetDefaultImageID(att.ID).Exec(ctx); err != nil {
+			return err
+		}
+
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+		committed = true
+		return nil
 	}
 
-	if _, err = template.Update().SetDefaultImageID(att.ID).Save(ctx); err != nil {
+	if err := swap(); err != nil {
 		// Roll the file back so a failed swap doesn't leave a stored blob that
 		// nothing references.
 		if delErr := r.attachments.delete(ctx, att); delErr != nil {

--- a/backend/internal/data/repo/repo_entity_templates_test.go
+++ b/backend/internal/data/repo/repo_entity_templates_test.go
@@ -2,12 +2,16 @@ package repo
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/attachment"
 )
 
 func templateFactory() EntityTemplateCreate {
@@ -120,4 +124,138 @@ func TestEntityTemplatesRepository_Delete(t *testing.T) {
 
 	_, err = tRepos.EntityTemplates.GetOne(context.Background(), tGroup.ID, created.ID)
 	require.Error(t, err)
+}
+
+func TestEntityTemplatesRepository_SetDefaultImage(t *testing.T) {
+	ctx := context.Background()
+
+	created, err := tRepos.EntityTemplates.Create(ctx, tGroup.ID, templateFactory())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tRepos.EntityTemplates.Delete(ctx, tGroup.ID, created.ID)
+	})
+
+	result, err := tRepos.EntityTemplates.SetDefaultImage(ctx, tGroup.ID, created.ID, ItemCreateAttachment{
+		Title:   "photo.png",
+		Content: strings.NewReader("template image"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.DefaultImage)
+	assert.Equal(t, "photo.png", result.DefaultImage.Title)
+
+	// The image must survive a round trip through GetOne
+	fetched, err := tRepos.EntityTemplates.GetOne(ctx, tGroup.ID, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, fetched.DefaultImage)
+	assert.Equal(t, result.DefaultImage.ID, fetched.DefaultImage.ID)
+
+	// Replacing the image must not leave the old attachment behind
+	old := result.DefaultImage.ID
+	replaced, err := tRepos.EntityTemplates.SetDefaultImage(ctx, tGroup.ID, created.ID, ItemCreateAttachment{
+		Title:   "replacement.png",
+		Content: strings.NewReader("replacement image"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, replaced.DefaultImage)
+	assert.NotEqual(t, old, replaced.DefaultImage.ID)
+
+	_, err = tRepos.Attachments.Get(ctx, tGroup.ID, old)
+	require.Error(t, err)
+}
+
+func TestEntityTemplatesRepository_ClearDefaultImage(t *testing.T) {
+	ctx := context.Background()
+
+	created, err := tRepos.EntityTemplates.Create(ctx, tGroup.ID, templateFactory())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tRepos.EntityTemplates.Delete(ctx, tGroup.ID, created.ID)
+	})
+
+	withImage, err := tRepos.EntityTemplates.SetDefaultImage(ctx, tGroup.ID, created.ID, ItemCreateAttachment{
+		Title:   "photo.png",
+		Content: strings.NewReader("template image"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, withImage.DefaultImage)
+
+	cleared, err := tRepos.EntityTemplates.ClearDefaultImage(ctx, tGroup.ID, created.ID)
+	require.NoError(t, err)
+	assert.Nil(t, cleared.DefaultImage)
+
+	// Clearing again is a no-op rather than an error
+	cleared, err = tRepos.EntityTemplates.ClearDefaultImage(ctx, tGroup.ID, created.ID)
+	require.NoError(t, err)
+	assert.Nil(t, cleared.DefaultImage)
+}
+
+func TestEntityTemplatesRepository_CreateFromTemplateAppliesDefaultImage(t *testing.T) {
+	ctx := context.Background()
+
+	created, err := tRepos.EntityTemplates.Create(ctx, tGroup.ID, templateFactory())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tRepos.EntityTemplates.Delete(ctx, tGroup.ID, created.ID)
+	})
+
+	withImage, err := tRepos.EntityTemplates.SetDefaultImage(ctx, tGroup.ID, created.ID, ItemCreateAttachment{
+		Title:   "photo.png",
+		Content: strings.NewReader("template image"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, withImage.DefaultImage)
+
+	templateImage, err := tRepos.EntityTemplates.GetDefaultImage(ctx, tGroup.ID, created.ID)
+	require.NoError(t, err)
+
+	entity, err := tRepos.Entities.CreateFromTemplate(ctx, tGroup.ID, EntityCreateFromTemplate{
+		TemplateID: created.ID,
+		Name:       "From Template",
+		Quantity:   1,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tRepos.Entities.Delete(ctx, entity.ID)
+	})
+
+	require.Len(t, entity.Attachments, 1)
+	applied := entity.Attachments[0]
+	assert.Equal(t, attachment.TypePhoto.String(), applied.Type)
+	assert.True(t, applied.Primary)
+	assert.Equal(t, templateImage.Title, applied.Title)
+	// The file is stored once and shared, not copied per entity
+	assert.Equal(t, templateImage.Path, applied.Path)
+
+	// Deleting the entity's copy must not take the shared file with it while
+	// the template still points at that path.
+	err = tRepos.Attachments.Delete(ctx, tGroup.ID, applied.ID)
+	require.NoError(t, err)
+
+	// Blob keys are relative to the bucket root, which the test harness backs
+	// with the temp dir.
+	stored := filepath.Join(os.TempDir(), tRepos.Attachments.GetFullPath(templateImage.Path))
+	_, err = os.Stat(stored)
+	require.NoError(t, err, "shared file was deleted while the template still references it")
+}
+
+func TestEntityTemplatesRepository_CreateFromTemplateWithoutImage(t *testing.T) {
+	ctx := context.Background()
+
+	created, err := tRepos.EntityTemplates.Create(ctx, tGroup.ID, templateFactory())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tRepos.EntityTemplates.Delete(ctx, tGroup.ID, created.ID)
+	})
+
+	entity, err := tRepos.Entities.CreateFromTemplate(ctx, tGroup.ID, EntityCreateFromTemplate{
+		TemplateID: created.ID,
+		Name:       "No Image",
+		Quantity:   1,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tRepos.Entities.Delete(ctx, entity.ID)
+	})
+
+	assert.Empty(t, entity.Attachments)
 }

--- a/backend/internal/data/repo/repo_item_attachments.go
+++ b/backend/internal/data/repo/repo_item_attachments.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"crypto/md5"
+	"database/sql"
+	"errors"
 	"fmt"
 	"image"
 	"io"
@@ -785,6 +787,15 @@ func (r *AttachmentRepo) Rename(ctx context.Context, gid uuid.UUID, id uuid.UUID
 	return r.db.Attachment.UpdateOneID(id).SetTitle(title).Save(ctx)
 }
 
+// rollbackThumbnailTx discards an in-flight thumbnail transaction. Leaving one
+// open holds the SQLite write lock for the life of the process, which turns a
+// single failed thumbnail into SQLITE_BUSY on every later write.
+func rollbackThumbnailTx(tx *ent.Tx) {
+	if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+		log.Err(err).Msg("failed to roll back thumbnail transaction")
+	}
+}
+
 //nolint:gocyclo
 func (r *AttachmentRepo) CreateThumbnail(ctx context.Context, groupId, attachmentId uuid.UUID, title string, path string) error {
 	ctx, span := otel.Tracer("data").Start(ctx, "repo.AttachmentRepo.CreateThumbnail")
@@ -804,6 +815,21 @@ func (r *AttachmentRepo) CreateThumbnail(ctx context.Context, groupId, attachmen
 			}
 		}
 	}()
+
+	// The attachment can be deleted between the request being published and the
+	// worker picking it up. Bail out before decoding anything: the edge write at
+	// the end would fail the foreign key check anyway.
+	exists, err := tx.Attachment.Query().Where(attachment.ID(attachmentId)).Exist(ctx)
+	if err != nil {
+		rollbackThumbnailTx(tx)
+		return err
+	}
+	if !exists {
+		log.Debug().Str("attachment_id", attachmentId.String()).
+			Msg("attachment deleted before its thumbnail could be created")
+		rollbackThumbnailTx(tx)
+		return nil
+	}
 
 	log.Debug().Msg("set initial database transaction")
 	att := tx.Attachment.Create().
@@ -863,6 +889,7 @@ func (r *AttachmentRepo) CreateThumbnail(ctx context.Context, groupId, attachmen
 	}
 
 	if stats.Size() > 100*1024*1024 {
+		rollbackThumbnailTx(tx)
 		return fmt.Errorf("original file %s is too large to create a thumbnail", title)
 	}
 
@@ -1010,6 +1037,7 @@ func (r *AttachmentRepo) CreateThumbnail(ctx context.Context, groupId, attachmen
 		}
 		att.SetPath(uploadResult.Path)
 	default:
+		rollbackThumbnailTx(tx)
 		return fmt.Errorf("file type %s is not supported for thumbnail creation or document thumnails disabled", title)
 	}
 
@@ -1018,11 +1046,13 @@ func (r *AttachmentRepo) CreateThumbnail(ctx context.Context, groupId, attachmen
 	log.Debug().Msg("saving thumbnail attachment to database")
 	thumbnail, err := att.Save(ctx)
 	if err != nil {
+		rollbackThumbnailTx(tx)
 		return err
 	}
 
 	_, err = tx.Attachment.UpdateOneID(attachmentId).SetThumbnail(thumbnail).Save(ctx)
 	if err != nil {
+		rollbackThumbnailTx(tx)
 		return err
 	}
 

--- a/backend/internal/data/repo/repo_item_attachments.go
+++ b/backend/internal/data/repo/repo_item_attachments.go
@@ -476,6 +476,11 @@ func (r *AttachmentRepo) requestThumbnail(ctx context.Context, groupID uuid.UUID
 		log.Err(err).Msg("failed to generate pubsub connection string")
 		return
 	}
+	// Not shut down after sending: the pubsub URL openers cache topics by name
+	// (mempubsub, the default, returns the same *pubsub.Topic for every
+	// OpenTopic on a given name), so shutting it down here would poison the
+	// topic process-wide and every later publisher would fail with
+	// FailedPrecondition. This matches how the other publishers here treat it.
 	topic, err := pubsub.OpenTopic(ctx, pubsubString)
 	if err != nil {
 		log.Err(err).Msg("failed to open pubsub topic")
@@ -712,7 +717,15 @@ func (r *AttachmentRepo) delete(ctx context.Context, doc *ent.Attachment) error 
 	}
 	committed = true
 
-	return r.deleteFiles(ctx, orphaned)
+	// The rows are gone. Reclaiming the files is best effort from here: a
+	// failure leaves an unreferenced file for create-missing-thumbnails or an
+	// operator to clean up, and must not report the committed deletion as
+	// failed, which would show the client an error and then NotFound on retry.
+	if err := r.deleteFiles(ctx, orphaned); err != nil {
+		log.Err(err).Msg("attachment deleted, but its unreferenced files could not be removed")
+	}
+
+	return nil
 }
 
 // dedupePaths returns the distinct stored paths of an attachment and its
@@ -726,8 +739,8 @@ func dedupePaths(doc *ent.Attachment, thumb *ent.Attachment) []string {
 }
 
 // deleteFiles removes stored files that no attachment row references any more.
-// A failure here leaves an unreferenced file behind rather than failing the
-// deletion the caller already committed.
+// Every path is attempted; the first failure is returned so the caller can log
+// it, having already committed the row deletion those files belonged to.
 func (r *AttachmentRepo) deleteFiles(ctx context.Context, paths []string) error {
 	if len(paths) == 0 {
 		return nil
@@ -744,14 +757,17 @@ func (r *AttachmentRepo) deleteFiles(ctx context.Context, paths []string) error 
 		}
 	}(bucket)
 
+	var firstErr error
 	for _, path := range paths {
 		if err := bucket.Delete(ctx, r.fullPath(path)); err != nil {
 			log.Err(err).Str("path", path).Msg("failed to delete unreferenced file")
-			return err
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
 
-	return nil
+	return firstErr
 }
 
 func (r *AttachmentRepo) Rename(ctx context.Context, gid uuid.UUID, id uuid.UUID, title string) (*ent.Attachment, error) {

--- a/backend/internal/data/repo/repo_item_attachments.go
+++ b/backend/internal/data/repo/repo_item_attachments.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/attachment"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entity"
+	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/entitytemplate"
 	"github.com/sysadminsmedia/homebox/backend/internal/data/ent/group"
 	"github.com/sysadminsmedia/homebox/backend/internal/sys/config"
 	"github.com/sysadminsmedia/homebox/backend/pkgs/utils"
@@ -428,6 +429,73 @@ func (r *AttachmentRepo) Create(ctx context.Context, itemID uuid.UUID, doc ItemC
 	return attachmentDb, nil
 }
 
+// CreateUnlinked stores a file and creates an attachment row that is not linked
+// to an entity. It backs entity template default images, which are owned by a
+// template rather than an entity; entities created from that template get their
+// own attachment rows pointing at the same stored path, so the file is stored
+// once and the path refcount in delete keeps it alive while anything uses it.
+func (r *AttachmentRepo) CreateUnlinked(ctx context.Context, grp *ent.Group, doc ItemCreateAttachment, typ attachment.Type) (*ent.Attachment, error) {
+	ctx, span := otel.Tracer("data").Start(ctx, "repo.AttachmentRepo.CreateUnlinked")
+	defer span.End()
+
+	uploadResult, err := r.UploadFile(ctx, grp, doc)
+	if err != nil {
+		return nil, err
+	}
+
+	att, err := r.db.Attachment.Create().
+		SetID(uuid.New()).
+		SetCreatedAt(time.Now()).
+		SetUpdatedAt(time.Now()).
+		SetType(typ).
+		SetTitle(doc.Title).
+		SetPath(uploadResult.Path).
+		SetMimeType(uploadResult.ContentType).
+		Save(ctx)
+	if err != nil {
+		log.Err(err).Msg("failed to save unlinked attachment to database")
+		return nil, err
+	}
+
+	r.requestThumbnail(ctx, grp.ID, att, doc.Title)
+
+	return att, nil
+}
+
+// requestThumbnail asks the background worker to generate a thumbnail for an
+// attachment. Failures are logged rather than returned: a missing thumbnail
+// degrades display but must not fail the write that produced the attachment,
+// and the create-missing-thumbnails action can backfill it later.
+func (r *AttachmentRepo) requestThumbnail(ctx context.Context, groupID uuid.UUID, att *ent.Attachment, title string) {
+	if !r.thumbnail.Enabled {
+		return
+	}
+
+	pubsubString, err := utils.GenerateSubPubConn(r.pubSubConn, "thumbnails")
+	if err != nil {
+		log.Err(err).Msg("failed to generate pubsub connection string")
+		return
+	}
+	topic, err := pubsub.OpenTopic(ctx, pubsubString)
+	if err != nil {
+		log.Err(err).Msg("failed to open pubsub topic")
+		return
+	}
+
+	err = topic.Send(ctx, &pubsub.Message{
+		Body: []byte(fmt.Sprintf("attachment_created:%s", att.ID.String())),
+		Metadata: map[string]string{
+			"group_id":      groupID.String(),
+			"attachment_id": att.ID.String(),
+			"title":         title,
+			"path":          att.Path,
+		},
+	})
+	if err != nil {
+		log.Err(err).Msg("failed to send message to topic")
+	}
+}
+
 func (r *AttachmentRepo) CreateExternalLink(ctx context.Context, entityID uuid.UUID, externalID string, title string, mimeType string, attType attachment.Type) (*ent.Attachment, error) {
 	ctx, span := otel.Tracer("data").Start(ctx, "repo.AttachmentRepo.CreateExternalLink")
 	defer span.End()
@@ -550,56 +618,99 @@ func (r *AttachmentRepo) Delete(ctx context.Context, gid uuid.UUID, id uuid.UUID
 		return err
 	}
 
+	return r.delete(ctx, doc)
+}
+
+// DeleteTemplateImage deletes an attachment owned by an entity template rather
+// than an entity. Group ownership is validated through the template edge, since
+// template images intentionally have no entity edge.
+func (r *AttachmentRepo) DeleteTemplateImage(ctx context.Context, gid uuid.UUID, id uuid.UUID) error {
+	ctx, span := otel.Tracer("data").Start(ctx, "repo.AttachmentRepo.DeleteTemplateImage")
+	defer span.End()
+
+	doc, err := r.db.Attachment.Query().
+		Where(
+			attachment.ID(id),
+			attachment.HasEntityTemplateWith(entitytemplate.HasGroupWith(group.ID(gid))),
+		).
+		Only(ctx)
+	if err != nil {
+		return err
+	}
+
+	return r.delete(ctx, doc)
+}
+
+// delete removes an attachment row, along with its thumbnail, and the files
+// backing them once no other attachment references the same path. Callers are
+// responsible for validating group ownership before calling.
+//
+// Paths are shared rather than copied when the same bytes are stored twice
+// (entity template default images, duplicated entities), so every file removal
+// is guarded by a reference count over the path.
+func (r *AttachmentRepo) delete(ctx context.Context, doc *ent.Attachment) error {
+	id := doc.ID
+
 	if isExternalLink(doc.MimeType) {
 		return r.db.Attachment.DeleteOneID(id).Exec(ctx)
 	}
 
-	all, err := r.db.Attachment.Query().Where(attachment.Path(doc.Path)).All(ctx)
-	if err != nil {
+	// The thumbnail edge is one-to-one, so the thumbnail row always goes with
+	// the attachment being deleted, even when the source file lives on for
+	// other attachments.
+	thumb, err := doc.QueryThumbnail().First(ctx)
+	if err != nil && !ent.IsNotFound(err) {
+		log.Err(err).Msg("failed to query thumbnail for attachment")
 		return err
 	}
-	// If this is the last attachment for this path, delete the file
-	if len(all) == 1 {
-		thumb, err := doc.QueryThumbnail().First(ctx)
-		if err != nil && !ent.IsNotFound(err) {
-			log.Err(err).Msg("failed to query thumbnail for attachment")
+	if thumb != nil {
+		if err := r.deleteFileIfUnreferenced(ctx, thumb.Path, thumb.ID); err != nil {
 			return err
 		}
-		if thumb != nil {
-			thumbBucket, err := blob.OpenBucket(ctx, r.GetConnString())
-			if err != nil {
-				log.Err(err).Msg("failed to open bucket for thumbnail deletion")
-				return err
-			}
-			err = thumbBucket.Delete(ctx, r.fullPath(thumb.Path))
-			if err != nil {
-				return err
-			}
-			_ = doc.Update().SetNillableThumbnailID(nil).SaveX(ctx)
-			_ = thumb.Update().SetNillableThumbnailID(nil).SaveX(ctx)
-			err = r.db.Attachment.DeleteOneID(thumb.ID).Exec(ctx)
-			if err != nil {
-				return err
-			}
-		}
-		bucket, err := blob.OpenBucket(ctx, r.GetConnString())
-		if err != nil {
-			log.Err(err).Msg("failed to open bucket")
+		if err := doc.Update().ClearThumbnail().Exec(ctx); err != nil {
+			log.Err(err).Msg("failed to clear thumbnail edge")
 			return err
 		}
-		defer func(bucket *blob.Bucket) {
-			err := bucket.Close()
-			if err != nil {
-				log.Err(err).Msg("failed to close bucket")
-			}
-		}(bucket)
-		err = bucket.Delete(ctx, r.fullPath(doc.Path))
-		if err != nil {
+		if err := r.db.Attachment.DeleteOneID(thumb.ID).Exec(ctx); err != nil {
 			return err
 		}
 	}
 
+	if err := r.deleteFileIfUnreferenced(ctx, doc.Path, doc.ID); err != nil {
+		return err
+	}
+
 	return r.db.Attachment.DeleteOneID(id).Exec(ctx)
+}
+
+// deleteFileIfUnreferenced removes the stored file at path when the attachment
+// about to be deleted is the last one pointing at it.
+func (r *AttachmentRepo) deleteFileIfUnreferenced(ctx context.Context, path string, excludeID uuid.UUID) error {
+	others, err := r.db.Attachment.Query().
+		Where(
+			attachment.Path(path),
+			attachment.IDNEQ(excludeID),
+		).
+		Count(ctx)
+	if err != nil {
+		return err
+	}
+	if others > 0 {
+		return nil
+	}
+
+	bucket, err := blob.OpenBucket(ctx, r.GetConnString())
+	if err != nil {
+		log.Err(err).Msg("failed to open bucket")
+		return err
+	}
+	defer func(bucket *blob.Bucket) {
+		if err := bucket.Close(); err != nil {
+			log.Err(err).Msg("failed to close bucket")
+		}
+	}(bucket)
+
+	return bucket.Delete(ctx, r.fullPath(path))
 }
 
 func (r *AttachmentRepo) Rename(ctx context.Context, gid uuid.UUID, id uuid.UUID, title string) (*ent.Attachment, error) {

--- a/backend/internal/data/repo/repo_item_attachments.go
+++ b/backend/internal/data/repo/repo_item_attachments.go
@@ -646,8 +646,11 @@ func (r *AttachmentRepo) DeleteTemplateImage(ctx context.Context, gid uuid.UUID,
 // responsible for validating group ownership before calling.
 //
 // Paths are shared rather than copied when the same bytes are stored twice
-// (entity template default images, duplicated entities), so every file removal
-// is guarded by a reference count over the path.
+// (entity template default images, duplicated entities), so a file is only
+// removed once no row still references its path. The rows are deleted and the
+// references counted in one transaction, before any file is touched, so the
+// count is taken against committed state rather than a snapshot that a
+// concurrent writer can invalidate.
 func (r *AttachmentRepo) delete(ctx context.Context, doc *ent.Attachment) error {
 	id := doc.ID
 
@@ -663,39 +666,70 @@ func (r *AttachmentRepo) delete(ctx context.Context, doc *ent.Attachment) error 
 		log.Err(err).Msg("failed to query thumbnail for attachment")
 		return err
 	}
-	if thumb != nil {
-		if err := r.deleteFileIfUnreferenced(ctx, thumb.Path, thumb.ID); err != nil {
-			return err
-		}
-		if err := doc.Update().ClearThumbnail().Exec(ctx); err != nil {
-			log.Err(err).Msg("failed to clear thumbnail edge")
-			return err
-		}
-		if err := r.db.Attachment.DeleteOneID(thumb.ID).Exec(ctx); err != nil {
-			return err
-		}
-	}
 
-	if err := r.deleteFileIfUnreferenced(ctx, doc.Path, doc.ID); err != nil {
-		return err
-	}
-
-	return r.db.Attachment.DeleteOneID(id).Exec(ctx)
-}
-
-// deleteFileIfUnreferenced removes the stored file at path when the attachment
-// about to be deleted is the last one pointing at it.
-func (r *AttachmentRepo) deleteFileIfUnreferenced(ctx context.Context, path string, excludeID uuid.UUID) error {
-	others, err := r.db.Attachment.Query().
-		Where(
-			attachment.Path(path),
-			attachment.IDNEQ(excludeID),
-		).
-		Count(ctx)
+	tx, err := r.db.Tx(ctx)
 	if err != nil {
 		return err
 	}
-	if others > 0 {
+	committed := false
+	defer func() {
+		if !committed {
+			if err := tx.Rollback(); err != nil {
+				log.Warn().Err(err).Msg("failed to roll back attachment deletion")
+			}
+		}
+	}()
+
+	if thumb != nil {
+		if err := tx.Attachment.UpdateOneID(id).ClearThumbnail().Exec(ctx); err != nil {
+			log.Err(err).Msg("failed to clear thumbnail edge")
+			return err
+		}
+		if err := tx.Attachment.DeleteOneID(thumb.ID).Exec(ctx); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Attachment.DeleteOneID(id).Exec(ctx); err != nil {
+		return err
+	}
+
+	// Counted after the rows are gone, so a path with no remaining rows is
+	// genuinely unreferenced rather than merely unreferenced by this caller.
+	orphaned := make([]string, 0, 2)
+	for _, path := range dedupePaths(doc, thumb) {
+		remaining, err := tx.Attachment.Query().Where(attachment.Path(path)).Count(ctx)
+		if err != nil {
+			return err
+		}
+		if remaining == 0 {
+			orphaned = append(orphaned, path)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	committed = true
+
+	return r.deleteFiles(ctx, orphaned)
+}
+
+// dedupePaths returns the distinct stored paths of an attachment and its
+// thumbnail. Identical content dedupes onto one path, so the two can coincide.
+func dedupePaths(doc *ent.Attachment, thumb *ent.Attachment) []string {
+	paths := []string{doc.Path}
+	if thumb != nil && thumb.Path != doc.Path {
+		paths = append(paths, thumb.Path)
+	}
+	return paths
+}
+
+// deleteFiles removes stored files that no attachment row references any more.
+// A failure here leaves an unreferenced file behind rather than failing the
+// deletion the caller already committed.
+func (r *AttachmentRepo) deleteFiles(ctx context.Context, paths []string) error {
+	if len(paths) == 0 {
 		return nil
 	}
 
@@ -710,7 +744,14 @@ func (r *AttachmentRepo) deleteFileIfUnreferenced(ctx context.Context, path stri
 		}
 	}(bucket)
 
-	return bucket.Delete(ctx, r.fullPath(path))
+	for _, path := range paths {
+		if err := bucket.Delete(ctx, r.fullPath(path)); err != nil {
+			log.Err(err).Str("path", path).Msg("failed to delete unreferenced file")
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (r *AttachmentRepo) Rename(ctx context.Context, gid uuid.UUID, id uuid.UUID, title string) (*ent.Attachment, error) {

--- a/backend/internal/data/repo/repo_item_attachments_test.go
+++ b/backend/internal/data/repo/repo_item_attachments_test.go
@@ -1,7 +1,9 @@
 package repo
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"strings"
@@ -530,4 +532,71 @@ func TestAttachmentRepo_DeleteSharedPathKeepsFileAndDropsThumbnail(t *testing.T)
 	sharedFile := filepath.Join(os.TempDir(), tRepos.Attachments.GetFullPath(second.Path))
 	_, err = os.Stat(sharedFile)
 	require.NoError(t, err, "shared file was deleted while another attachment references it")
+}
+
+// tinyPNG is a 1x1 image, decodable so thumbnail creation reaches the edge
+// write rather than bailing out at the decode step.
+const tinyPNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+// thumbnailRepo returns an attachment repository with thumbnail generation
+// switched on. The shared test harness disables it, which makes CreateThumbnail
+// exit before it does any real work.
+func thumbnailRepo() *AttachmentRepo {
+	return &AttachmentRepo{
+		db:         tClient,
+		storage:    config.Storage{PrefixPath: "/", ConnString: "file://" + os.TempDir()},
+		pubSubConn: "mem://{{ .Topic }}",
+		thumbnail:  config.Thumbnail{Enabled: true, Width: 50, Height: 50},
+	}
+}
+
+func TestAttachmentRepo_CreateThumbnailForDeletedAttachment(t *testing.T) {
+	ctx := context.Background()
+	e := useEntities(t, 1)[0]
+	repo := thumbnailRepo()
+
+	png, err := base64.StdEncoding.DecodeString(tinyPNG)
+	require.NoError(t, err)
+
+	// Two attachments with the same bytes share one stored path, so deleting
+	// the first leaves the file in place for the thumbnail worker to read.
+	deleted, err := repo.Create(ctx, e.ID, ItemCreateAttachment{
+		Title:   "gone.png",
+		Content: bytes.NewReader(png),
+	}, attachment.TypePhoto, false)
+	require.NoError(t, err)
+
+	kept, err := repo.Create(ctx, e.ID, ItemCreateAttachment{
+		Title:   "kept.png",
+		Content: bytes.NewReader(png),
+	}, attachment.TypePhoto, false)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = repo.Delete(context.Background(), tGroup.ID, kept.ID)
+	})
+	require.Equal(t, deleted.Path, kept.Path)
+
+	require.NoError(t, repo.Delete(ctx, tGroup.ID, deleted.ID))
+
+	// The worker can pick the request up after the attachment is deleted, which
+	// must be a no-op rather than a foreign key failure. This pins that
+	// behaviour down; it does not reproduce the failure that motivated the
+	// guard, which needs the concurrency of a running server (the edge write
+	// failing and leaving the transaction open, which on SQLite holds the write
+	// lock so every later write fails with SQLITE_BUSY).
+	err = repo.CreateThumbnail(ctx, tGroup.ID, deleted.ID, "gone.png", deleted.Path)
+	require.NoError(t, err)
+
+	// No thumbnail row should have been left behind for the deleted attachment.
+	orphans, err := tClient.Attachment.Query().
+		Where(attachment.TypeEQ(attachment.TypeThumbnail), attachment.Title("gone.png-thumb")).
+		Count(ctx)
+	require.NoError(t, err)
+	require.Zero(t, orphans, "a thumbnail row was created for a deleted attachment")
+
+	// Proves the write lock was released. Updates a row rather than creating
+	// one so the check leaves no rows behind for other tests to count.
+	require.NoError(t,
+		tClient.Attachment.UpdateOneID(kept.ID).SetTitle("kept-after-thumbnail.png").Exec(ctx),
+		"database still locked after a thumbnail request for a deleted attachment")
 }

--- a/backend/internal/data/repo/repo_item_attachments_test.go
+++ b/backend/internal/data/repo/repo_item_attachments_test.go
@@ -472,3 +472,62 @@ func TestAttachmentRepo_MigrateLegacyFlatPaths_TargetExistsKeepsSource(t *testin
 	require.NoError(t, err)
 	assert.Equal(t, "new", string(dst), "target file should not be overwritten")
 }
+
+func TestAttachmentRepo_DeleteSharedPathKeepsFileAndDropsThumbnail(t *testing.T) {
+	ctx := context.Background()
+	e := useEntities(t, 1)[0]
+
+	// Two attachments with identical content dedupe onto one stored path, which
+	// is also what entity template default images produce.
+	first, err := tRepos.Attachments.Create(ctx, e.ID, ItemCreateAttachment{
+		Title:   "shared.png",
+		Content: strings.NewReader("shared bytes"),
+	}, attachment.TypePhoto, false)
+	require.NoError(t, err)
+
+	second, err := tRepos.Attachments.Create(ctx, e.ID, ItemCreateAttachment{
+		Title:   "shared.png",
+		Content: strings.NewReader("shared bytes"),
+	}, attachment.TypePhoto, false)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tRepos.Attachments.Delete(ctx, tGroup.ID, second.ID)
+	})
+	require.Equal(t, first.Path, second.Path)
+
+	// Give the first attachment a thumbnail. The harness runs with thumbnail
+	// generation disabled, so build the row the generator would have written.
+	grp, err := tClient.Group.Get(ctx, tGroup.ID)
+	require.NoError(t, err)
+	thumbUpload, err := tRepos.Attachments.UploadFile(ctx, grp, ItemCreateAttachment{
+		Title:   "shared-thumb.png",
+		Content: strings.NewReader("thumb bytes"),
+	})
+	require.NoError(t, err)
+
+	thumb, err := tClient.Attachment.Create().
+		SetID(uuid.New()).
+		SetType(attachment.TypeThumbnail).
+		SetTitle("shared.png-thumb").
+		SetPath(thumbUpload.Path).
+		SetMimeType(thumbUpload.ContentType).
+		Save(ctx)
+	require.NoError(t, err)
+	require.NoError(t, tClient.Attachment.UpdateOneID(first.ID).SetThumbnail(thumb).Exec(ctx))
+
+	require.NoError(t, tRepos.Attachments.Delete(ctx, tGroup.ID, first.ID))
+
+	// The thumbnail row belongs to the deleted attachment alone and must go
+	// with it, even though the source path is still in use.
+	_, err = tClient.Attachment.Get(ctx, thumb.ID)
+	require.Error(t, err, "thumbnail row was orphaned")
+
+	thumbFile := filepath.Join(os.TempDir(), tRepos.Attachments.GetFullPath(thumbUpload.Path))
+	_, err = os.Stat(thumbFile)
+	require.Error(t, err, "thumbnail file was orphaned")
+
+	// The shared source file must survive for the remaining attachment.
+	sharedFile := filepath.Join(os.TempDir(), tRepos.Attachments.GetFullPath(second.Path))
+	_, err = os.Stat(sharedFile)
+	require.NoError(t, err, "shared file was deleted while another attachment references it")
+}

--- a/backend/internal/data/repo/repos_all.go
+++ b/backend/internal/data/repo/repos_all.go
@@ -34,7 +34,7 @@ func New(db *ent.Client, bus *eventbus.EventBus, storage config.Storage, pubSubC
 		Groups:              NewGroupRepository(db, attachments),
 		Entities:            &EntityRepository{db, bus, attachments},
 		EntityTypes:         &EntityTypeRepository{db, bus},
-		EntityTemplates:     &EntityTemplatesRepository{db, bus},
+		EntityTemplates:     &EntityTemplatesRepository{db, bus, attachments},
 		Tags:                &TagRepository{db, bus},
 		Attachments:         attachments,
 		MaintEntry:          &MaintenanceEntryRepository{db},

--- a/docs/public/api/openapi-3.0.json
+++ b/docs/public/api/openapi-3.0.json
@@ -2823,6 +2823,148 @@
                 }
             }
         },
+        "/v1/templates/{id}/image": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "tags": [
+                    "Entity Templates"
+                ],
+                "summary": "Get Entity Template Default Image",
+                "parameters": [
+                    {
+                        "description": "Template ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/octet-stream": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Stores an image on the template. Entities created from the template",
+                "tags": [
+                    "Entity Templates"
+                ],
+                "summary": "Set Entity Template Default Image",
+                "parameters": [
+                    {
+                        "description": "Template ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "file": {
+                                        "description": "Image file",
+                                        "type": "string",
+                                        "format": "binary"
+                                    },
+                                    "name": {
+                                        "description": "name of the file including extension",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "file",
+                                    "name"
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/repo.EntityTemplateOut"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/validate.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Removes the template's default image. Entities already created from",
+                "tags": [
+                    "Entity Templates"
+                ],
+                "summary": "Delete Entity Template Default Image",
+                "parameters": [
+                    {
+                        "description": "Template ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/repo.EntityTemplateOut"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v1/users/change-password": {
             "put": {
                 "security": [
@@ -3606,6 +3748,14 @@
                             }
                         ]
                     },
+                    "entity_template": {
+                        "description": "EntityTemplate holds the value of the entity_template edge.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ent.EntityTemplate"
+                            }
+                        ]
+                    },
                     "thumbnail": {
                         "description": "Thumbnail holds the value of the thumbnail edge.",
                         "allOf": [
@@ -4049,6 +4199,14 @@
             "ent.EntityTemplateEdges": {
                 "type": "object",
                 "properties": {
+                    "default_image": {
+                        "description": "DefaultImage holds the value of the default_image edge.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ent.Attachment"
+                            }
+                        ]
+                    },
                     "fields": {
                         "description": "Fields holds the value of the fields edge.",
                         "type": "array",
@@ -5496,6 +5654,14 @@
                     "defaultDescription": {
                         "type": "string"
                     },
+                    "defaultImage": {
+                        "description": "Default image applied to entities created from this template",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/repo.TemplateImageSummary"
+                            }
+                        ]
+                    },
                     "defaultInsured": {
                         "type": "boolean"
                     },
@@ -6362,6 +6528,24 @@
                         "type": "string"
                     },
                     "type": {
+                        "type": "string"
+                    }
+                }
+            },
+            "repo.TemplateImageSummary": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "mimeType": {
+                        "type": "string"
+                    },
+                    "thumbnailId": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "title": {
                         "type": "string"
                     }
                 }

--- a/docs/public/api/openapi-3.0.json
+++ b/docs/public/api/openapi-3.0.json
@@ -5660,7 +5660,8 @@
                             {
                                 "$ref": "#/components/schemas/repo.TemplateImageSummary"
                             }
-                        ]
+                        ],
+                        "nullable": true
                     },
                     "defaultInsured": {
                         "type": "boolean"

--- a/docs/public/api/openapi-3.0.yaml
+++ b/docs/public/api/openapi-3.0.yaml
@@ -3596,6 +3596,7 @@ components:
           description: Default image applied to entities created from this template
           allOf:
             - $ref: "#/components/schemas/repo.TemplateImageSummary"
+          nullable: true
         defaultInsured:
           type: boolean
         defaultLifetimeWarranty:

--- a/docs/public/api/openapi-3.0.yaml
+++ b/docs/public/api/openapi-3.0.yaml
@@ -1675,6 +1675,93 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/repo.EntityOut"
+  "/v1/templates/{id}/image":
+    get:
+      security:
+        - Bearer: []
+      tags:
+        - Entity Templates
+      summary: Get Entity Template Default Image
+      parameters:
+        - description: Template ID
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+    post:
+      security:
+        - Bearer: []
+      description: Stores an image on the template. Entities created from the template
+      tags:
+        - Entity Templates
+      summary: Set Entity Template Default Image
+      parameters:
+        - description: Template ID
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  description: Image file
+                  type: string
+                  format: binary
+                name:
+                  description: name of the file including extension
+                  type: string
+              required:
+                - file
+                - name
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/repo.EntityTemplateOut"
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/validate.ErrorResponse"
+    delete:
+      security:
+        - Bearer: []
+      description: Removes the template's default image. Entities already created from
+      tags:
+        - Entity Templates
+      summary: Delete Entity Template Default Image
+      parameters:
+        - description: Template ID
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/repo.EntityTemplateOut"
   /v1/users/change-password:
     put:
       security:
@@ -2171,6 +2258,10 @@ components:
           description: Entity holds the value of the entity edge.
           allOf:
             - $ref: "#/components/schemas/ent.Entity"
+        entity_template:
+          description: EntityTemplate holds the value of the entity_template edge.
+          allOf:
+            - $ref: "#/components/schemas/ent.EntityTemplate"
         thumbnail:
           description: Thumbnail holds the value of the thumbnail edge.
           allOf:
@@ -2485,6 +2576,10 @@ components:
     ent.EntityTemplateEdges:
       type: object
       properties:
+        default_image:
+          description: DefaultImage holds the value of the default_image edge.
+          allOf:
+            - $ref: "#/components/schemas/ent.Attachment"
         fields:
           description: Fields holds the value of the fields edge.
           type: array
@@ -3497,6 +3592,10 @@ components:
           type: string
         defaultDescription:
           type: string
+        defaultImage:
+          description: Default image applied to entities created from this template
+          allOf:
+            - $ref: "#/components/schemas/repo.TemplateImageSummary"
         defaultInsured:
           type: boolean
         defaultLifetimeWarranty:
@@ -4089,6 +4188,18 @@ components:
         timeValue:
           type: string
         type:
+          type: string
+    repo.TemplateImageSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        mimeType:
+          type: string
+        thumbnailId:
+          type: string
+          nullable: true
+        title:
           type: string
     repo.TemplateLocationSummary:
       type: object

--- a/docs/public/api/swagger-2.0.json
+++ b/docs/public/api/swagger-2.0.json
@@ -5396,7 +5396,8 @@
                         {
                             "$ref": "#/definitions/repo.TemplateImageSummary"
                         }
-                    ]
+                    ],
+                    "x-nullable": true
                 },
                 "defaultInsured": {
                     "type": "boolean"

--- a/docs/public/api/swagger-2.0.json
+++ b/docs/public/api/swagger-2.0.json
@@ -2620,6 +2620,126 @@
                 }
             }
         },
+        "/v1/templates/{id}/image": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "Entity Templates"
+                ],
+                "summary": "Get Entity Template Default Image",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Template ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "file"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Stores an image on the template. Entities created from the template",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Entity Templates"
+                ],
+                "summary": "Set Entity Template Default Image",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Template ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "Image file",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "name of the file including extension",
+                        "name": "name",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/repo.EntityTemplateOut"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/validate.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Removes the template's default image. Entities already created from",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Entity Templates"
+                ],
+                "summary": "Delete Entity Template Default Image",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Template ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/repo.EntityTemplateOut"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/users/change-password": {
             "put": {
                 "security": [
@@ -3364,6 +3484,14 @@
                         }
                     ]
                 },
+                "entity_template": {
+                    "description": "EntityTemplate holds the value of the entity_template edge.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/ent.EntityTemplate"
+                        }
+                    ]
+                },
                 "thumbnail": {
                     "description": "Thumbnail holds the value of the thumbnail edge.",
                     "allOf": [
@@ -3807,6 +3935,14 @@
         "ent.EntityTemplateEdges": {
             "type": "object",
             "properties": {
+                "default_image": {
+                    "description": "DefaultImage holds the value of the default_image edge.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/ent.Attachment"
+                        }
+                    ]
+                },
                 "fields": {
                     "description": "Fields holds the value of the fields edge.",
                     "type": "array",
@@ -5254,6 +5390,14 @@
                 "defaultDescription": {
                     "type": "string"
                 },
+                "defaultImage": {
+                    "description": "Default image applied to entities created from this template",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/repo.TemplateImageSummary"
+                        }
+                    ]
+                },
                 "defaultInsured": {
                     "type": "boolean"
                 },
@@ -6120,6 +6264,24 @@
                     "type": "string"
                 },
                 "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "repo.TemplateImageSummary": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "mimeType": {
+                    "type": "string"
+                },
+                "thumbnailId": {
+                    "type": "string",
+                    "x-nullable": true
+                },
+                "title": {
                     "type": "string"
                 }
             }

--- a/docs/public/api/swagger-2.0.yaml
+++ b/docs/public/api/swagger-2.0.yaml
@@ -120,6 +120,10 @@ definitions:
         allOf:
         - $ref: '#/definitions/ent.Entity'
         description: Entity holds the value of the entity edge.
+      entity_template:
+        allOf:
+        - $ref: '#/definitions/ent.EntityTemplate'
+        description: EntityTemplate holds the value of the entity_template edge.
       thumbnail:
         allOf:
         - $ref: '#/definitions/ent.Attachment'
@@ -430,6 +434,10 @@ definitions:
     type: object
   ent.EntityTemplateEdges:
     properties:
+      default_image:
+        allOf:
+        - $ref: '#/definitions/ent.Attachment'
+        description: DefaultImage holds the value of the default_image edge.
       fields:
         description: Fields holds the value of the fields edge.
         items:
@@ -1431,6 +1439,10 @@ definitions:
         type: string
       defaultDescription:
         type: string
+      defaultImage:
+        allOf:
+        - $ref: '#/definitions/repo.TemplateImageSummary'
+        description: Default image applied to entities created from this template
       defaultInsured:
         type: boolean
       defaultLifetimeWarranty:
@@ -2023,6 +2035,18 @@ definitions:
       timeValue:
         type: string
       type:
+        type: string
+    type: object
+  repo.TemplateImageSummary:
+    properties:
+      id:
+        type: string
+      mimeType:
+        type: string
+      thumbnailId:
+        type: string
+        x-nullable: true
+      title:
         type: string
     type: object
   repo.TemplateLocationSummary:
@@ -3969,6 +3993,83 @@ paths:
       security:
       - Bearer: []
       summary: Create Entity from Template
+      tags:
+      - Entity Templates
+  /v1/templates/{id}/image:
+    delete:
+      description: Removes the template's default image. Entities already created
+        from
+      parameters:
+      - description: Template ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/repo.EntityTemplateOut'
+      security:
+      - Bearer: []
+      summary: Delete Entity Template Default Image
+      tags:
+      - Entity Templates
+    get:
+      parameters:
+      - description: Template ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/octet-stream
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: file
+      security:
+      - Bearer: []
+      summary: Get Entity Template Default Image
+      tags:
+      - Entity Templates
+    post:
+      consumes:
+      - multipart/form-data
+      description: Stores an image on the template. Entities created from the template
+      parameters:
+      - description: Template ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Image file
+        in: formData
+        name: file
+        required: true
+        type: file
+      - description: name of the file including extension
+        in: formData
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/repo.EntityTemplateOut'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/validate.ErrorResponse'
+      security:
+      - Bearer: []
+      summary: Set Entity Template Default Image
       tags:
       - Entity Templates
   /v1/users/change-password:

--- a/docs/public/api/swagger-2.0.yaml
+++ b/docs/public/api/swagger-2.0.yaml
@@ -1443,6 +1443,7 @@ definitions:
         allOf:
         - $ref: '#/definitions/repo.TemplateImageSummary'
         description: Default image applied to entities created from this template
+        x-nullable: true
       defaultInsured:
         type: boolean
       defaultLifetimeWarranty:

--- a/docs/src/content/docs/en/user-guide/items.mdx
+++ b/docs/src/content/docs/en/user-guide/items.mdx
@@ -50,7 +50,7 @@ Templates hold the values you want to reuse across similar items, so you don't h
 item from a template, the template's defaults are pre-filled into the form.
 
 ### Setting a Default Image
-A template can carry a default image. Items created from that template afterwards get it as their primary photo, so a
+A template can carry a default image. Items created from that template afterward get it as their primary photo, so a
 set of similar items can share a picture without uploading it once per item.
 
 <Steps>

--- a/docs/src/content/docs/en/user-guide/items.mdx
+++ b/docs/src/content/docs/en/user-guide/items.mdx
@@ -44,3 +44,28 @@ To delete an item, follow these steps:
     2. Click on "Delete" in the upper right corner of the item screen.
     3. Click "Delete" to confirm deletion.
 </Steps>
+
+## Templates
+Templates hold the values you want to reuse across similar items, so you don't have to retype them. When you create an
+item from a template, the template's defaults are pre-filled into the form.
+
+### Setting a Default Image
+A template can carry a default image. Items created from that template afterwards get it as their primary photo, so a
+set of similar items can share a picture without uploading it once per item.
+
+<Steps>
+    1. Open the template you wish to change from the Templates page.
+    2. Under "Default Image", click "Upload image" (or "Replace image" if the template already has one).
+    3. Choose an image file. It is applied immediately.
+</Steps>
+
+You can also set the image while creating a template, in the create dialog.
+
+A few things worth knowing:
+
+- The image applies to items created **after** it is set. Items created earlier are left alone.
+- The image is stored once and shared by every item created from the template, so it does not consume extra storage per
+  item.
+- Removing an item's photo, or the template's image, does not affect the others. The stored file is kept as long as
+  anything still uses it.
+- Click "Remove image" on the template to clear it. Items already created from the template keep their photo.

--- a/frontend/components/Template/CreateModal.vue
+++ b/frontend/components/Template/CreateModal.vue
@@ -62,6 +62,33 @@
       </div>
 
       <Separator class="my-2" />
+      <div class="flex flex-col gap-2">
+        <h3 class="text-sm font-medium">{{ $t("components.template.form.default_image") }}</h3>
+        <p class="text-xs text-muted-foreground">{{ $t("components.template.form.default_image_hint") }}</p>
+        <div class="flex items-center gap-3">
+          <img
+            v-if="imagePreview"
+            :src="imagePreview"
+            :alt="$t('components.template.form.default_image')"
+            class="size-16 rounded border object-cover"
+          />
+          <Button type="button" size="sm" variant="outline" @click="imageInput?.click()">
+            {{ image ? $t("components.template.form.replace_image") : $t("components.template.form.upload_image") }}
+          </Button>
+          <Button v-if="image" type="button" size="sm" variant="ghost" @click="clearImage">
+            {{ $t("components.template.form.remove_image") }}
+          </Button>
+          <input
+            ref="imageInput"
+            type="file"
+            class="hidden"
+            accept="image/png,image/jpeg,image/gif,image/avif,image/webp"
+            @change="onImageSelected"
+          />
+        </div>
+      </div>
+
+      <Separator class="my-2" />
       <div class="flex items-center justify-between">
         <h3 class="text-sm font-medium">{{ $t("components.template.form.custom_fields") }}</h3>
         <Button type="button" size="sm" variant="outline" @click="addField">
@@ -145,6 +172,31 @@
 
   const NIL_UUID = "00000000-0000-0000-0000-000000000000";
 
+  const image = ref<File | null>(null);
+  const imagePreview = ref<string | null>(null);
+  const imageInput = ref<HTMLInputElement | null>(null);
+
+  function onImageSelected(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = "";
+    if (!file) return;
+
+    clearImage();
+    image.value = file;
+    imagePreview.value = URL.createObjectURL(file);
+  }
+
+  function clearImage() {
+    if (imagePreview.value) {
+      URL.revokeObjectURL(imagePreview.value);
+    }
+    image.value = null;
+    imagePreview.value = null;
+  }
+
+  onBeforeUnmount(clearImage);
+
   function addField() {
     form.fields.push({ id: NIL_UUID, name: "", type: "text", textValue: "" });
   }
@@ -170,6 +222,7 @@
       includeSoldFields: false,
       fields: [],
     });
+    clearImage();
     loading.value = false;
   }
 
@@ -202,11 +255,20 @@
       fields: form.fields,
     };
 
-    const { error } = await api.templates.create(createData);
+    const { error, data } = await api.templates.create(createData);
     if (error) {
       toast.error(t("components.template.toast.create_failed"));
       loading.value = false;
       return;
+    }
+
+    // The image needs a template to belong to, so it follows the create call.
+    // A failure here leaves a usable template, so it warns rather than aborts.
+    if (image.value && data) {
+      const { error: imageError } = await api.templates.setImage(data.id, image.value, image.value.name);
+      if (imageError) {
+        toast.error(t("components.template.toast.image_update_failed"));
+      }
     }
 
     toast.success(t("components.template.toast.created"));

--- a/frontend/lib/api/__test__/user/templates.test.ts
+++ b/frontend/lib/api/__test__/user/templates.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import type { EntityTemplateOut } from "../../types/data-contracts";
+import type { EntityOut, EntityTemplateCreateItemRequest, EntityTemplateOut } from "../../types/data-contracts";
 import type { UserClient } from "../../user";
 import { factories } from "../factories";
 import { sharedUserClient } from "../test-utils";
@@ -310,6 +310,35 @@ describe("template default image", () => {
     return new Blob([bytes], { type: "image/png" });
   }
 
+  /**
+   * useImageLocation creates a location to hold items created from a template,
+   * and returns it alongside the group's item entity type. Locations must carry
+   * the location entity type; without it the backend defaults new entities to
+   * the item type.
+   */
+  async function useImageLocation(api: UserClient): Promise<[EntityOut, string]> {
+    const { data: entityTypes } = await api.entityTypes.getAll();
+    const locationType = entityTypes.find(t => t.isLocation);
+    const itemType = entityTypes.find(t => !t.isLocation);
+    expect(locationType).toBeTruthy();
+    expect(itemType).toBeTruthy();
+
+    const { response, data } = await api.items.createLocation({
+      parentId: null,
+      name: "__test__.template_image.location",
+      description: "",
+      entityTypeId: locationType!.id,
+      quantity: 1,
+      tagIds: [],
+    });
+    expect(response.status).toBe(201);
+    return [data, itemType!.id];
+  }
+
+  function createItemRequest(parentId: string, entityTypeId: string, name: string): EntityTemplateCreateItemRequest {
+    return { name, description: "", parentId, entityTypeId, tagIds: [], quantity: 1 };
+  }
+
   test("user should be able to set and remove a template default image", async () => {
     const api = await sharedUserClient();
 
@@ -336,8 +365,7 @@ describe("template default image", () => {
   test("template default image is applied to items created from the template", async () => {
     const api = await sharedUserClient();
 
-    const { response: locResponse, data: location } = await api.items.createLocation(factories.location());
-    expect(locResponse.status).toBe(201);
+    const [location, itemTypeId] = await useImageLocation(api);
 
     const { response: createResponse, data: template } = await api.templates.create(factories.template());
     expect(createResponse.status).toBe(201);
@@ -345,12 +373,10 @@ describe("template default image", () => {
     const { response: imageResponse } = await api.templates.setImage(template.id, pngBlob(), "default.png");
     expect(imageResponse.status).toBe(200);
 
-    const { response, data: item } = await api.templates.createItem(template.id, {
-      name: "item-from-template",
-      description: "",
-      parentId: location.id,
-      tagIds: [],
-    });
+    const { response, data: item } = await api.templates.createItem(
+      template.id,
+      createItemRequest(location.id, itemTypeId, "item-from-template")
+    );
     expect(response.status).toBe(201);
     expect(item.attachments).toHaveLength(1);
     expect(item.attachments[0]?.type).toBe("photo");
@@ -373,17 +399,14 @@ describe("template default image", () => {
   test("items created before an image is set are left alone", async () => {
     const api = await sharedUserClient();
 
-    const { response: locResponse, data: location } = await api.items.createLocation(factories.location());
-    expect(locResponse.status).toBe(201);
+    const [location, itemTypeId] = await useImageLocation(api);
 
     const { data: template } = await api.templates.create(factories.template());
 
-    const { response, data: item } = await api.templates.createItem(template.id, {
-      name: "item-before-image",
-      description: "",
-      parentId: location.id,
-      tagIds: [],
-    });
+    const { response, data: item } = await api.templates.createItem(
+      template.id,
+      createItemRequest(location.id, itemTypeId, "item-before-image")
+    );
     expect(response.status).toBe(201);
     expect(item.attachments).toHaveLength(0);
 

--- a/frontend/lib/api/__test__/user/templates.test.ts
+++ b/frontend/lib/api/__test__/user/templates.test.ts
@@ -295,3 +295,105 @@ describe("templates with location and tags", () => {
     await api.items.deleteLocation(location.id);
   });
 });
+
+describe("template default image", () => {
+  // A 1x1 PNG, small enough to inline and a real image so the upload passes
+  // the image-type check.
+  const PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+  function pngBlob(): Blob {
+    const binary = atob(PNG_BASE64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return new Blob([bytes], { type: "image/png" });
+  }
+
+  test("user should be able to set and remove a template default image", async () => {
+    const api = await sharedUserClient();
+
+    const { response: createResponse, data: template } = await api.templates.create(factories.template());
+    expect(createResponse.status).toBe(201);
+
+    const { response, data } = await api.templates.setImage(template.id, pngBlob(), "default.png");
+    expect(response.status).toBe(200);
+    expect(data.defaultImage).toBeTruthy();
+    expect(data.defaultImage?.title).toBe("default.png");
+    expect(data.defaultImage?.mimeType).toBe("image/png");
+
+    // The image survives a round trip
+    const { data: fetched } = await api.templates.get(template.id);
+    expect(fetched.defaultImage?.id).toBe(data.defaultImage?.id);
+
+    const { response: removeResponse, data: removed } = await api.templates.deleteImage(template.id);
+    expect(removeResponse.status).toBe(200);
+    expect(removed.defaultImage).toBeNull();
+
+    await api.templates.delete(template.id);
+  });
+
+  test("template default image is applied to items created from the template", async () => {
+    const api = await sharedUserClient();
+
+    const { response: locResponse, data: location } = await api.items.createLocation(factories.location());
+    expect(locResponse.status).toBe(201);
+
+    const { response: createResponse, data: template } = await api.templates.create(factories.template());
+    expect(createResponse.status).toBe(201);
+
+    const { response: imageResponse } = await api.templates.setImage(template.id, pngBlob(), "default.png");
+    expect(imageResponse.status).toBe(200);
+
+    const { response, data: item } = await api.templates.createItem(template.id, {
+      name: "item-from-template",
+      description: "",
+      parentId: location.id,
+      tagIds: [],
+    });
+    expect(response.status).toBe(201);
+    expect(item.attachments).toHaveLength(1);
+    expect(item.attachments[0]?.type).toBe("photo");
+    expect(item.attachments[0]?.primary).toBe(true);
+    expect(item.imageId).toBe(item.attachments[0]?.id);
+
+    // Removing the item's copy must not take the template's image with it,
+    // since both point at the same stored file.
+    const { response: deleteAttachment } = await api.items.attachments.delete(item.id, item.attachments[0]!.id);
+    expect(deleteAttachment.status).toBe(204);
+
+    const { data: templateAfter } = await api.templates.get(template.id);
+    expect(templateAfter.defaultImage).toBeTruthy();
+
+    await api.items.delete(item.id);
+    await api.templates.delete(template.id);
+    await api.items.deleteLocation(location.id);
+  });
+
+  test("items created before an image is set are left alone", async () => {
+    const api = await sharedUserClient();
+
+    const { response: locResponse, data: location } = await api.items.createLocation(factories.location());
+    expect(locResponse.status).toBe(201);
+
+    const { data: template } = await api.templates.create(factories.template());
+
+    const { response, data: item } = await api.templates.createItem(template.id, {
+      name: "item-before-image",
+      description: "",
+      parentId: location.id,
+      tagIds: [],
+    });
+    expect(response.status).toBe(201);
+    expect(item.attachments).toHaveLength(0);
+
+    await api.templates.setImage(template.id, pngBlob(), "default.png");
+
+    const { data: itemAfter } = await api.items.get(item.id);
+    expect(itemAfter.attachments).toHaveLength(0);
+
+    await api.items.delete(item.id);
+    await api.templates.delete(template.id);
+    await api.items.deleteLocation(location.id);
+  });
+});

--- a/frontend/lib/api/classes/templates.ts
+++ b/frontend/lib/api/classes/templates.ts
@@ -29,6 +29,21 @@ export class TemplatesApi extends BaseAPI {
     return this.http.put<EntityTemplateUpdate, EntityTemplateOut>({ url: route(`/templates/${id}`), body });
   }
 
+  setImage(id: string, file: File | Blob, filename: string) {
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("name", filename);
+
+    return this.http.post<FormData, EntityTemplateOut>({
+      url: route(`/templates/${id}/image`),
+      data: formData,
+    });
+  }
+
+  deleteImage(id: string) {
+    return this.http.delete<EntityTemplateOut>({ url: route(`/templates/${id}/image`) });
+  }
+
   createItem(templateId: string, body: EntityTemplateCreateItemRequest) {
     return this.http.post<EntityTemplateCreateItemRequest, EntityOut>({
       url: route(`/templates/${templateId}/create-item`),

--- a/frontend/lib/api/types/data-contracts.ts
+++ b/frontend/lib/api/types/data-contracts.ts
@@ -914,7 +914,7 @@ export interface EntityTemplateOut {
   createdAt: Date | string;
   defaultDescription: string;
   /** Default image applied to entities created from this template */
-  defaultImage: TemplateImageSummary;
+  defaultImage?: TemplateImageSummary | null;
   defaultInsured: boolean;
   defaultLifetimeWarranty: boolean;
   /** Default location and tags */

--- a/frontend/lib/api/types/data-contracts.ts
+++ b/frontend/lib/api/types/data-contracts.ts
@@ -135,6 +135,8 @@ export interface EntAttachment {
 export interface EntAttachmentEdges {
   /** Entity holds the value of the entity edge. */
   entity: EntEntity;
+  /** EntityTemplate holds the value of the entity_template edge. */
+  entity_template: EntEntityTemplate;
   /** Thumbnail holds the value of the thumbnail edge. */
   thumbnail: EntAttachment;
 }
@@ -336,6 +338,8 @@ export interface EntEntityTemplate {
 }
 
 export interface EntEntityTemplateEdges {
+  /** DefaultImage holds the value of the default_image edge. */
+  default_image: EntAttachment;
   /** Fields holds the value of the fields edge. */
   fields: EntTemplateField[];
   /** Group holds the value of the group edge. */
@@ -909,6 +913,8 @@ export interface EntityTemplateCreate {
 export interface EntityTemplateOut {
   createdAt: Date | string;
   defaultDescription: string;
+  /** Default image applied to entities created from this template */
+  defaultImage: TemplateImageSummary;
   defaultInsured: boolean;
   defaultLifetimeWarranty: boolean;
   /** Default location and tags */
@@ -1250,6 +1256,13 @@ export interface TemplateField {
   textValue: string;
   timeValue: string;
   type: string;
+}
+
+export interface TemplateImageSummary {
+  id: string;
+  mimeType: string;
+  thumbnailId?: string | null;
+  title: string;
 }
 
 export interface TemplateLocationSummary {

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -337,10 +337,12 @@
                 "edit": "Edit template"
             },
             "confirm_delete": "Delete this template?",
+            "confirm_remove_image": "Remove this template's default image? Items already created from it keep their photo.",
             "create_modal": {
                 "title": "Create Template"
             },
             "detail": {
+                "default_image": "Default Image",
                 "default_values": "Default Values",
                 "updated": "Updated"
             },
@@ -350,6 +352,8 @@
             "empty_value": "(empty)",
             "form": {
                 "custom_fields": "Custom Fields",
+                "default_image": "Default Image",
+                "default_image_hint": "Applied as the primary photo of items created from this template.",
                 "default_item_values": "Default Item Values",
                 "default_location": "Default Location",
                 "default_value": "Default Value",
@@ -361,8 +365,12 @@
                 "manufacturer": "Manufacturer",
                 "model_number": "Model Number",
                 "no_custom_fields": "No custom fields.",
+                "no_default_image": "No default image.",
+                "remove_image": "Remove image",
+                "replace_image": "Replace image",
                 "template_description": "Template Description",
-                "template_name": "Template Name"
+                "template_name": "Template Name",
+                "upload_image": "Upload image"
             },
             "hide_defaults": "Hide defaults",
             "save_as_template": "Save as Template",
@@ -382,6 +390,10 @@
                 "deleted": "Template deleted",
                 "duplicate_failed": "Failed to duplicate template",
                 "duplicated": "Template duplicated as \"{name}\"",
+                "image_remove_failed": "Failed to remove template image",
+                "image_removed": "Template image removed",
+                "image_update_failed": "Failed to update template image",
+                "image_updated": "Template image updated",
                 "load_failed": "Failed to load template details",
                 "saved_as_template": "Item saved as template \"{name}\"",
                 "update_failed": "Failed to update template",

--- a/frontend/pages/template/[id].vue
+++ b/frontend/pages/template/[id].vue
@@ -4,6 +4,7 @@
   import MdiPencil from "~icons/mdi/pencil";
   import MdiDelete from "~icons/mdi/delete";
   import MdiPlus from "~icons/mdi/plus";
+  import MdiImagePlus from "~icons/mdi/image-plus";
   import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
   import { useDialog } from "@/components/ui/dialog-provider";
   import { Card } from "@/components/ui/card";
@@ -136,6 +137,51 @@
   }
 
   const NIL_UUID = "00000000-0000-0000-0000-000000000000";
+
+  const imageUploading = ref(false);
+  const imageInput = ref<HTMLInputElement | null>(null);
+
+  const hasImage = computed(() => !!template.value?.defaultImage);
+
+  const imageUrl = computed(() => {
+    const image = template.value?.defaultImage;
+    if (!image) return null;
+    // Cache-bust on the attachment id so replacing the image repaints.
+    // authURL only adds a query string when an attachment token is in play.
+    const url = api.authURL(`/templates/${templateId.value}/image`);
+    return `${url}${url.includes("?") ? "&" : "?"}v=${image.id}`;
+  });
+
+  async function onImageSelected(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = "";
+    if (!file) return;
+
+    imageUploading.value = true;
+    const { error, data } = await api.templates.setImage(templateId.value, file, file.name);
+    imageUploading.value = false;
+
+    if (error) {
+      toast.error(t("components.template.toast.image_update_failed"));
+      return;
+    }
+    toast.success(t("components.template.toast.image_updated"));
+    template.value = data;
+  }
+
+  async function removeImage() {
+    const { isCanceled } = await confirm.open(t("components.template.confirm_remove_image"));
+    if (isCanceled) return;
+
+    const { error, data } = await api.templates.deleteImage(templateId.value);
+    if (error) {
+      toast.error(t("components.template.toast.image_remove_failed"));
+      return;
+    }
+    toast.success(t("components.template.toast.image_removed"));
+    template.value = data;
+  }
 </script>
 
 <template>
@@ -275,6 +321,46 @@
 
       <Separator v-if="template.description" class="my-3" />
       <Markdown v-if="template.description" :source="template.description" />
+
+      <Separator class="my-3" />
+      <div class="flex flex-wrap items-start gap-4">
+        <div>
+          <h3 class="mb-2 text-sm font-medium">{{ $t("components.template.detail.default_image") }}</h3>
+          <img
+            v-if="imageUrl"
+            :src="imageUrl"
+            :alt="$t('components.template.detail.default_image')"
+            class="size-32 rounded border object-cover"
+          />
+          <p v-else class="text-sm text-muted-foreground">
+            {{ $t("components.template.form.no_default_image") }}
+          </p>
+        </div>
+        <div class="flex flex-col gap-2 pt-7">
+          <p class="max-w-xs text-xs text-muted-foreground">
+            {{ $t("components.template.form.default_image_hint") }}
+          </p>
+          <div class="flex gap-2">
+            <Button type="button" size="sm" variant="outline" :loading="imageUploading" @click="imageInput?.click()">
+              <MdiImagePlus class="mr-1 size-4" />
+              {{
+                hasImage ? $t("components.template.form.replace_image") : $t("components.template.form.upload_image")
+              }}
+            </Button>
+            <Button v-if="hasImage" type="button" size="sm" variant="ghost" @click="removeImage">
+              <MdiDelete class="mr-1 size-4" />
+              {{ $t("components.template.form.remove_image") }}
+            </Button>
+          </div>
+          <input
+            ref="imageInput"
+            type="file"
+            class="hidden"
+            accept="image/png,image/jpeg,image/gif,image/avif,image/webp"
+            @change="onImageSelected"
+          />
+        </div>
+      </div>
 
       <Separator class="my-3" />
       <div class="grid gap-4 text-sm md:grid-cols-2">


### PR DESCRIPTION
Feature discussion: #1721 (originally filed as #1719, before I noticed feature requests belong in Discussions).

Entity templates could carry defaults for every text field but not an image, so every item created from a template started with the placeholder photo and needed one uploaded by hand.

A template now owns an optional default image, and entities created from it afterwards get it as their primary photo.

## Approach

The image is a real `Attachment` row owned by the template rather than an entity, reachable through a new `default_image` edge on `EntityTemplate`. Two things fall out of that:

- **Thumbnails work unchanged.** `CreateThumbnail` keys off the attachment and group, not the entity edge, so the existing pubsub worker handles template images with no special casing.
- **The file is stored once and shared.** `EntityRepository.CreateFromTemplate` — already the single choke point for template-created entities — creates the new attachment pointing at the same stored path. The path reference count in `AttachmentRepo.delete` keeps the file alive until the template and every entity created from it have let go of it, so a template used 500 times costs one file.

`AttachmentRepo.Delete` is split so the group-ownership check and the removal logic are separate, letting template images validate ownership through the template edge while sharing the same deletion path.

## Incidental fix

Deleting an attachment whose path was shared skipped thumbnail cleanup entirely, because the cleanup sat inside the `len(all) == 1` branch that guards the *source* file. The thumbnail row and its file were orphaned. Thumbnails are one-to-one with the attachment being deleted, so they are now always cleaned up, with their own file reference count. This is reachable on `main` today by duplicating an entity with "copy attachments" and then deleting a photo from one of the copies.

## Semantics

- The image applies to items created **after** it is set; items created earlier are left alone.
- Removing an item's photo does not affect the template or sibling items.
- Removing the template's image leaves items that already have it untouched.
- Deleting the template removes its image row; the file survives if items still reference it.

## UI

Upload / replace / remove on the template detail page, and an optional image picker in the create-template dialog (uploaded right after create, since the image needs a template to belong to). A failure there warns but still leaves a usable template.

## Testing

- Repository tests for set, replace, clear, applying on create, and the shared-file case where deleting an item's photo must not take the template's image with it.
- A regression test for the orphaned-thumbnail fix.
- API-level tests in `templates.test.ts` covering the image lifecycle, application on create, and that pre-existing items are left alone.
- Verified end to end against a live server on a fresh SQLite database: migration applies, upload → create item → served bytes match the original, and the template image survives deleting the item's copy.
- `golangci-lint`, `go vet`, `gofmt`, backend tests, `pnpm lint`, and the full vitest suite (65 passing) are clean. `pnpm typecheck` error count is unchanged from `main`.

Migrations are provided for both SQLite and Postgres. The generated API docs and TypeScript contracts are regenerated with `swag` and `swagger-typescript-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mv2GPsFQgbFxmaTNQ9Av3F

