### PR TITLE
fix(lint): extract repeated notifier URL fixture into a constant

### DIFF
--- a/backend/internal/sys/validate/notifier_url_test.go
+++ b/backend/internal/sys/validate/notifier_url_test.go
@@ -10,6 +10,7 @@ import (
 // Repeated fixture values used across many test cases.
 const (
 	cidrPrivate24       = "192.168.1.0/24"
+	urlDiscord          = "discord://token@id"
 	urlGenericIPv6Local = "generic://http://[fd00::1]/webhook"
 	urlGenericIPv4Local = "generic://http://192.168.1.100/webhook"
 )
@@ -26,7 +27,7 @@ func TestValidateNotifierURL(t *testing.T) {
 	}{
 		{
 			name: "non-generic notifier passes validation",
-			url:  "discord://token@id",
+			url:  urlDiscord,
 			config: config.NotifierConf{
 				BlockLocalhost: true,
 			},
@@ -177,7 +178,7 @@ func TestValidateNotifierURL(t *testing.T) {
 		},
 		{
 			name: "block_nets does not affect non-generic notifiers",
-			url:  "discord://token@id",
+			url:  urlDiscord,
 			config: config.NotifierConf{
 				BlockNets: []string{"0.0.0.0/0"},
 			},
@@ -439,7 +440,7 @@ func TestIsGenericNotifier(t *testing.T) {
 		{"generic://", "generic://http://example.com", true},
 		{"generic+https://", "generic+https://example.com", true},
 		{"generic+http://", "generic+http://example.com", true},
-		{"discord://", "discord://token@id", false},
+		{"discord://", urlDiscord, false},
 		{"slack://", "slack://token@channel", false},
 		{"smtp://", "smtp://user:pass@host:587", false},
 	}
@@ -487,7 +488,7 @@ func TestExtractGenericURL(t *testing.T) {
 		},
 		{
 			name:        "not generic",
-			url:         "discord://token@id",
+			url:         urlDiscord,
 			expected:    "",
 			expectError: true,
 		},
@@ -743,7 +744,7 @@ func TestValidateNotifierURL_IdentifierHostsAllowed(t *testing.T) {
 	}
 
 	allowed := []string{
-		"discord://token@id",
+		urlDiscord,
 		"slack://token:token@channel",
 		"telegram://token@telegram?chats=1",
 		"pushover://shoutrrr:apiToken@userKey/",


### PR DESCRIPTION
`golangci-lint` currently fails on `main` with a single `goconst` finding:

```
internal/sys/validate/notifier_url_test.go:29:10: string `discord://token@id` has 5 occurrences, make it a constant (goconst)
```

The lint step runs before Build API and Test in the Backend Server Tests job, so the job exits there and never builds or tests anything. Every open pull request shows a red backend check as a result, which makes it hard to tell a real backend failure from the inherited one.

`notifier_url_test.go` already collects repeated fixture values in a const block at the top (`cidrPrivate24`, `urlGenericIPv6Local`, `urlGenericIPv4Local`), so this adds `urlDiscord` alongside them and uses it at the six occurrences. No test logic changes.

After this, `golangci-lint run --timeout=6m` reports `0 issues` and `go test ./internal/sys/validate/` passes.

Found while working on #1720; sending it separately since it is unrelated to that feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mv2GPsFQgbFxmaTNQ9Av3F
