### PR TITLE
your -> you are / you're

### DIFF
--- a/docs/src/content/docs/en/user-guide/index.mdx
+++ b/docs/src/content/docs/en/user-guide/index.mdx
@@ -22,7 +22,7 @@ Once you've registered, you can log in to your Homebox account:
 2. Click the "Login" button to access your dashboard.
 </Steps>
 
-Once logged in, you'll see that your part of a default Collection called `<Name>'s Collection`. With the rest being empty:
+Once logged in, you'll see that you're part of a default Collection called `<Name>'s Collection`. With the rest being empty:
 
 ![Homebox Dashboard](../../../../assets/user-guide/empty-dashboard.png)
 


### PR DESCRIPTION
Small doc correction/improvement.

## What type of PR is this?

- documentation

## What this PR does / why we need it:

'your' is wrong, if i'm not mistaken. It would need to be 'you are'.

## Which issue(s) this PR fixes:

No Issue filed for it.

## Special notes for your reviewer:

Another option could be to write:
"... you'll see your default Collection called ..."
or even shorter without "will":
"... you see your default Collection called ..."
this way, 'your' would be correct again.

Might need even more changes, as i did have a different collection as default with some premade labels and locations?
Anyway i also think "<Name>'s Collection. With the rest being empty:" might be "<Name>'s Collection, with the rest being empty:" or can completely be removed, as the picture already shows them being empty. Less to read, less to correct, less to get confused about (sometimes).

I also do not know nor see why it shows line 31 as removed and added. I cannot see nor want to have it changed.
